### PR TITLE
Add library link id generator util

### DIFF
--- a/test/integration/compoundUniswapLeverageDebtIssuance.spec.ts
+++ b/test/integration/compoundUniswapLeverageDebtIssuance.spec.ts
@@ -152,7 +152,7 @@ describe("CompoundUniswapLeverageDebtIssuance", () => {
       compoundSetup.comptroller.address,
       cEther.address,
       setup.weth.address,
-      "contracts/protocol/integration/lib/Compound.sol:Compound",
+      "Compound",
       compoundLibrary.address,
     );
     await setup.controller.addModule(compoundLeverageModule.address);

--- a/test/protocol/modules/compoundLeverageModule.spec.ts
+++ b/test/protocol/modules/compoundLeverageModule.spec.ts
@@ -123,7 +123,7 @@ describe("CompoundLeverageModule", () => {
       compoundSetup.comptroller.address,
       cEther.address,
       setup.weth.address,
-      "contracts/protocol/integration/lib/Compound.sol:Compound",
+      "Compound",
       compoundLibrary.address,
     );
     await setup.controller.addModule(compoundLeverageModule.address);

--- a/utils/common/index.ts
+++ b/utils/common/index.ts
@@ -34,3 +34,6 @@ export {
   calculateTokensInReserve,
   getReservesSafe
 } from "./uniswapUtils";
+export {
+  convertLibraryNameToLinkId
+} from "./libraryUtils";

--- a/utils/common/libraryUtils.ts
+++ b/utils/common/libraryUtils.ts
@@ -1,0 +1,22 @@
+import { utils } from "ethers";
+import { artifacts } from "hardhat";
+import path from "path";
+
+// If libraryName corresponds to more than one artifact (e.g there are
+// duplicate contract names in the project), `readArtifactSync`
+// will throw. In such cases it"s necessary to pass this method the fully qualified
+// contract name. ex: `contracts/mocks/LibraryMock.sol:LibraryMock`
+export function convertLibraryNameToLinkId(libraryName: string): string {
+  let artifact;
+  let fullyQualifiedName;
+
+  if (libraryName.includes(path.sep) && libraryName.includes(":")) {
+    fullyQualifiedName = libraryName;
+  } else {
+    artifact = artifacts.readArtifactSync(libraryName);
+    fullyQualifiedName = `${artifact.sourceName}:${artifact.contractName}`;
+  }
+
+  const hashedName = utils.keccak256(utils.toUtf8Bytes(fullyQualifiedName));
+  return `__$${hashedName.slice(2).slice(0, 34)}$__`;
+}

--- a/utils/deploys/deployModules.ts
+++ b/utils/deploys/deployModules.ts
@@ -1,4 +1,5 @@
-import { Signer, utils } from "ethers";
+import { Signer } from "ethers";
+import { convertLibraryNameToLinkId } from "../common";
 
 import {
   AirdropModule,
@@ -153,13 +154,12 @@ export default class DeployModules {
     libraryName: string,
     libraryAddress: Address
   ): Promise<CompoundLeverageModule> {
-    const hashedLibName = utils.keccak256(utils.toUtf8Bytes(libraryName));
-    const libKey = `__$${hashedLibName.slice(2).slice(0, 34)}$__`;
+    const linkId = convertLibraryNameToLinkId(libraryName);
 
     return await new CompoundLeverageModule__factory(
       // @ts-ignore
       {
-        [libKey]: libraryAddress,
+        [linkId]: libraryAddress,
       },
       this._deployerSigner
     ).deploy(


### PR DESCRIPTION
Adds a util to `common` which converts a short library name (like "Compound") into a link id that can be used as the key to an entry in the library links object passed to a typechain factory.

```js
// Usage
const linkId = convertLibraryNameToLinkId("SomeLibrary");

await UsesSomeLibrary__factory(
  {
    [linkId]: libraryAddress,
  },
  this._deployerSigner
).deploy();
```

Also updates library linking code from #32 to use this method.