### PR TITLE
Remove aliases from import paths in utils/fixtures

### DIFF
--- a/utils/fixtures/aaveFixture.ts
+++ b/utils/fixtures/aaveFixture.ts
@@ -29,9 +29,9 @@ import { StandardTokenMock } from "../contracts";
 import { ether } from "../common";
 
 import { AToken__factory } from "../../typechain/factories/AToken__factory";
-import { MAX_UINT_256 } from "@utils/constants";
-import { AaveTokenV2Mintable } from "@typechain/AaveTokenV2Mintable";
-import { getRandomAddress } from "@utils/test";
+import { MAX_UINT_256 } from "../constants";
+import { AaveTokenV2Mintable } from "../../typechain/AaveTokenV2Mintable";
+import { getRandomAddress } from "../test";
 
 export class AaveFixture {
   private _deployer: DeployHelper;

--- a/utils/fixtures/compoundFixture.ts
+++ b/utils/fixtures/compoundFixture.ts
@@ -29,7 +29,7 @@ import {
   ZERO,
   ZERO_BYTES
 } from "../constants";
-import { getLastBlockTimestamp, increaseTimeAsync } from "@utils/test";
+import { getLastBlockTimestamp, increaseTimeAsync } from "../test";
 
 export class CompoundFixture {
   private _deployer: DeployHelper;

--- a/utils/fixtures/uniswapFixture.ts
+++ b/utils/fixtures/uniswapFixture.ts
@@ -2,7 +2,7 @@ import DeployHelper from "../deploys";
 import { Signer } from "ethers";
 import { JsonRpcProvider, Web3Provider } from "@ethersproject/providers";
 import { Address } from "../types";
-import { Account } from "@utils/test/types";
+import { Account } from "../test/types";
 import { BigNumber } from "@ethersproject/bignumber";
 
 import {


### PR DESCRIPTION
This hopefully patches the test failures in [v2-deployments PR 39][1]. The governance adapters brought over from public in #52 use import aliases in a couple places and it seems like this makes module-alias really confused. The deployments repo and protocol-v2 dependency share alias definitions. 

(The module-alias package has [some warnings][2] about using module-alias in npm published packages.)

[1]: https://github.com/SetProtocol/set-v2-deployments/pull/39
[2]: https://github.com/ilearnio/module-alias#using-within-another-npm-package
