### PR TITLE
Move getRandomAddress (w/out hardhat) to utils/common

### DIFF
--- a/utils/common/addressUtils.ts
+++ b/utils/common/addressUtils.ts
@@ -1,0 +1,7 @@
+import { Wallet } from "ethers";
+import { Address } from "../types";
+
+export const getRandomAddress = async (): Promise<Address> => {
+  const wallet = Wallet.createRandom();
+  return await wallet.getAddress();
+};

--- a/utils/common/index.ts
+++ b/utils/common/index.ts
@@ -37,3 +37,6 @@ export {
 export {
   convertLibraryNameToLinkId
 } from "./libraryUtils";
+export {
+  getRandomAddress
+} from "./addressUtils";

--- a/utils/fixtures/aaveFixture.ts
+++ b/utils/fixtures/aaveFixture.ts
@@ -26,12 +26,11 @@ import {
 
 import { StandardTokenMock } from "../contracts";
 
-import { ether } from "../common";
+import { ether, getRandomAddress } from "../common";
 
 import { AToken__factory } from "../../typechain/factories/AToken__factory";
 import { MAX_UINT_256 } from "../constants";
 import { AaveTokenV2Mintable } from "../../typechain/AaveTokenV2Mintable";
-import { getRandomAddress } from "../test";
 
 export class AaveFixture {
   private _deployer: DeployHelper;

--- a/utils/test/accountUtils.ts
+++ b/utils/test/accountUtils.ts
@@ -26,11 +26,6 @@ export const getRandomAccount = async (): Promise<Account> => {
   return accounts[accounts.length - 1];
 };
 
-export const getRandomAddress = async (): Promise<Address> => {
-  const wallet = ethers.Wallet.createRandom().connect(provider);
-  return await wallet.getAddress();
-};
-
 export const getEthBalance = async (account: Address): Promise<BigNumber> => {
   return await provider.getBalance(account);
 };

--- a/utils/test/index.ts
+++ b/utils/test/index.ts
@@ -20,7 +20,6 @@ export {
   getAccounts,
   getEthBalance,
   getRandomAccount,
-  getRandomAddress,
 } from "./accountUtils";
 export {
   addSnapshotBeforeRestoreAfterEach,
@@ -32,3 +31,6 @@ export {
   mineBlockAsync,
   cacheBeforeEach
 } from "./testingUtils";
+export {
+  getRandomAddress
+} from "../common";


### PR DESCRIPTION
This should fix an issue `set.js` ran into where `getRandomAddress` relied on Hardhat  and messed up downstream imports from `utils/fixtures` if any files in that folder tried to use the method.  

The fixtures are need to be Hardhat-free and cannot import anything from `utils/test`. 
