### PR TITLE
Fix failing CompoundWrap tests

### DIFF
--- a/test/integration/compoundWrapModule.spec.ts
+++ b/test/integration/compoundWrapModule.spec.ts
@@ -23,7 +23,7 @@ import { CompoundFixture, SystemFixture } from "@utils/fixtures";
 
 const expect = getWaffleExpect();
 
-describe("compoundWrapModule", () => {
+describe.only("compoundWrapModule", () => {
   let owner: Account;
   let deployer: DeployHelper;
   let setup: SystemFixture;
@@ -70,7 +70,10 @@ describe("compoundWrapModule", () => {
 
     // compoundWrapAdapter setup
     const compoundLibrary = await deployer.libraries.deployCompound();
-    const compoundWrapAdapter = await deployer.adapters.deployCompoundWrapAdapter("Compound", compoundLibrary.address);
+    const compoundWrapAdapter = await deployer.adapters.deployCompoundWrapAdapter(
+      "contracts/protocol/integration/lib/Compound.sol:Compound",
+      compoundLibrary.address
+    );
     await setup.integrationRegistry.addIntegration(wrapModule.address, compoundWrapAdapterIntegrationName, compoundWrapAdapter.address);
   });
 

--- a/test/integration/compoundWrapModule.spec.ts
+++ b/test/integration/compoundWrapModule.spec.ts
@@ -23,7 +23,7 @@ import { CompoundFixture, SystemFixture } from "@utils/fixtures";
 
 const expect = getWaffleExpect();
 
-describe.only("compoundWrapModule", () => {
+describe("compoundWrapModule", () => {
   let owner: Account;
   let deployer: DeployHelper;
   let setup: SystemFixture;

--- a/test/protocol/integration/compoundWrapAdapter.spec.ts
+++ b/test/protocol/integration/compoundWrapAdapter.spec.ts
@@ -64,7 +64,10 @@ describe("CompoundWrapAdapter", () => {
     );
 
     const compoundLibrary = await deployer.libraries.deployCompound();
-    compoundWrapAdapter = await deployer.adapters.deployCompoundWrapAdapter("Compound", compoundLibrary.address);
+    compoundWrapAdapter = await deployer.adapters.deployCompoundWrapAdapter(
+      "contracts/protocol/integration/lib/Compound.sol:Compound",
+      compoundLibrary.address
+    );
   });
 
   addSnapshotBeforeRestoreAfterEach();


### PR DESCRIPTION
Updates `CompoundWrapModule` spec to use library link logic implemented in #60.

(Fixes CI) 

