### PR TITLE
Upgrade solidity pragmas to 0.6.12

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -2,6 +2,6 @@
   "extends": "solhint:recommended",
   "rules": {
     "reason-string": ["warn", { "maxLength": 50 }],
-    "compiler-version": ["error", "0.6.10"]
+    "compiler-version": ["error", "0.6.12"]
   }
 }

--- a/contracts/interfaces/IAmmAdapter.sol
+++ b/contracts/interfaces/IAmmAdapter.sol
@@ -15,7 +15,7 @@
 
     SPDX-License-Identifier: Apache License, Version 2.0
 */
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 
 /**

--- a/contracts/interfaces/IAmmAdapter.sol
+++ b/contracts/interfaces/IAmmAdapter.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 pragma solidity 0.6.12;
 

--- a/contracts/interfaces/IBasicIssuanceModule.sol
+++ b/contracts/interfaces/IBasicIssuanceModule.sol
@@ -15,7 +15,7 @@
 
     SPDX-License-Identifier: Apache License, Version 2.0
 */
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 import { ISetToken } from "./ISetToken.sol";
 

--- a/contracts/interfaces/IBasicIssuanceModule.sol
+++ b/contracts/interfaces/IBasicIssuanceModule.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 pragma solidity 0.6.12;
 

--- a/contracts/interfaces/IClaimAdapter.sol
+++ b/contracts/interfaces/IClaimAdapter.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 /**
  * @title IClaimAdapter

--- a/contracts/interfaces/IClaimAdapter.sol
+++ b/contracts/interfaces/IClaimAdapter.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/interfaces/IController.sol
+++ b/contracts/interfaces/IController.sol
@@ -15,7 +15,7 @@
 
     SPDX-License-Identifier: Apache License, Version 2.0
 */
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 interface IController {
     function addSet(address _setToken) external;

--- a/contracts/interfaces/IController.sol
+++ b/contracts/interfaces/IController.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 pragma solidity 0.6.12;
 

--- a/contracts/interfaces/IDebtIssuanceModule.sol
+++ b/contracts/interfaces/IDebtIssuanceModule.sol
@@ -15,7 +15,7 @@
 
     SPDX-License-Identifier: Apache License, Version 2.0
 */
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 import { ISetToken } from "./ISetToken.sol";
 

--- a/contracts/interfaces/IDebtIssuanceModule.sol
+++ b/contracts/interfaces/IDebtIssuanceModule.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 pragma solidity 0.6.12;
 

--- a/contracts/interfaces/IExchangeAdapter.sol
+++ b/contracts/interfaces/IExchangeAdapter.sol
@@ -15,7 +15,7 @@
 
     SPDX-License-Identifier: Apache License, Version 2.0
 */
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 interface IExchangeAdapter {
     function getSpender() external view returns(address);

--- a/contracts/interfaces/IExchangeAdapter.sol
+++ b/contracts/interfaces/IExchangeAdapter.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 pragma solidity 0.6.12;
 

--- a/contracts/interfaces/IGovernanceAdapter.sol
+++ b/contracts/interfaces/IGovernanceAdapter.sol
@@ -15,7 +15,7 @@
 
     SPDX-License-Identifier: Apache License, Version 2.0
 */
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 
 /**

--- a/contracts/interfaces/IGovernanceAdapter.sol
+++ b/contracts/interfaces/IGovernanceAdapter.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 pragma solidity 0.6.12;
 

--- a/contracts/interfaces/IIndexExchangeAdapter.sol
+++ b/contracts/interfaces/IIndexExchangeAdapter.sol
@@ -15,7 +15,7 @@
 
     SPDX-License-Identifier: Apache License, Version 2.0
 */
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 interface IIndexExchangeAdapter {
     function getSpender() external view returns(address);

--- a/contracts/interfaces/IIndexExchangeAdapter.sol
+++ b/contracts/interfaces/IIndexExchangeAdapter.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 pragma solidity 0.6.12;
 

--- a/contracts/interfaces/IIntegrationRegistry.sol
+++ b/contracts/interfaces/IIntegrationRegistry.sol
@@ -15,7 +15,7 @@
 
     SPDX-License-Identifier: Apache License, Version 2.0
 */
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 interface IIntegrationRegistry {
     function addIntegration(address _module, string memory _id, address _wrapper) external;

--- a/contracts/interfaces/IIntegrationRegistry.sol
+++ b/contracts/interfaces/IIntegrationRegistry.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 pragma solidity 0.6.12;
 

--- a/contracts/interfaces/IManagerIssuanceHook.sol
+++ b/contracts/interfaces/IManagerIssuanceHook.sol
@@ -15,7 +15,7 @@
 
     SPDX-License-Identifier: Apache License, Version 2.0
 */
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 import { ISetToken } from "./ISetToken.sol";
 

--- a/contracts/interfaces/IManagerIssuanceHook.sol
+++ b/contracts/interfaces/IManagerIssuanceHook.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 pragma solidity 0.6.12;
 

--- a/contracts/interfaces/IModule.sol
+++ b/contracts/interfaces/IModule.sol
@@ -15,7 +15,7 @@
 
     SPDX-License-Identifier: Apache License, Version 2.0
 */
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 
 /**

--- a/contracts/interfaces/IModule.sol
+++ b/contracts/interfaces/IModule.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 pragma solidity 0.6.12;
 

--- a/contracts/interfaces/IModuleIssuanceHook.sol
+++ b/contracts/interfaces/IModuleIssuanceHook.sol
@@ -15,7 +15,7 @@
 
     SPDX-License-Identifier: Apache License, Version 2.0
 */
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
@@ -31,7 +31,7 @@ interface IModuleIssuanceHook {
 
     function moduleIssueHook(ISetToken _setToken, uint256 _setTokenQuantity) external;
     function moduleRedeemHook(ISetToken _setToken, uint256 _setTokenQuantity) external;
-    
+
     function componentIssueHook(
         ISetToken _setToken,
         uint256 _setTokenQuantity,

--- a/contracts/interfaces/IModuleIssuanceHook.sol
+++ b/contracts/interfaces/IModuleIssuanceHook.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 pragma solidity 0.6.12;
 

--- a/contracts/interfaces/INAVIssuanceHook.sol
+++ b/contracts/interfaces/INAVIssuanceHook.sol
@@ -15,7 +15,7 @@
 
     SPDX-License-Identifier: Apache License, Version 2.0
 */
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 import { ISetToken } from "./ISetToken.sol";
 

--- a/contracts/interfaces/INAVIssuanceHook.sol
+++ b/contracts/interfaces/INAVIssuanceHook.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 pragma solidity 0.6.12;
 

--- a/contracts/interfaces/INAVIssuanceModule.sol
+++ b/contracts/interfaces/INAVIssuanceModule.sol
@@ -15,7 +15,7 @@
 
     SPDX-License-Identifier: Apache License, Version 2.0
 */
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 import { ISetToken } from "./ISetToken.sol";
 
@@ -26,15 +26,15 @@ interface INAVIssuanceModule {
         uint256 _reserveAssetQuantity,
         uint256 _minSetTokenReceiveQuantity,
         address _to
-    ) 
+    )
         external;
-    
+
     function redeem(
         ISetToken _setToken,
         address _reserveAsset,
         uint256 _setTokenQuantity,
         uint256 _minReserveReceiveQuantity,
         address _to
-    ) 
+    )
         external;
 }

--- a/contracts/interfaces/INAVIssuanceModule.sol
+++ b/contracts/interfaces/INAVIssuanceModule.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 pragma solidity 0.6.12;
 

--- a/contracts/interfaces/IOracle.sol
+++ b/contracts/interfaces/IOracle.sol
@@ -15,7 +15,7 @@
 
     SPDX-License-Identifier: Apache License, Version 2.0
 */
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 
 /**

--- a/contracts/interfaces/IOracle.sol
+++ b/contracts/interfaces/IOracle.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 pragma solidity 0.6.12;
 

--- a/contracts/interfaces/IOracleAdapter.sol
+++ b/contracts/interfaces/IOracleAdapter.sol
@@ -15,7 +15,7 @@
 
     SPDX-License-Identifier: Apache License, Version 2.0
 */
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 
 /**

--- a/contracts/interfaces/IOracleAdapter.sol
+++ b/contracts/interfaces/IOracleAdapter.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 pragma solidity 0.6.12;
 

--- a/contracts/interfaces/IPriceOracle.sol
+++ b/contracts/interfaces/IPriceOracle.sol
@@ -15,7 +15,7 @@
 
     SPDX-License-Identifier: Apache License, Version 2.0
 */
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 /**
  * @title IPriceOracle

--- a/contracts/interfaces/IPriceOracle.sol
+++ b/contracts/interfaces/IPriceOracle.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 pragma solidity 0.6.12;
 

--- a/contracts/interfaces/ISetToken.sol
+++ b/contracts/interfaces/ISetToken.sol
@@ -15,7 +15,7 @@
 
     SPDX-License-Identifier: Apache License, Version 2.0
 */
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 pragma experimental "ABIEncoderV2";
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
@@ -56,13 +56,13 @@ interface ISetToken is IERC20 {
 
     /**
      * A struct that stores a component's cash position details and external positions
-     * This data structure allows O(1) access to a component's cash position units and 
+     * This data structure allows O(1) access to a component's cash position units and
      * virtual units.
      *
      * @param virtualUnit               Virtual value of a component's DEFAULT position. Stored as virtual for efficiency
      *                                  updating all units at once via the position multiplier. Virtual units are achieved
      *                                  by dividing a "real" value by the "positionMultiplier"
-     * @param componentIndex            
+     * @param componentIndex
      * @param externalPositionModules   List of external modules attached to each external position. Each module
      *                                  maps to an external position
      * @param externalPositions         Mapping of module => ExternalPosition struct for a given component
@@ -87,7 +87,7 @@ interface ISetToken is IERC20 {
 
 
     /* ============ Functions ============ */
-    
+
     function addComponent(address _component) external;
     function removeComponent(address _component) external;
     function editDefaultPositionUnit(address _component, int256 _realUnit) external;
@@ -115,7 +115,7 @@ interface ISetToken is IERC20 {
     function manager() external view returns (address);
     function moduleStates(address _module) external view returns (ModuleState);
     function getModules() external view returns (address[] memory);
-    
+
     function getDefaultPositionRealUnit(address _component) external view returns(int256);
     function getExternalPositionRealUnit(address _component, address _positionModule) external view returns(int256);
     function getComponents() external view returns(address[] memory);
@@ -123,7 +123,7 @@ interface ISetToken is IERC20 {
     function getExternalPositionData(address _component, address _positionModule) external view returns(bytes memory);
     function isExternalPositionModule(address _component, address _module) external view returns(bool);
     function isComponent(address _component) external view returns(bool);
-    
+
     function positionMultiplier() external view returns (int256);
     function getPositions() external view returns (Position[] memory);
     function getTotalComponentRealUnits(address _component) external view returns(int256);

--- a/contracts/interfaces/ISetToken.sol
+++ b/contracts/interfaces/ISetToken.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 pragma solidity 0.6.12;
 pragma experimental "ABIEncoderV2";

--- a/contracts/interfaces/ISetValuer.sol
+++ b/contracts/interfaces/ISetValuer.sol
@@ -15,7 +15,7 @@
 
     SPDX-License-Identifier: Apache License, Version 2.0
 */
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 import { ISetToken } from "../interfaces/ISetToken.sol";
 

--- a/contracts/interfaces/ISetValuer.sol
+++ b/contracts/interfaces/ISetValuer.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 pragma solidity 0.6.12;
 

--- a/contracts/interfaces/IStakingAdapter.sol
+++ b/contracts/interfaces/IStakingAdapter.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/interfaces/IStakingAdapter.sol
+++ b/contracts/interfaces/IStakingAdapter.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 /**
  * @title IStakingAdapter
@@ -32,7 +32,7 @@ interface IStakingAdapter {
         uint256 _notionalAmount
     )
         external
-        view 
+        view
         returns(address, uint256, bytes memory);
 
     function getUnstakeCallData(
@@ -40,6 +40,6 @@ interface IStakingAdapter {
         uint256 _notionalAmount
     )
         external
-        view 
+        view
         returns(address, uint256, bytes memory);
 }

--- a/contracts/interfaces/IStreamingFeeModule.sol
+++ b/contracts/interfaces/IStreamingFeeModule.sol
@@ -15,7 +15,7 @@
 
     SPDX-License-Identifier: Apache License, Version 2.0
 */
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 pragma experimental "ABIEncoderV2";
 
 import { ISetToken } from "./ISetToken.sol";

--- a/contracts/interfaces/IStreamingFeeModule.sol
+++ b/contracts/interfaces/IStreamingFeeModule.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 pragma solidity 0.6.12;
 pragma experimental "ABIEncoderV2";

--- a/contracts/interfaces/IWrapAdapter.sol
+++ b/contracts/interfaces/IWrapAdapter.sol
@@ -15,7 +15,7 @@
 
     SPDX-License-Identifier: Apache License, Version 2.0
 */
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 
 /**

--- a/contracts/interfaces/IWrapAdapter.sol
+++ b/contracts/interfaces/IWrapAdapter.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 pragma solidity 0.6.12;
 

--- a/contracts/interfaces/external/IAaveLendingPool.sol
+++ b/contracts/interfaces/external/IAaveLendingPool.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 interface IAaveLendingPool {
     function core() external view returns(address);

--- a/contracts/interfaces/external/IAaveLendingPool.sol
+++ b/contracts/interfaces/external/IAaveLendingPool.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/interfaces/external/IAaveLendingPoolCore.sol
+++ b/contracts/interfaces/external/IAaveLendingPoolCore.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 interface IAaveLendingPoolCore {
     function getReserveATokenAddress(address _reserve) external view returns (address);

--- a/contracts/interfaces/external/IAaveLendingPoolCore.sol
+++ b/contracts/interfaces/external/IAaveLendingPoolCore.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/interfaces/external/ICErc20.sol
+++ b/contracts/interfaces/external/ICErc20.sol
@@ -14,7 +14,7 @@
     limitations under the License.
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 

--- a/contracts/interfaces/external/ICErc20.sol
+++ b/contracts/interfaces/external/ICErc20.sol
@@ -12,6 +12,10 @@
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
+
+    SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/interfaces/external/ICEth.sol
+++ b/contracts/interfaces/external/ICEth.sol
@@ -14,7 +14,7 @@
     limitations under the License.
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 

--- a/contracts/interfaces/external/ICEth.sol
+++ b/contracts/interfaces/external/ICEth.sol
@@ -12,6 +12,10 @@
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
+
+    SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/interfaces/external/IComptroller.sol
+++ b/contracts/interfaces/external/IComptroller.sol
@@ -14,7 +14,7 @@
     limitations under the License.
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 import { ICErc20 } from "./ICErc20.sol";
 

--- a/contracts/interfaces/external/IComptroller.sol
+++ b/contracts/interfaces/external/IComptroller.sol
@@ -12,6 +12,10 @@
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
+
+    SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/interfaces/external/IGaugeController.sol
+++ b/contracts/interfaces/external/IGaugeController.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/interfaces/external/IGaugeController.sol
+++ b/contracts/interfaces/external/IGaugeController.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 interface IGaugeController {
     function gauge_types(address _gauge) external view returns (int128);

--- a/contracts/interfaces/external/IKyberNetworkProxy.sol
+++ b/contracts/interfaces/external/IKyberNetworkProxy.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/interfaces/external/IKyberNetworkProxy.sol
+++ b/contracts/interfaces/external/IKyberNetworkProxy.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 interface IKyberNetworkProxy {
     function getExpectedRate(

--- a/contracts/interfaces/external/IStakingRewards.sol
+++ b/contracts/interfaces/external/IStakingRewards.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/interfaces/external/IStakingRewards.sol
+++ b/contracts/interfaces/external/IStakingRewards.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 interface IStakingRewards {
     function balanceOf(address account) external view returns (uint256);

--- a/contracts/interfaces/external/ISynth.sol
+++ b/contracts/interfaces/external/ISynth.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/interfaces/external/ISynth.sol
+++ b/contracts/interfaces/external/ISynth.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 // https://docs.synthetix.io/contracts/source/interfaces/isynth
 interface ISynth {

--- a/contracts/interfaces/external/ISynthetixExchanger.sol
+++ b/contracts/interfaces/external/ISynthetixExchanger.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 // https://docs.synthetix.io/contracts/source/interfaces/iExchanger
 interface ISynthetixExchanger {

--- a/contracts/interfaces/external/ISynthetixExchanger.sol
+++ b/contracts/interfaces/external/ISynthetixExchanger.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/interfaces/external/IUniswapV2Pair.sol
+++ b/contracts/interfaces/external/IUniswapV2Pair.sol
@@ -10,6 +10,8 @@
     See the License for the specific language governing permissions and
     limitations under the License.
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/interfaces/external/IUniswapV2Pair.sol
+++ b/contracts/interfaces/external/IUniswapV2Pair.sol
@@ -12,7 +12,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 interface IUniswapV2Pair {
     event Approval(address indexed owner, address indexed spender, uint value);

--- a/contracts/interfaces/external/IUniswapV2Router.sol
+++ b/contracts/interfaces/external/IUniswapV2Router.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/interfaces/external/IUniswapV2Router.sol
+++ b/contracts/interfaces/external/IUniswapV2Router.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 interface IUniswapV2Router {
     function factory() external pure returns (address);

--- a/contracts/interfaces/external/IWETH.sol
+++ b/contracts/interfaces/external/IWETH.sol
@@ -14,7 +14,7 @@
     limitations under the License.
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 

--- a/contracts/interfaces/external/IWETH.sol
+++ b/contracts/interfaces/external/IWETH.sol
@@ -12,6 +12,10 @@
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
+
+    SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/interfaces/external/IYearnVault.sol
+++ b/contracts/interfaces/external/IYearnVault.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/interfaces/external/IYearnVault.sol
+++ b/contracts/interfaces/external/IYearnVault.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 interface IYearnVault {
     function token() external view returns(address);

--- a/contracts/lib/AddressArrayUtils.sol
+++ b/contracts/lib/AddressArrayUtils.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/lib/AddressArrayUtils.sol
+++ b/contracts/lib/AddressArrayUtils.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 /**
  * @title AddressArrayUtils

--- a/contracts/lib/ExplicitERC20.sol
+++ b/contracts/lib/ExplicitERC20.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/lib/ExplicitERC20.sol
+++ b/contracts/lib/ExplicitERC20.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";

--- a/contracts/lib/PreciseUnitMath.sol
+++ b/contracts/lib/PreciseUnitMath.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/lib/PreciseUnitMath.sol
+++ b/contracts/lib/PreciseUnitMath.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 pragma experimental ABIEncoderV2;
 
 import { SafeMath } from "@openzeppelin/contracts/math/SafeMath.sol";

--- a/contracts/lib/Uint256ArrayUtils.sol
+++ b/contracts/lib/Uint256ArrayUtils.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 /**
  * @title Uint256ArrayUtils

--- a/contracts/lib/Uint256ArrayUtils.sol
+++ b/contracts/lib/Uint256ArrayUtils.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/mocks/AddressArrayUtilsMock.sol
+++ b/contracts/mocks/AddressArrayUtilsMock.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 pragma experimental "ABIEncoderV2";
 
 import { AddressArrayUtils } from "../lib/AddressArrayUtils.sol";

--- a/contracts/mocks/AddressArrayUtilsMock.sol
+++ b/contracts/mocks/AddressArrayUtilsMock.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/mocks/ContractCallerMock.sol
+++ b/contracts/mocks/ContractCallerMock.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/mocks/ContractCallerMock.sol
+++ b/contracts/mocks/ContractCallerMock.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 import { Address } from "@openzeppelin/contracts/utils/Address.sol";
 

--- a/contracts/mocks/ExplicitERC20Mock.sol
+++ b/contracts/mocks/ExplicitERC20Mock.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/mocks/ExplicitERC20Mock.sol
+++ b/contracts/mocks/ExplicitERC20Mock.sol
@@ -16,14 +16,14 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 pragma experimental "ABIEncoderV2";
 
 import { ExplicitERC20 } from "../lib/ExplicitERC20.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 contract ExplicitERC20Mock {
-    
+
     function transferFrom(
         IERC20 _token,
         address _from,

--- a/contracts/mocks/GodModeMock.sol
+++ b/contracts/mocks/GodModeMock.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 import { IController } from "../interfaces/IController.sol";
 import { ISetToken } from "../interfaces/ISetToken.sol";

--- a/contracts/mocks/GodModeMock.sol
+++ b/contracts/mocks/GodModeMock.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/mocks/OracleAdapterMock.sol
+++ b/contracts/mocks/OracleAdapterMock.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 import { SafeMath } from "@openzeppelin/contracts/math/SafeMath.sol";

--- a/contracts/mocks/OracleAdapterMock.sol
+++ b/contracts/mocks/OracleAdapterMock.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/mocks/OracleMock.sol
+++ b/contracts/mocks/OracleMock.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/mocks/OracleMock.sol
+++ b/contracts/mocks/OracleMock.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 contract OracleMock {
     uint256 public price;

--- a/contracts/mocks/PositionMock.sol
+++ b/contracts/mocks/PositionMock.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/mocks/PositionMock.sol
+++ b/contracts/mocks/PositionMock.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 pragma experimental "ABIEncoderV2";
 
 import { ISetToken } from "../interfaces/ISetToken.sol";
@@ -34,14 +34,14 @@ contract PositionMock {
     }
 
     function testHasDefaultPosition(ISetToken _setToken, address _component) external view returns(bool) {
-        return Position.hasDefaultPosition(_setToken, _component);    
+        return Position.hasDefaultPosition(_setToken, _component);
     }
 
     function testHasExternalPosition(ISetToken _setToken, address _component) external view returns(bool) {
         return Position.hasExternalPosition(_setToken, _component);
     }
     function testHasSufficientDefaultUnits(ISetToken _setToken, address _component, uint256 _unit) external view returns(bool) {
-        return Position.hasSufficientDefaultUnits(_setToken, _component, _unit);    
+        return Position.hasSufficientDefaultUnits(_setToken, _component, _unit);
     }
     function testHasSufficientExternalUnits(
         ISetToken _setToken,
@@ -53,11 +53,11 @@ contract PositionMock {
         view
         returns(bool)
     {
-        return Position.hasSufficientExternalUnits(_setToken, _component, _module, _unit);    
+        return Position.hasSufficientExternalUnits(_setToken, _component, _module, _unit);
     }
 
     function testEditDefaultPosition(ISetToken _setToken, address _component, uint256 _newUnit) external {
-        return Position.editDefaultPosition(_setToken, _component, _newUnit);   
+        return Position.editDefaultPosition(_setToken, _component, _newUnit);
     }
 
     function testEditExternalPosition(

--- a/contracts/mocks/PreciseUnitMathMock.sol
+++ b/contracts/mocks/PreciseUnitMathMock.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 pragma experimental "ABIEncoderV2";
 
 import { PreciseUnitMath } from "../lib/PreciseUnitMath.sol";

--- a/contracts/mocks/PreciseUnitMathMock.sol
+++ b/contracts/mocks/PreciseUnitMathMock.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/mocks/StandardTokenMock.sol
+++ b/contracts/mocks/StandardTokenMock.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 

--- a/contracts/mocks/StandardTokenMock.sol
+++ b/contracts/mocks/StandardTokenMock.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/mocks/StandardTokenWithFeeMock.sol
+++ b/contracts/mocks/StandardTokenWithFeeMock.sol
@@ -15,7 +15,7 @@
 
     SPDX-License-Identifier: Apache License, Version 2.0
 */
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 
 import "@openzeppelin/contracts/math/SafeMath.sol";

--- a/contracts/mocks/StandardTokenWithFeeMock.sol
+++ b/contracts/mocks/StandardTokenWithFeeMock.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 pragma solidity 0.6.12;
 

--- a/contracts/mocks/Uint256ArrayUtilsMock.sol
+++ b/contracts/mocks/Uint256ArrayUtilsMock.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/mocks/Uint256ArrayUtilsMock.sol
+++ b/contracts/mocks/Uint256ArrayUtilsMock.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 pragma experimental "ABIEncoderV2";
 
 import { Uint256ArrayUtils } from "../lib/Uint256ArrayUtils.sol";

--- a/contracts/mocks/external/CompoundPriceOracleMock.sol
+++ b/contracts/mocks/external/CompoundPriceOracleMock.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/mocks/external/CompoundPriceOracleMock.sol
+++ b/contracts/mocks/external/CompoundPriceOracleMock.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 contract CompoundPriceOracleMock {
     mapping(address => uint256) public assetToPrices;

--- a/contracts/mocks/external/ComptrollerMock.sol
+++ b/contracts/mocks/external/ComptrollerMock.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import { ICErc20 } from "../../interfaces/external/ICErc20.sol";

--- a/contracts/mocks/external/ComptrollerMock.sol
+++ b/contracts/mocks/external/ComptrollerMock.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/mocks/external/GaugeControllerMock.sol
+++ b/contracts/mocks/external/GaugeControllerMock.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 /**
  * @title GaugeControllerMock

--- a/contracts/mocks/external/GaugeControllerMock.sol
+++ b/contracts/mocks/external/GaugeControllerMock.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/mocks/external/KyberNetworkProxyMock.sol
+++ b/contracts/mocks/external/KyberNetworkProxyMock.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/mocks/external/KyberNetworkProxyMock.sol
+++ b/contracts/mocks/external/KyberNetworkProxyMock.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import { SafeMath } from "@openzeppelin/contracts/math/SafeMath.sol";

--- a/contracts/mocks/external/OneInchExchangeMock.sol
+++ b/contracts/mocks/external/OneInchExchangeMock.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/mocks/external/OneInchExchangeMock.sol
+++ b/contracts/mocks/external/OneInchExchangeMock.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import { SafeMath } from "@openzeppelin/contracts/math/SafeMath.sol";

--- a/contracts/mocks/external/SynthMock.sol
+++ b/contracts/mocks/external/SynthMock.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/mocks/external/SynthMock.sol
+++ b/contracts/mocks/external/SynthMock.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 import "../StandardTokenMock.sol";
 

--- a/contracts/mocks/external/SynthetixExchangerMock.sol
+++ b/contracts/mocks/external/SynthetixExchangerMock.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 import { SafeMath } from "@openzeppelin/contracts/math/SafeMath.sol";
 import { SynthMock } from "./SynthMock.sol";

--- a/contracts/mocks/external/SynthetixExchangerMock.sol
+++ b/contracts/mocks/external/SynthetixExchangerMock.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/mocks/external/YearnStrategyMock.sol
+++ b/contracts/mocks/external/YearnStrategyMock.sol
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
+// @unsupported: ovm
 pragma solidity 0.6.12;
 pragma experimental ABIEncoderV2;
 

--- a/contracts/mocks/external/YearnStrategyMock.sol
+++ b/contracts/mocks/external/YearnStrategyMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 pragma experimental ABIEncoderV2;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/contracts/mocks/external/YearnVaultMock.sol
+++ b/contracts/mocks/external/YearnVaultMock.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 contract YearnVaultMock {
     uint256 public pricePerShare;

--- a/contracts/mocks/external/YearnVaultMock.sol
+++ b/contracts/mocks/external/YearnVaultMock.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/mocks/external/ZeroExMock.sol
+++ b/contracts/mocks/external/ZeroExMock.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 pragma experimental ABIEncoderV2;
 
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";

--- a/contracts/mocks/external/ZeroExMock.sol
+++ b/contracts/mocks/external/ZeroExMock.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/mocks/integrations/AmmAdapterMock.sol
+++ b/contracts/mocks/integrations/AmmAdapterMock.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
@@ -150,7 +150,7 @@ contract AmmAdapterMock is ERC20 {
         );
         return (address(this), 0, callData);
     }
-    
+
     function isValidPool(address _pool) public view returns(bool) {
         return _pool == address(this) || _pool == approvedToken;
     }

--- a/contracts/mocks/integrations/AmmAdapterMock.sol
+++ b/contracts/mocks/integrations/AmmAdapterMock.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/mocks/integrations/ClaimAdapterMock.sol
+++ b/contracts/mocks/integrations/ClaimAdapterMock.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 

--- a/contracts/mocks/integrations/ClaimAdapterMock.sol
+++ b/contracts/mocks/integrations/ClaimAdapterMock.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/mocks/integrations/GovernanceAdapterMock.sol
+++ b/contracts/mocks/integrations/GovernanceAdapterMock.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 pragma experimental ABIEncoderV2;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
@@ -61,7 +61,7 @@ contract GovernanceAdapterMock {
         bytes memory /* _data */
     )
         external
-        view 
+        view
         returns(address, uint256, bytes memory)
     {
         bytes memory callData = abi.encodeWithSignature("castVote(uint256,bool)", _proposalId, _support);
@@ -70,7 +70,7 @@ contract GovernanceAdapterMock {
 
     function getProposeCalldata(bytes memory _proposalData)
         external
-        view 
+        view
         returns(address, uint256, bytes memory)
     {
         (uint256 proposalId) = abi.decode(_proposalData, (uint256));

--- a/contracts/mocks/integrations/GovernanceAdapterMock.sol
+++ b/contracts/mocks/integrations/GovernanceAdapterMock.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/mocks/integrations/StakingAdapterMock.sol
+++ b/contracts/mocks/integrations/StakingAdapterMock.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 import { SafeMath } from "@openzeppelin/contracts/math/SafeMath.sol";
 
@@ -66,7 +66,7 @@ contract StakingAdapterMock {
         uint256 _notionalAmount
     )
         external
-        view 
+        view
         returns(address, uint256, bytes memory)
     {
         bytes memory callData = abi.encodeWithSignature("stake(uint256)", _notionalAmount);
@@ -78,7 +78,7 @@ contract StakingAdapterMock {
         uint256 _notionalAmount
     )
         external
-        view 
+        view
         returns(address, uint256, bytes memory)
     {
         bytes memory callData = abi.encodeWithSignature("unstake(uint256)", _notionalAmount);

--- a/contracts/mocks/integrations/StakingAdapterMock.sol
+++ b/contracts/mocks/integrations/StakingAdapterMock.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/mocks/integrations/TradeAdapterMock.sol
+++ b/contracts/mocks/integrations/TradeAdapterMock.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/mocks/integrations/TradeAdapterMock.sol
+++ b/contracts/mocks/integrations/TradeAdapterMock.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 pragma experimental ABIEncoderV2;
 
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
@@ -37,7 +37,7 @@ contract TradeAdapterMock {
         uint256 balance = ERC20(_token).balanceOf(address(this));
         require(ERC20(_token).transfer(msg.sender, balance), "ERC20 transfer failed");
     }
-    
+
     /* ============ Trade Functions ============ */
 
     function trade(

--- a/contracts/mocks/integrations/WrapAdapterMock.sol
+++ b/contracts/mocks/integrations/WrapAdapterMock.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/mocks/integrations/WrapAdapterMock.sol
+++ b/contracts/mocks/integrations/WrapAdapterMock.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/contracts/mocks/protocol/CustomSetValuerMock.sol
+++ b/contracts/mocks/protocol/CustomSetValuerMock.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/mocks/protocol/CustomSetValuerMock.sol
+++ b/contracts/mocks/protocol/CustomSetValuerMock.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 pragma experimental "ABIEncoderV2";
 
 import { ISetValuer } from "../../interfaces/ISetValuer.sol";
@@ -42,7 +42,7 @@ contract CustomSetValuerMock is ISetValuer {
      * Gets the valuation of a SetToken using data from the price oracle. Reverts
      * if no price exists for a component in the SetToken. Note: this works for external
      * positions and negative (debt) positions.
-     * 
+     *
      * Note: There is a risk that the valuation is off if airdrops aren't retrieved or
      * debt builds up via interest and its not reflected in the position
      *

--- a/contracts/mocks/protocol/integration/AaveLendingPoolCoreMock.sol
+++ b/contracts/mocks/protocol/integration/AaveLendingPoolCoreMock.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/mocks/protocol/integration/AaveLendingPoolCoreMock.sol
+++ b/contracts/mocks/protocol/integration/AaveLendingPoolCoreMock.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 contract AaveLendingPoolCoreMock {
 

--- a/contracts/mocks/protocol/integration/AaveLendingPoolMock.sol
+++ b/contracts/mocks/protocol/integration/AaveLendingPoolMock.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 contract AaveLendingPoolMock {
 

--- a/contracts/mocks/protocol/integration/AaveLendingPoolMock.sol
+++ b/contracts/mocks/protocol/integration/AaveLendingPoolMock.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/mocks/protocol/integration/lib/CompoundMock.sol
+++ b/contracts/mocks/protocol/integration/lib/CompoundMock.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/mocks/protocol/integration/lib/CompoundMock.sol
+++ b/contracts/mocks/protocol/integration/lib/CompoundMock.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 import { ICErc20 } from "../../../../interfaces/external/ICErc20.sol";
 import { IComptroller } from "../../../../interfaces/external/IComptroller.sol";

--- a/contracts/mocks/protocol/lib/InvokeMock.sol
+++ b/contracts/mocks/protocol/lib/InvokeMock.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 import { ISetToken } from "../../../interfaces/ISetToken.sol";
 import { Invoke } from "../../../protocol/lib/Invoke.sol";

--- a/contracts/mocks/protocol/lib/InvokeMock.sol
+++ b/contracts/mocks/protocol/lib/InvokeMock.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/mocks/protocol/lib/ModuleBaseMock.sol
+++ b/contracts/mocks/protocol/lib/ModuleBaseMock.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 

--- a/contracts/mocks/protocol/lib/ModuleBaseMock.sol
+++ b/contracts/mocks/protocol/lib/ModuleBaseMock.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/mocks/protocol/lib/ResourceIdentifierMock.sol
+++ b/contracts/mocks/protocol/lib/ResourceIdentifierMock.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/mocks/protocol/lib/ResourceIdentifierMock.sol
+++ b/contracts/mocks/protocol/lib/ResourceIdentifierMock.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 import { IController } from "../../../interfaces/IController.sol";
 import { IIntegrationRegistry } from "../../../interfaces/IIntegrationRegistry.sol";
@@ -29,7 +29,7 @@ contract ResourceIdentifierMock {
     /* ============ External Functions ============ */
 
     function testGetIntegrationRegistry(IController _controller) external view returns (IIntegrationRegistry) {
-        
+
         return ResourceIdentifier.getIntegrationRegistry(_controller);
     }
 

--- a/contracts/mocks/protocol/module/DebtIssuanceMock.sol
+++ b/contracts/mocks/protocol/module/DebtIssuanceMock.sol
@@ -15,7 +15,7 @@
 
     SPDX-License-Identifier: Apache License, Version 2.0
 */
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
@@ -24,7 +24,7 @@ import { ISetToken } from "../../../interfaces/ISetToken.sol";
 contract DebtIssuanceMock {
 
     mapping(ISetToken => bool) public isRegistered;
-    
+
     function initialize(ISetToken _setToken) external {
         _setToken.initializeModule();
     }

--- a/contracts/mocks/protocol/module/DebtIssuanceMock.sol
+++ b/contracts/mocks/protocol/module/DebtIssuanceMock.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 pragma solidity 0.6.12;
 

--- a/contracts/mocks/protocol/module/DebtModuleMock.sol
+++ b/contracts/mocks/protocol/module/DebtModuleMock.sol
@@ -1,3 +1,23 @@
+/*
+    Copyright 2021 Set Labs Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
+*/
+
 pragma solidity 0.6.12;
 pragma experimental "ABIEncoderV2";
 

--- a/contracts/mocks/protocol/module/DebtModuleMock.sol
+++ b/contracts/mocks/protocol/module/DebtModuleMock.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 pragma experimental "ABIEncoderV2";
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
@@ -37,7 +37,7 @@ contract DebtModuleMock is ModuleBase {
 
     function moduleIssueHook(ISetToken /*_setToken*/, uint256 /*_setTokenQuantity*/) external { moduleIssueHookCalled = true; }
     function moduleRedeemHook(ISetToken /*_setToken*/, uint256 /*_setTokenQuantity*/) external { moduleRedeemHookCalled = true; }
-    
+
     function componentIssueHook(
         ISetToken _setToken,
         uint256 _setTokenQuantity,

--- a/contracts/mocks/protocol/module/ManagerIssuanceHookMock.sol
+++ b/contracts/mocks/protocol/module/ManagerIssuanceHookMock.sol
@@ -15,7 +15,7 @@
 
     SPDX-License-Identifier: Apache License, Version 2.0
 */
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 import { ISetToken } from "../../../interfaces/ISetToken.sol";
 
@@ -28,14 +28,14 @@ contract ManagerIssuanceHookMock {
     function invokePreIssueHook(ISetToken _setToken, uint256 _issueQuantity, address _sender, address _to) external {
         retrievedSetToken = _setToken;
         retrievedIssueQuantity = _issueQuantity;
-        retrievedSender = _sender;    
-        retrievedTo = _to;        
+        retrievedSender = _sender;
+        retrievedTo = _to;
     }
 
     function invokePreRedeemHook(ISetToken _setToken, uint256 _redeemQuantity, address _sender, address _to) external {
         retrievedSetToken = _setToken;
         retrievedIssueQuantity = _redeemQuantity;
-        retrievedSender = _sender;    
-        retrievedTo = _to;        
+        retrievedSender = _sender;
+        retrievedTo = _to;
     }
 }

--- a/contracts/mocks/protocol/module/ManagerIssuanceHookMock.sol
+++ b/contracts/mocks/protocol/module/ManagerIssuanceHookMock.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 pragma solidity 0.6.12;
 

--- a/contracts/mocks/protocol/module/ModuleIssuanceHookMock.sol
+++ b/contracts/mocks/protocol/module/ModuleIssuanceHookMock.sol
@@ -15,7 +15,7 @@
 
     SPDX-License-Identifier: Apache License, Version 2.0
 */
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { SafeCast } from "@openzeppelin/contracts/utils/SafeCast.sol";

--- a/contracts/mocks/protocol/module/ModuleIssuanceHookMock.sol
+++ b/contracts/mocks/protocol/module/ModuleIssuanceHookMock.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 pragma solidity 0.6.12;
 

--- a/contracts/mocks/protocol/module/NAVIssuanceCaller.sol
+++ b/contracts/mocks/protocol/module/NAVIssuanceCaller.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/mocks/protocol/module/NAVIssuanceCaller.sol
+++ b/contracts/mocks/protocol/module/NAVIssuanceCaller.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 pragma experimental "ABIEncoderV2";
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
@@ -36,7 +36,7 @@ contract NAVIssuanceCaller {
         uint256 _reserveAssetQuantity,
         uint256 _minSetTokenReceiveQuantity,
         address _to
-    ) 
+    )
         external
     {
         IERC20(_reserveAsset).approve(address(navIssuance), _reserveAssetQuantity);
@@ -55,7 +55,7 @@ contract NAVIssuanceCaller {
         uint256 _setTokenQuantity,
         uint256 _minReserveReceiveQuantity,
         address _to
-    ) 
+    )
         external
     {
         navIssuance.redeem(

--- a/contracts/mocks/protocol/module/NAVIssuanceHookMock.sol
+++ b/contracts/mocks/protocol/module/NAVIssuanceHookMock.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 pragma solidity 0.6.12;
 

--- a/contracts/mocks/protocol/module/NAVIssuanceHookMock.sol
+++ b/contracts/mocks/protocol/module/NAVIssuanceHookMock.sol
@@ -15,7 +15,7 @@
 
     SPDX-License-Identifier: Apache License, Version 2.0
 */
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 import { ISetToken } from "../../../interfaces/ISetToken.sol";
 

--- a/contracts/product/AssetLimitHook.sol
+++ b/contracts/product/AssetLimitHook.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/product/AssetLimitHook.sol
+++ b/contracts/product/AssetLimitHook.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 pragma experimental "ABIEncoderV2";
 
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
@@ -44,7 +44,7 @@ contract AssetLimitHook is INAVIssuanceHook, Ownable {
     constructor(address[] memory _assets, uint256[] memory _limits) public {
         require(_assets.length == _limits.length, "Arrays must be equal");
         require(_assets.length != 0, "Array must not be empty");
-        
+
         for (uint256 i = 0; i < _assets.length; i++) {
             address asset = _assets[i];
             require(assetLimits[asset] == 0, "Asset already added");
@@ -105,6 +105,6 @@ contract AssetLimitHook is INAVIssuanceHook, Ownable {
     }
 
     /* ============ Getters ============ */
-    
+
     function getAssets() external view returns(address[] memory) { return assets; }
 }

--- a/contracts/product/UniswapYieldHook.sol
+++ b/contracts/product/UniswapYieldHook.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/product/UniswapYieldHook.sol
+++ b/contracts/product/UniswapYieldHook.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 pragma experimental "ABIEncoderV2";
 
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
@@ -39,7 +39,7 @@ contract UniswapYieldHook is INAVIssuanceHook, Ownable {
     constructor(address[] memory _assets, uint256[] memory _limits) public {
         require(_assets.length == _limits.length, "Arrays must be equal");
         require(_assets.length != 0, "Array must not be empty");
-        
+
         for (uint256 i = 0; i < _assets.length; i++) {
             address asset = _assets[i];
             require(assetLimits[asset] == 0, "Asset already added");
@@ -104,6 +104,6 @@ contract UniswapYieldHook is INAVIssuanceHook, Ownable {
     }
 
     /* ============ Getters ============ */
-    
+
     function getAssets() external view returns(address[] memory) { return assets; }
 }

--- a/contracts/protocol-viewers/ERC20Viewer.sol
+++ b/contracts/protocol-viewers/ERC20Viewer.sol
@@ -9,6 +9,10 @@
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
+
+    SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 pragma solidity 0.6.12;
 

--- a/contracts/protocol-viewers/ERC20Viewer.sol
+++ b/contracts/protocol-viewers/ERC20Viewer.sol
@@ -10,7 +10,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 */
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
@@ -41,7 +41,7 @@ contract ERC20Viewer {
     {
         // Cache length of addresses to fetch balances for
         uint256 addressesCount = _tokenAddresses.length;
-        
+
         // Instantiate output array in memory
         uint256[] memory balances = new uint256[](addressesCount);
 
@@ -72,7 +72,7 @@ contract ERC20Viewer {
     {
         // Cache length of addresses to fetch allowances for
         uint256 addressesCount = _tokenAddresses.length;
-        
+
         // Instantiate output array in memory
         uint256[] memory allowances = new uint256[](addressesCount);
 

--- a/contracts/protocol-viewers/ProtocolViewer.sol
+++ b/contracts/protocol-viewers/ProtocolViewer.sol
@@ -15,7 +15,7 @@
 
     SPDX-License-Identifier: Apache License, Version 2.0
 */
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 pragma experimental "ABIEncoderV2";
 
 

--- a/contracts/protocol-viewers/ProtocolViewer.sol
+++ b/contracts/protocol-viewers/ProtocolViewer.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 pragma solidity 0.6.12;
 pragma experimental "ABIEncoderV2";

--- a/contracts/protocol-viewers/SetTokenViewer.sol
+++ b/contracts/protocol-viewers/SetTokenViewer.sol
@@ -15,7 +15,7 @@
 
     SPDX-License-Identifier: Apache License, Version 2.0
 */
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 pragma experimental "ABIEncoderV2";
 
 
@@ -49,7 +49,7 @@ contract SetTokenViewer {
     )
         external
         view
-        returns (address[] memory) 
+        returns (address[] memory)
     {
         address[] memory managers = new address[](_setTokens.length);
 

--- a/contracts/protocol-viewers/SetTokenViewer.sol
+++ b/contracts/protocol-viewers/SetTokenViewer.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 pragma solidity 0.6.12;
 pragma experimental "ABIEncoderV2";

--- a/contracts/protocol-viewers/StreamingFeeModuleViewer.sol
+++ b/contracts/protocol-viewers/StreamingFeeModuleViewer.sol
@@ -15,7 +15,7 @@
 
     SPDX-License-Identifier: Apache License, Version 2.0
 */
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 pragma experimental "ABIEncoderV2";
 
 

--- a/contracts/protocol-viewers/StreamingFeeModuleViewer.sol
+++ b/contracts/protocol-viewers/StreamingFeeModuleViewer.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 pragma solidity 0.6.12;
 pragma experimental "ABIEncoderV2";

--- a/contracts/protocol/Controller.sol
+++ b/contracts/protocol/Controller.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";

--- a/contracts/protocol/Controller.sol
+++ b/contracts/protocol/Controller.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/protocol/IntegrationRegistry.sol
+++ b/contracts/protocol/IntegrationRegistry.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 pragma experimental ABIEncoderV2;
 
 import { IController } from "../interfaces/IController.sol";

--- a/contracts/protocol/IntegrationRegistry.sol
+++ b/contracts/protocol/IntegrationRegistry.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/protocol/PriceOracle.sol
+++ b/contracts/protocol/PriceOracle.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/protocol/PriceOracle.sol
+++ b/contracts/protocol/PriceOracle.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 pragma experimental "ABIEncoderV2";
 
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";

--- a/contracts/protocol/SetToken.sol
+++ b/contracts/protocol/SetToken.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/protocol/SetToken.sol
+++ b/contracts/protocol/SetToken.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 pragma experimental "ABIEncoderV2";
 
 import { Address } from "@openzeppelin/contracts/utils/Address.sol";
@@ -38,7 +38,7 @@ import { AddressArrayUtils } from "../lib/AddressArrayUtils.sol";
  * @author Set Protocol
  *
  * ERC20 Token contract that allows privileged modules to make modifications to its positions and invoke function calls
- * from the SetToken. 
+ * from the SetToken.
  */
 contract SetToken is ERC20 {
     using SafeMath for uint256;
@@ -64,7 +64,7 @@ contract SetToken is ERC20 {
 
     event Invoked(address indexed _target, uint indexed _value, bytes _data, bytes _returnValue);
     event ModuleAdded(address indexed _module);
-    event ModuleRemoved(address indexed _module);    
+    event ModuleRemoved(address indexed _module);
     event ModuleInitialized(address indexed _module);
     event ManagerEdited(address _newManager, address _oldManager);
     event PendingModuleRemoved(address indexed _module);
@@ -144,7 +144,7 @@ contract SetToken is ERC20 {
 
     /**
      * When a new SetToken is created, initializes Positions in default state and adds modules into pending state.
-     * All parameter validations are on the SetTokenCreator contract. Validations are performed already on the 
+     * All parameter validations are on the SetTokenCreator contract. Validations are performed already on the
      * SetTokenCreator. Initiates the positionMultiplier as 1e18 (no adjustments).
      *
      * @param _components             List of addresses of components for initial Positions
@@ -216,7 +216,7 @@ contract SetToken is ERC20 {
      */
     function addComponent(address _component) external onlyModule whenLockedOnlyLocker {
         require(!isComponent(_component), "Must not be component");
-        
+
         components.push(_component);
 
         emit ComponentAdded(_component);
@@ -255,7 +255,7 @@ contract SetToken is ERC20 {
     }
 
     /**
-     * PRIVELEGED MODULE FUNCTION. Low level function that removes a module from a component's 
+     * PRIVELEGED MODULE FUNCTION. Low level function that removes a module from a component's
      * externalPositionModules array and deletes the associated externalPosition.
      */
     function removeExternalPositionModule(
@@ -274,7 +274,7 @@ contract SetToken is ERC20 {
     }
 
     /**
-     * PRIVELEGED MODULE FUNCTION. Low level function that edits a component's external position virtual unit. 
+     * PRIVELEGED MODULE FUNCTION. Low level function that edits a component's external position virtual unit.
      * Takes a real unit and converts it to virtual before committing.
      */
     function editExternalPositionUnit(
@@ -314,7 +314,7 @@ contract SetToken is ERC20 {
      * PRIVELEGED MODULE FUNCTION. Modifies the position multiplier. This is typically used to efficiently
      * update all the Positions' units at once in applications where inflation is awarded (e.g. subscription fees).
      */
-    function editPositionMultiplier(int256 _newMultiplier) external onlyModule whenLockedOnlyLocker {        
+    function editPositionMultiplier(int256 _newMultiplier) external onlyModule whenLockedOnlyLocker {
         _validateNewMultiplier(_newMultiplier);
 
         positionMultiplier = _newMultiplier;
@@ -357,7 +357,7 @@ contract SetToken is ERC20 {
     }
 
     /**
-     * MANAGER ONLY. Adds a module into a PENDING state; Module must later be initialized via 
+     * MANAGER ONLY. Adds a module into a PENDING state; Module must later be initialized via
      * module's initialize function
      */
     function addModule(address _module) external onlyManager {
@@ -406,7 +406,7 @@ contract SetToken is ERC20 {
     function initializeModule() external {
         require(!isLocked, "Only when unlocked");
         require(moduleStates[msg.sender] == ISetToken.ModuleState.PENDING, "Module must be pending");
-        
+
         moduleStates[msg.sender] = ISetToken.ModuleState.INITIALIZED;
         modules.push(msg.sender);
 
@@ -575,7 +575,7 @@ contract SetToken is ERC20 {
     }
 
     /**
-     * To prevent virtual to real unit conversion issues (where real unit may be 0), the 
+     * To prevent virtual to real unit conversion issues (where real unit may be 0), the
      * product of the positionMultiplier and the lowest absolute virtualUnit value (across default and
      * external positions) must be greater than 0.
      */
@@ -586,7 +586,7 @@ contract SetToken is ERC20 {
     }
 
     /**
-     * Loops through all of the positions and returns the smallest absolute value of 
+     * Loops through all of the positions and returns the smallest absolute value of
      * the virtualUnit.
      *
      * @return Min virtual unit across positions denominated as int256
@@ -617,7 +617,7 @@ contract SetToken is ERC20 {
             }
         }
 
-        return minimumUnit.toInt256();        
+        return minimumUnit.toInt256();
     }
 
     /**
@@ -638,7 +638,7 @@ contract SetToken is ERC20 {
             // Increment the position count by each external position module
             address[] memory externalModules = _externalPositionModules(component);
             if (externalModules.length > 0) {
-                positionCount = positionCount.add(externalModules.length);  
+                positionCount = positionCount.add(externalModules.length);
             }
         }
 

--- a/contracts/protocol/SetTokenCreator.sol
+++ b/contracts/protocol/SetTokenCreator.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/protocol/SetTokenCreator.sol
+++ b/contracts/protocol/SetTokenCreator.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 pragma experimental "ABIEncoderV2";
 
 import { IController } from "../interfaces/IController.sol";

--- a/contracts/protocol/SetValuer.sol
+++ b/contracts/protocol/SetValuer.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/protocol/SetValuer.sol
+++ b/contracts/protocol/SetValuer.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 pragma experimental "ABIEncoderV2";
 
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
@@ -48,7 +48,7 @@ contract SetValuer {
     using SafeCast for int256;
     using SafeCast for uint256;
     using SignedSafeMath for int256;
-    
+
     /* ============ State Variables ============ */
 
     // Instance of the Controller contract
@@ -71,7 +71,7 @@ contract SetValuer {
      * Gets the valuation of a SetToken using data from the price oracle. Reverts
      * if no price exists for a component in the SetToken. Note: this works for external
      * positions and negative (debt) positions.
-     * 
+     *
      * Note: There is a risk that the valuation is off if airdrops aren't retrieved or
      * debt builds up via interest and its not reflected in the position
      *

--- a/contracts/protocol/integration/UniswapV2TransferFeeExchangeAdapter.sol
+++ b/contracts/protocol/integration/UniswapV2TransferFeeExchangeAdapter.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/protocol/integration/UniswapV2TransferFeeExchangeAdapter.sol
+++ b/contracts/protocol/integration/UniswapV2TransferFeeExchangeAdapter.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 pragma experimental "ABIEncoderV2";
 
 /**
@@ -70,7 +70,7 @@ contract UniswapV2TransferFeeExchangeAdapter {
         external
         view
         returns (address, uint256, bytes memory)
-    {   
+    {
         address[] memory path;
 
         if(_data.length == 0){
@@ -104,4 +104,4 @@ contract UniswapV2TransferFeeExchangeAdapter {
     {
         return router;
     }
-} 
+}

--- a/contracts/protocol/integration/exchange/KyberExchangeAdapter.sol
+++ b/contracts/protocol/integration/exchange/KyberExchangeAdapter.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/protocol/integration/exchange/KyberExchangeAdapter.sol
+++ b/contracts/protocol/integration/exchange/KyberExchangeAdapter.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 pragma experimental "ABIEncoderV2";
 
 /**
@@ -36,7 +36,7 @@ contract KyberExchangeAdapter {
     using PreciseUnitMath for uint256;
 
     /* ============ Structs ============ */
-    
+
     /**
      * Struct containing information for trade function
      */
@@ -47,7 +47,7 @@ contract KyberExchangeAdapter {
     }
 
     /* ============ State Variables ============ */
-    
+
     // Address of Kyber Network Proxy
     address public kyberNetworkProxyAddress;
 

--- a/contracts/protocol/integration/exchange/OneInchExchangeAdapter.sol
+++ b/contracts/protocol/integration/exchange/OneInchExchangeAdapter.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 pragma experimental "ABIEncoderV2";
 
 /**
@@ -29,7 +29,7 @@ pragma experimental "ABIEncoderV2";
 contract OneInchExchangeAdapter {
 
     /* ============ State Variables ============ */
-    
+
     // Address of 1Inch approve token address
     address public oneInchApprovalAddress;
 
@@ -86,7 +86,7 @@ contract OneInchExchangeAdapter {
         external
         view
         returns (address, uint256, bytes memory)
-    {   
+    {
         bytes4 signature;
         address fromToken;
         address toToken;

--- a/contracts/protocol/integration/exchange/OneInchExchangeAdapter.sol
+++ b/contracts/protocol/integration/exchange/OneInchExchangeAdapter.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/protocol/integration/exchange/SynthetixExchangeAdapter.sol
+++ b/contracts/protocol/integration/exchange/SynthetixExchangeAdapter.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/protocol/integration/exchange/SynthetixExchangeAdapter.sol
+++ b/contracts/protocol/integration/exchange/SynthetixExchangeAdapter.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 pragma experimental "ABIEncoderV2";
 
 import { ISynth } from "../../../interfaces/external/ISynth.sol";

--- a/contracts/protocol/integration/exchange/UniswapV2ExchangeAdapter.sol
+++ b/contracts/protocol/integration/exchange/UniswapV2ExchangeAdapter.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 pragma experimental "ABIEncoderV2";
 
 /**
@@ -70,7 +70,7 @@ contract UniswapV2ExchangeAdapter {
         external
         view
         returns (address, uint256, bytes memory)
-    {   
+    {
         address[] memory path;
 
         if(_data.length == 0){
@@ -104,4 +104,4 @@ contract UniswapV2ExchangeAdapter {
     {
         return router;
     }
-} 
+}

--- a/contracts/protocol/integration/exchange/UniswapV2ExchangeAdapter.sol
+++ b/contracts/protocol/integration/exchange/UniswapV2ExchangeAdapter.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/protocol/integration/exchange/UniswapV2ExchangeAdapterV2.sol
+++ b/contracts/protocol/integration/exchange/UniswapV2ExchangeAdapterV2.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/protocol/integration/exchange/UniswapV2ExchangeAdapterV2.sol
+++ b/contracts/protocol/integration/exchange/UniswapV2ExchangeAdapterV2.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 pragma experimental "ABIEncoderV2";
 
 /**
@@ -84,7 +84,7 @@ contract UniswapV2ExchangeAdapterV2 {
         external
         view
         returns (address, uint256, bytes memory)
-    {   
+    {
         (
             address[] memory path,
             bool shouldSwapExactTokensForTokens
@@ -104,16 +104,16 @@ contract UniswapV2ExchangeAdapterV2 {
     /**
      * Generate data parameter to be passed to `getTradeCallData`. Returns encoded trade paths and bool to select trade function.
      *
-     * @param _sourceToken          Address of the source token to be sold        
+     * @param _sourceToken          Address of the source token to be sold
      * @param _destinationToken     Address of the destination token to buy
      * @param _fixIn                Boolean representing if input tokens amount is fixed
-     * 
-     * @return bytes                Data parameter to be passed to `getTradeCallData`          
+     *
+     * @return bytes                Data parameter to be passed to `getTradeCallData`
      */
     function generateDataParam(address _sourceToken, address _destinationToken, bool _fixIn)
         external
         pure
-        returns (bytes memory) 
+        returns (bytes memory)
     {
         address[] memory path = new address[](2);
         path[0] = _sourceToken;
@@ -138,4 +138,4 @@ contract UniswapV2ExchangeAdapterV2 {
     function getUniswapExchangeData(address[] memory _path, bool _shouldSwapExactTokensForTokens) external pure returns (bytes memory) {
         return abi.encode(_path, _shouldSwapExactTokensForTokens);
     }
-} 
+}

--- a/contracts/protocol/integration/exchange/ZeroExApiAdapter.sol
+++ b/contracts/protocol/integration/exchange/ZeroExApiAdapter.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 pragma experimental "ABIEncoderV2";
 
 /**

--- a/contracts/protocol/integration/exchange/ZeroExApiAdapter.sol
+++ b/contracts/protocol/integration/exchange/ZeroExApiAdapter.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/protocol/integration/governance/AaveGovernanceAdapter.sol
+++ b/contracts/protocol/integration/governance/AaveGovernanceAdapter.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/protocol/integration/governance/AaveGovernanceAdapter.sol
+++ b/contracts/protocol/integration/governance/AaveGovernanceAdapter.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 pragma experimental "ABIEncoderV2";
 
 

--- a/contracts/protocol/integration/governance/AaveGovernanceV2Adapter.sol
+++ b/contracts/protocol/integration/governance/AaveGovernanceV2Adapter.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/protocol/integration/governance/AaveGovernanceV2Adapter.sol
+++ b/contracts/protocol/integration/governance/AaveGovernanceV2Adapter.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 pragma experimental "ABIEncoderV2";
 
 

--- a/contracts/protocol/integration/governance/CompoundBravoGovernanceAdapter.sol
+++ b/contracts/protocol/integration/governance/CompoundBravoGovernanceAdapter.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/protocol/integration/governance/CompoundBravoGovernanceAdapter.sol
+++ b/contracts/protocol/integration/governance/CompoundBravoGovernanceAdapter.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 pragma experimental "ABIEncoderV2";
 
 
@@ -32,7 +32,7 @@ contract CompoundBravoGovernanceAdapter {
 
     // Signature of the propose function in Compound Governor Bravo. This is used to encode the calldata for the propose function
     string public constant PROPOSE_SIGNATURE = "propose(address[],uint256[],string[],bytes[],string)";
-    
+
     // Signature of the delegate function in Compound Governor Bravo
     string public constant DELEGATE_SIGNATURE = "delegate(address)";
 

--- a/contracts/protocol/integration/governance/CompoundLikeGovernanceAdapter.sol
+++ b/contracts/protocol/integration/governance/CompoundLikeGovernanceAdapter.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 pragma experimental "ABIEncoderV2";
 
 
@@ -32,7 +32,7 @@ contract CompoundLikeGovernanceAdapter {
 
     // Signature of the propose function in Compound Governor Alpha. This is used to encode the calldata for the propose function
     string public constant PROPOSE_SIGNATURE = "propose(address[],uint256[],string[],bytes[],string)";
-    
+
     // Signature of the delegate function in Compound Governor Alpha
     string public constant DELEGATE_SIGNATURE = "delegate(address)";
 

--- a/contracts/protocol/integration/governance/CompoundLikeGovernanceAdapter.sol
+++ b/contracts/protocol/integration/governance/CompoundLikeGovernanceAdapter.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/protocol/integration/governance/SnapshotGovernanceAdapter.sol
+++ b/contracts/protocol/integration/governance/SnapshotGovernanceAdapter.sol
@@ -22,14 +22,14 @@
  *
  * Governance adapter for Snapshot delegation that returns data delegating and revoking delegations
  */
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 pragma experimental "ABIEncoderV2";
 
 
 contract SnapshotGovernanceAdapter {
 
     /* ============ Constants ============ */
-    
+
     // Signature of the delegate function for Snapshot
     string public constant SET_DELEGATE_SIGNATURE = "setDelegate(bytes32,address)";
 

--- a/contracts/protocol/integration/governance/SnapshotGovernanceAdapter.sol
+++ b/contracts/protocol/integration/governance/SnapshotGovernanceAdapter.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 /**

--- a/contracts/protocol/integration/index-exchange/BalancerV1IndexExchangeAdapter.sol
+++ b/contracts/protocol/integration/index-exchange/BalancerV1IndexExchangeAdapter.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 pragma experimental "ABIEncoderV2";
 
 import { IIndexExchangeAdapter } from "../../../interfaces/IIndexExchangeAdapter.sol";
@@ -34,9 +34,9 @@ contract BalancerV1IndexExchangeAdapter is IIndexExchangeAdapter {
 
     // Amount of pools examined when fetching quote
     uint256 private constant BALANCER_POOL_LIMIT = 3;
-    
+
     /* ============ State Variables ============ */
-    
+
     // Address of Balancer V1 Proxy contract
     address public immutable balancerProxy;
     // Balancer proxy function string for swapping exact tokens for a minimum of receive tokens
@@ -87,7 +87,7 @@ contract BalancerV1IndexExchangeAdapter is IIndexExchangeAdapter {
         view
         override
         returns (address, uint256, bytes memory)
-    {   
+    {
         bytes memory callData = abi.encodeWithSignature(
             _isSendTokenFixed ? EXACT_IN : EXACT_OUT,
             _sourceToken,
@@ -108,4 +108,4 @@ contract BalancerV1IndexExchangeAdapter is IIndexExchangeAdapter {
     function getSpender() external view override returns (address) {
         return balancerProxy;
     }
-} 
+}

--- a/contracts/protocol/integration/index-exchange/BalancerV1IndexExchangeAdapter.sol
+++ b/contracts/protocol/integration/index-exchange/BalancerV1IndexExchangeAdapter.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/protocol/integration/index-exchange/UniswapV2IndexExchangeAdapter.sol
+++ b/contracts/protocol/integration/index-exchange/UniswapV2IndexExchangeAdapter.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 pragma experimental "ABIEncoderV2";
 
 import { IIndexExchangeAdapter } from "../../../interfaces/IIndexExchangeAdapter.sol";
@@ -107,4 +107,4 @@ contract UniswapV2IndexExchangeAdapter is IIndexExchangeAdapter {
     function getSpender() external view override returns (address) {
         return router;
     }
-} 
+}

--- a/contracts/protocol/integration/index-exchange/UniswapV2IndexExchangeAdapter.sol
+++ b/contracts/protocol/integration/index-exchange/UniswapV2IndexExchangeAdapter.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/protocol/integration/lib/Compound.sol
+++ b/contracts/protocol/integration/lib/Compound.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 import { ISetToken } from "../../../interfaces/ISetToken.sol";
 import { ICErc20 } from "../../../interfaces/external/ICErc20.sol";

--- a/contracts/protocol/integration/lib/Compound.sol
+++ b/contracts/protocol/integration/lib/Compound.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/protocol/integration/oracles/CTokenOracle.sol
+++ b/contracts/protocol/integration/oracles/CTokenOracle.sol
@@ -11,7 +11,7 @@
     limitations under the License.
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 import { SafeMath } from "@openzeppelin/contracts/math/SafeMath.sol";
 

--- a/contracts/protocol/integration/oracles/CTokenOracle.sol
+++ b/contracts/protocol/integration/oracles/CTokenOracle.sol
@@ -9,6 +9,10 @@
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
+
+    SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/protocol/integration/oracles/UniswapPairPriceAdapter.sol
+++ b/contracts/protocol/integration/oracles/UniswapPairPriceAdapter.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/protocol/integration/oracles/UniswapPairPriceAdapter.sol
+++ b/contracts/protocol/integration/oracles/UniswapPairPriceAdapter.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
@@ -37,7 +37,7 @@ contract UniswapPairPriceAdapter is Ownable {
     using ResourceIdentifier for IController;
 
     /* ============ Structs ============ */
-    
+
     /**
      * Struct containing information for get price function
      */
@@ -105,7 +105,7 @@ contract UniswapPairPriceAdapter is Ownable {
             // Add to storage
             allowedUniswapPools.push(address(uniswapPoolToAdd));
             uniswapPoolsToSettings[address(uniswapPoolToAdd)] = poolSettings;
-        } 
+        }
     }
 
     /* ============ External Functions ============ */
@@ -194,7 +194,7 @@ contract UniswapPairPriceAdapter is Ownable {
     {
         PoolSettings memory poolInfo = uniswapPoolsToSettings[_poolAddress];
         IUniswapV2Pair poolToken = IUniswapV2Pair(_poolAddress);
-        
+
         // Get prices against master quote asset. Note: if prices do not exist, function will revert
         uint256 tokenOnePriceToMaster = _priceOracle.getPrice(poolInfo.tokenOne, _masterQuoteAsset);
         uint256 tokenTwoPriceToMaster = _priceOracle.getPrice(poolInfo.tokenTwo, _masterQuoteAsset);

--- a/contracts/protocol/integration/oracles/YearnVaultOracle.sol
+++ b/contracts/protocol/integration/oracles/YearnVaultOracle.sol
@@ -11,7 +11,7 @@
     limitations under the License.
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 import { SafeMath } from "@openzeppelin/contracts/math/SafeMath.sol";
 

--- a/contracts/protocol/integration/oracles/YearnVaultOracle.sol
+++ b/contracts/protocol/integration/oracles/YearnVaultOracle.sol
@@ -9,6 +9,10 @@
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
+
+    SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/protocol/integration/staking/CurveStakingAdapter.sol
+++ b/contracts/protocol/integration/staking/CurveStakingAdapter.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/protocol/integration/staking/CurveStakingAdapter.sol
+++ b/contracts/protocol/integration/staking/CurveStakingAdapter.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 import { IGaugeController } from "../../../interfaces/external/IGaugeController.sol";
 

--- a/contracts/protocol/integration/wrap/AaveMigrationWrapAdapter.sol
+++ b/contracts/protocol/integration/wrap/AaveMigrationWrapAdapter.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/protocol/integration/wrap/AaveMigrationWrapAdapter.sol
+++ b/contracts/protocol/integration/wrap/AaveMigrationWrapAdapter.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 /**
  * @title AaveMigrationWrapAdapter

--- a/contracts/protocol/integration/wrap/AaveWrapAdapter.sol
+++ b/contracts/protocol/integration/wrap/AaveWrapAdapter.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 pragma experimental "ABIEncoderV2";
 
 import { IAaveLendingPool } from "../../../interfaces/external/IAaveLendingPool.sol";

--- a/contracts/protocol/integration/wrap/AaveWrapAdapter.sol
+++ b/contracts/protocol/integration/wrap/AaveWrapAdapter.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/protocol/integration/wrap/CompoundWrapAdapter.sol
+++ b/contracts/protocol/integration/wrap/CompoundWrapAdapter.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 pragma experimental "ABIEncoderV2";
 
 import { ICErc20 } from "../../../interfaces/external/ICErc20.sol";

--- a/contracts/protocol/integration/wrap/CompoundWrapAdapter.sol
+++ b/contracts/protocol/integration/wrap/CompoundWrapAdapter.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/protocol/integration/wrap/YearnWrapAdapter.sol
+++ b/contracts/protocol/integration/wrap/YearnWrapAdapter.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 pragma experimental "ABIEncoderV2";
 
 import { IYearnVault } from "../../../interfaces/external/IYearnVault.sol";

--- a/contracts/protocol/integration/wrap/YearnWrapAdapter.sol
+++ b/contracts/protocol/integration/wrap/YearnWrapAdapter.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/protocol/lib/Invoke.sol
+++ b/contracts/protocol/lib/Invoke.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { SafeMath } from "@openzeppelin/contracts/math/SafeMath.sol";

--- a/contracts/protocol/lib/Invoke.sol
+++ b/contracts/protocol/lib/Invoke.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/protocol/lib/ModuleBase.sol
+++ b/contracts/protocol/lib/ModuleBase.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/protocol/lib/ModuleBase.sol
+++ b/contracts/protocol/lib/ModuleBase.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
@@ -121,7 +121,7 @@ abstract contract ModuleBase is IModule {
     /**
      * Gets the integration for the module with the passed in name. Validates that the address is not empty
      */
-    function getAndValidateAdapter(string memory _integrationName) internal view returns(address) { 
+    function getAndValidateAdapter(string memory _integrationName) internal view returns(address) {
         bytes32 integrationHash = getNameHash(_integrationName);
         return getAndValidateAdapterWithHash(integrationHash);
     }
@@ -129,13 +129,13 @@ abstract contract ModuleBase is IModule {
     /**
      * Gets the integration for the module with the passed in hash. Validates that the address is not empty
      */
-    function getAndValidateAdapterWithHash(bytes32 _integrationHash) internal view returns(address) { 
+    function getAndValidateAdapterWithHash(bytes32 _integrationHash) internal view returns(address) {
         address adapter = controller.getIntegrationRegistry().getIntegrationAdapterWithHash(
             address(this),
             _integrationHash
         );
 
-        require(adapter != address(0), "Must be valid adapter"); 
+        require(adapter != address(0), "Must be valid adapter");
         return adapter;
     }
 
@@ -152,7 +152,7 @@ abstract contract ModuleBase is IModule {
      */
     function payProtocolFeeFromSetToken(ISetToken _setToken, address _token, uint256 _feeQuantity) internal {
         if (_feeQuantity > 0) {
-            _setToken.strictInvokeTransfer(_token, controller.feeRecipient(), _feeQuantity); 
+            _setToken.strictInvokeTransfer(_token, controller.feeRecipient(), _feeQuantity);
         }
     }
 
@@ -171,7 +171,7 @@ abstract contract ModuleBase is IModule {
     }
 
     /**
-     * Returns true if SetToken must be enabled on the controller 
+     * Returns true if SetToken must be enabled on the controller
      * and module is registered on the SetToken
      */
     function isSetValidAndInitialized(ISetToken _setToken) internal view returns(bool) {

--- a/contracts/protocol/lib/Position.sol
+++ b/contracts/protocol/lib/Position.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/protocol/lib/Position.sol
+++ b/contracts/protocol/lib/Position.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 pragma experimental "ABIEncoderV2";
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
@@ -59,7 +59,7 @@ library Position {
     function hasExternalPosition(ISetToken _setToken, address _component) internal view returns(bool) {
         return _setToken.getExternalPositionModules(_component).length > 0;
     }
-    
+
     /**
      * Returns whether the SetToken component default position real unit is greater than or equal to units passed in.
      */
@@ -80,12 +80,12 @@ library Position {
         view
         returns(bool)
     {
-       return _setToken.getExternalPositionRealUnit(_component, _positionModule) >= _unit.toInt256();    
+       return _setToken.getExternalPositionRealUnit(_component, _positionModule) >= _unit.toInt256();
     }
 
     /**
      * If the position does not exist, create a new Position and add to the SetToken. If it already exists,
-     * then set the position units. If the new units is 0, remove the position. Handles adding/removing of 
+     * then set the position units. If the new units is 0, remove the position. Handles adding/removing of
      * components where needed (in light of potential external positions).
      *
      * @param _setToken           Address of SetToken being modified
@@ -111,7 +111,7 @@ library Position {
 
     /**
      * Update an external position and remove and external positions or components if necessary. The logic flows as follows:
-     * 1) If component is not already added then add component and external position. 
+     * 1) If component is not already added then add component and external position.
      * 2) If component is added but no existing external position using the passed module exists then add the external position.
      * 3) If the existing position is being added to then just update the unit and data
      * 4) If the position is being closed and no other external positions or default positions are associated with the component
@@ -188,7 +188,7 @@ library Position {
      * @return                    Notional tracked balance
      */
     function getDefaultTrackedBalance(ISetToken _setToken, address _component) internal view returns(uint256) {
-        int256 positionUnit = _setToken.getDefaultPositionRealUnit(_component); 
+        int256 positionUnit = _setToken.getDefaultPositionRealUnit(_component);
         return _setToken.totalSupply().preciseMul(positionUnit.toUint256());
     }
 

--- a/contracts/protocol/lib/ResourceIdentifier.sol
+++ b/contracts/protocol/lib/ResourceIdentifier.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 import { IController } from "../../interfaces/IController.sol";
 import { IIntegrationRegistry } from "../../interfaces/IIntegrationRegistry.sol";

--- a/contracts/protocol/lib/ResourceIdentifier.sol
+++ b/contracts/protocol/lib/ResourceIdentifier.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/protocol/modules/AirdropModule.sol
+++ b/contracts/protocol/modules/AirdropModule.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/protocol/modules/AirdropModule.sol
+++ b/contracts/protocol/modules/AirdropModule.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 pragma experimental "ABIEncoderV2";
 
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
@@ -51,7 +51,7 @@ contract AirdropModule is ModuleBase, ReentrancyGuard {
     using Position for ISetToken;
 
     /* ============ Structs ============ */
-    
+
     struct AirdropSettings {
         address[] airdrops;    // Array of tokens manager is allowing to be absorbed
         address feeRecipient;  // Address airdrop fees are sent to
@@ -278,7 +278,7 @@ contract AirdropModule is ModuleBase, ReentrancyGuard {
 
         if (amountAirdropped > 0) {
             (uint256 managerTake, uint256 protocolTake, uint256 totalFees) = _handleFees(_setToken, _token, amountAirdropped);
-            
+
             uint256 newUnit = _getPostAirdropUnit(_setToken, preFeeTokenBalance, totalFees);
 
             _setToken.editDefaultPosition(_token, newUnit);
@@ -309,13 +309,13 @@ contract AirdropModule is ModuleBase, ReentrancyGuard {
 
         if (airdropFee > 0) {
             uint256 managerTake = _amountAirdropped.preciseMul(airdropFee);
-            
+
             uint256 protocolTake = ModuleBase.getModuleFee(AIRDROP_MODULE_PROTOCOL_FEE_INDEX, managerTake);
             uint256 netManagerTake = managerTake.sub(protocolTake);
             uint256 totalFees = netManagerTake.add(protocolTake);
 
             _setToken.invokeTransfer(_component, airdropSettings[_setToken].feeRecipient, netManagerTake);
-            
+
             ModuleBase.payProtocolFeeFromSetToken(_setToken, _component, protocolTake);
 
             return (netManagerTake, protocolTake, totalFees);
@@ -326,7 +326,7 @@ contract AirdropModule is ModuleBase, ReentrancyGuard {
 
     /**
      * Retrieve new unit, which is the current balance less fees paid divided by total supply
-     */ 
+     */
     function _getPostAirdropUnit(
         ISetToken _setToken,
         uint256 _totalComponentBalance,
@@ -339,9 +339,9 @@ contract AirdropModule is ModuleBase, ReentrancyGuard {
 
     /**
      * If absorption is confined to the manager, manager must be caller
-     */ 
+     */
     function _isValidCaller(ISetToken _setToken) internal view returns(bool) {
-        return airdropSettings[_setToken].anyoneAbsorb || isSetManager(_setToken, msg.sender);       
+        return airdropSettings[_setToken].anyoneAbsorb || isSetManager(_setToken, msg.sender);
     }
 
     function _airdrops(ISetToken _setToken) internal view returns(address[] memory) {

--- a/contracts/protocol/modules/AmmModule.sol
+++ b/contracts/protocol/modules/AmmModule.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/protocol/modules/AmmModule.sol
+++ b/contracts/protocol/modules/AmmModule.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 pragma experimental "ABIEncoderV2";
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
@@ -40,7 +40,7 @@ import { PreciseUnitMath } from "../../lib/PreciseUnitMath.sol";
  * @author Set Protocol
  *
  * A smart contract module that enables joining and exiting of AMM Pools using multiple or a single ERC20s.
- * Examples of intended protocols include Curve, Uniswap, and Balancer. 
+ * Examples of intended protocols include Curve, Uniswap, and Balancer.
  */
 contract AmmModule is ModuleBase, ReentrancyGuard {
     using SafeCast for int256;
@@ -61,7 +61,7 @@ contract AmmModule is ModuleBase, ReentrancyGuard {
         address[] _components,
         int256[] _componentBalancesDelta  // Change in SetToken component token balances
     );
-    
+
     event LiquidityRemoved(
         ISetToken indexed _setToken,
         address indexed _ammPool,
@@ -80,11 +80,11 @@ contract AmmModule is ModuleBase, ReentrancyGuard {
         address liquidityToken;                     // Address of the AMM pool token
         uint256 preActionLiquidityTokenBalance;     // Balance of liquidity token before add/remove liquidity action
         uint256[] preActionComponentBalances;       // Balance of components before add/remove liquidity action
-        uint256 liquidityQuantity;                  // When adding liquidity, minimum quantity of liquidity required. 
+        uint256 liquidityQuantity;                  // When adding liquidity, minimum quantity of liquidity required.
                                                     // When removing liquidity, quantity to dispose of
         uint256[] totalNotionalComponents;          // When adding liquidity, maximum components provided
                                                     // When removing liquidity, minimum components to receive
-        uint256[] componentUnits;                   // List of inputted component real units 
+        uint256[] componentUnits;                   // List of inputted component real units
         address[] components;                       // List of component addresses for providing/removing liquidity
     }
 
@@ -140,11 +140,11 @@ contract AmmModule is ModuleBase, ReentrancyGuard {
 
         emit LiquidityAdded(_setToken, _ammPool, liquidityTokenDelta, _components, componentsDelta);
     }
-    
+
     /**
-     * SET MANAGER ONLY. Adds liquidity to an AMM pool for a specified AMM using a single asset if supported. 
+     * SET MANAGER ONLY. Adds liquidity to an AMM pool for a specified AMM using a single asset if supported.
      * Differs from addLiquidity as it will opt to use the AMMs single asset liquidity function if it exists
-     * User specifies what component and component quantity to contribute and the minimum number of 
+     * User specifies what component and component quantity to contribute and the minimum number of
      * liquidity pool tokens to receive.
      *
      * @param _setToken                 Address of SetToken
@@ -197,7 +197,7 @@ contract AmmModule is ModuleBase, ReentrancyGuard {
     }
 
     /**
-     * SET MANAGER ONLY. Removes liquidity from an AMM pool for a specified AMM. User specifies the exact number of 
+     * SET MANAGER ONLY. Removes liquidity from an AMM pool for a specified AMM. User specifies the exact number of
      * liquidity pool tokens to provide and the components and minimum quantity of component units to receive
      *
      * @param _setToken                  Address of SetToken
@@ -244,7 +244,7 @@ contract AmmModule is ModuleBase, ReentrancyGuard {
             liquidityTokenDelta,
             _components,
             componentsDelta
-        );        
+        );
     }
 
     /**
@@ -266,7 +266,7 @@ contract AmmModule is ModuleBase, ReentrancyGuard {
         uint256 _poolTokenPositionUnits,
         address _component,
         uint256 _minComponentUnitsReceived
-    ) 
+    )
         external
         nonReentrant
         onlyManagerAndValidSet(_setToken)
@@ -343,14 +343,14 @@ contract AmmModule is ModuleBase, ReentrancyGuard {
         actionInfo.preActionComponentBalances = _getTokenBalances(address(_setToken), _components);
 
         actionInfo.liquidityQuantity = actionInfo.totalSupply.getDefaultTotalNotional(_poolTokenInPositionUnit);
-                                       
+
         actionInfo.totalNotionalComponents = _getTotalNotionalComponents(_setToken, _componentUnits);
 
         actionInfo.componentUnits = _componentUnits;
-                                       
-        actionInfo.components = _components;                  
 
-        return actionInfo;        
+        actionInfo.components = _components;
+
+        return actionInfo;
     }
 
     function _getActionInfoSingleAsset(
@@ -430,7 +430,7 @@ contract AmmModule is ModuleBase, ReentrancyGuard {
             );
         }
     }
-    
+
     function _executeAddLiquidity(ActionInfo memory _actionInfo) internal {
         (
             address targetAmm, uint256 callValue, bytes memory methodData
@@ -454,9 +454,9 @@ contract AmmModule is ModuleBase, ReentrancyGuard {
             _actionInfo.liquidityQuantity
         );
 
-        _actionInfo.setToken.invoke(targetAmm, callValue, methodData);        
+        _actionInfo.setToken.invoke(targetAmm, callValue, methodData);
     }
-    
+
     function _executeRemoveLiquidity(ActionInfo memory _actionInfo) internal {
         (
             address targetAmm, uint256 callValue, bytes memory methodData
@@ -467,7 +467,7 @@ contract AmmModule is ModuleBase, ReentrancyGuard {
             _actionInfo.liquidityQuantity
         );
 
-        _actionInfo.setToken.invoke(targetAmm, callValue, methodData);        
+        _actionInfo.setToken.invoke(targetAmm, callValue, methodData);
     }
 
     function _executeRemoveLiquiditySingleAsset(ActionInfo memory _actionInfo) internal {
@@ -480,9 +480,9 @@ contract AmmModule is ModuleBase, ReentrancyGuard {
             _actionInfo.liquidityQuantity
         );
 
-        _actionInfo.setToken.invoke(targetAmm, callValue, methodData);        
+        _actionInfo.setToken.invoke(targetAmm, callValue, methodData);
     }
-    
+
     function _validateMinimumLiquidityReceived(ActionInfo memory _actionInfo) internal view {
         uint256 liquidityTokenBalance = IERC20(_actionInfo.liquidityToken).balanceOf(address(_actionInfo.setToken));
 

--- a/contracts/protocol/modules/BasicIssuanceModule.sol
+++ b/contracts/protocol/modules/BasicIssuanceModule.sol
@@ -10,6 +10,8 @@
     See the License for the specific language governing permissions and
     limitations under the License.
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/protocol/modules/BasicIssuanceModule.sol
+++ b/contracts/protocol/modules/BasicIssuanceModule.sol
@@ -12,7 +12,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 pragma experimental "ABIEncoderV2";
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
@@ -87,7 +87,7 @@ contract BasicIssuanceModule is ModuleBase, ReentrancyGuard {
         ISetToken _setToken,
         uint256 _quantity,
         address _to
-    ) 
+    )
         external
         nonReentrant
         onlyValidAndInitializedSet(_setToken)

--- a/contracts/protocol/modules/ClaimModule.sol
+++ b/contracts/protocol/modules/ClaimModule.sol
@@ -10,6 +10,8 @@
     See the License for the specific language governing permissions and
     limitations under the License.
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/protocol/modules/ClaimModule.sol
+++ b/contracts/protocol/modules/ClaimModule.sol
@@ -12,7 +12,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 pragma experimental "ABIEncoderV2";
 
 import { AddressArrayUtils } from "../../lib/AddressArrayUtils.sol";
@@ -27,13 +27,13 @@ import { ModuleBase } from "../lib/ModuleBase.sol";
  * @author Set Protocol
  *
  * Module that enables managers to claim tokens from external protocols given to the Set as part of participating in
- * incentivized activities of other protocols. The ClaimModule works in conjunction with ClaimAdapters, in which the 
+ * incentivized activities of other protocols. The ClaimModule works in conjunction with ClaimAdapters, in which the
  * claimAdapterID / integrationNames are stored on the integration registry.
- * 
+ *
  * Design:
  * The ecosystem is coalescing around a few standards of how reward programs are created, using forks of popular
  * contracts such as Synthetix's Mintr. Thus, the Claim architecture reflects a more functional vs external-protocol
- * approach where an adapter with common functionality can be used across protocols. 
+ * approach where an adapter with common functionality can be used across protocols.
  *
  * Definitions:
  * Reward Pool: A reward pool is a contract associated with an external protocol's reward. Examples of reward pools
@@ -220,7 +220,7 @@ contract ClaimModule is ModuleBase {
             _removeClaim(_setToken, _rewardPools[i], _integrationNames[i]);
         }
     }
- 
+
     /**
      * SET MANAGER ONLY. Initializes this module to the SetToken.
      *
@@ -404,7 +404,7 @@ contract ClaimModule is ModuleBase {
     }
 
     /**
-     * Internal version. Adds a new rewardPool to the list to perform claims for the SetToken indicating the list of claim 
+     * Internal version. Adds a new rewardPool to the list to perform claims for the SetToken indicating the list of claim
      * integrations. Each claim integration is associated to an adapter that provides the functionality to claim the rewards
      * for a specific token.
      *
@@ -429,7 +429,7 @@ contract ClaimModule is ModuleBase {
 
     /**
      * Validates and store the adapter address used to claim rewards for the passed rewardPool. If no adapters
-     * left after removal then remove rewardPool from rewardPoolList and delete entry in claimSettings. 
+     * left after removal then remove rewardPool from rewardPoolList and delete entry in claimSettings.
      *
      * @param _setToken                 Address of SetToken
      * @param _rewardPool               Address of the rewardPool that identifies the contract governing claims
@@ -449,7 +449,7 @@ contract ClaimModule is ModuleBase {
     }
 
     /**
-     * For batch functions validate arrays are of equal length and not empty. Return length of array for iteration. 
+     * For batch functions validate arrays are of equal length and not empty. Return length of array for iteration.
      *
      * @param _rewardPools              Addresses of the rewardPool that identifies the contract governing claims
      * @param _integrationNames         IDs of claim module integration (mapping on integration registry)

--- a/contracts/protocol/modules/CompoundLeverageModule.sol
+++ b/contracts/protocol/modules/CompoundLeverageModule.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 pragma experimental "ABIEncoderV2";
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
@@ -37,7 +37,7 @@ import { ModuleBase } from "../lib/ModuleBase.sol";
  * @author Set Protocol
  *
  * Smart contract that enables leverage trading using Compound as the lending protocol. This module is paired with a debt issuance module that will call
- * functions on this module to keep interest accrual and liquidation state updated. This does not allow borrowing of assets from Compound alone. Each 
+ * functions on this module to keep interest accrual and liquidation state updated. This does not allow borrowing of assets from Compound alone. Each
  * asset is leveraged when using this module.
  *
  * Note: Do not use this module in conjunction with other debt modules that allow Compound debt positions as it could lead to double counting of
@@ -106,7 +106,7 @@ contract CompoundLeverageModule is ModuleBase, ReentrancyGuard, Ownable {
     );
 
     event AnySetAllowedUpdated(
-        bool indexed _anySetAllowed    
+        bool indexed _anySetAllowed
     );
 
     /* ============ Constants ============ */
@@ -155,7 +155,7 @@ contract CompoundLeverageModule is ModuleBase, ReentrancyGuard, Ownable {
 
     /**
      * Instantiate addresses. Underlying to cToken mapping is created.
-     * 
+     *
      * @param _controller               Address of controller contract
      * @param _compToken                Address of COMP token
      * @param _comptroller              Address of Compound Comptroller
@@ -214,7 +214,7 @@ contract CompoundLeverageModule is ModuleBase, ReentrancyGuard, Ownable {
         nonReentrant
         onlyManagerAndValidSet(_setToken)
     {
-        // For levering up, send quantity is derived from borrow asset and receive quantity is derived from 
+        // For levering up, send quantity is derived from borrow asset and receive quantity is derived from
         // collateral asset
         ActionInfo memory leverInfo = _createAndValidateActionInfo(
             _setToken,
@@ -273,7 +273,7 @@ contract CompoundLeverageModule is ModuleBase, ReentrancyGuard, Ownable {
         nonReentrant
         onlyManagerAndValidSet(_setToken)
     {
-        // Note: for delevering, send quantity is derived from collateral asset and receive quantity is derived from 
+        // Note: for delevering, send quantity is derived from collateral asset and receive quantity is derived from
         // repay asset
         ActionInfo memory deleverInfo = _createAndValidateActionInfo(
             _setToken,
@@ -332,7 +332,7 @@ contract CompoundLeverageModule is ModuleBase, ReentrancyGuard, Ownable {
         onlyManagerAndValidSet(_setToken)
     {
         uint256 notionalRedeemQuantity = _redeemQuantity.preciseMul(_setToken.totalSupply());
-        
+
         require(borrowCTokenEnabled[_setToken][underlyingToCToken[_repayAsset]], "Borrow not enabled");
         uint256 notionalRepayQuantity = underlyingToCToken[_repayAsset].borrowBalanceCurrent(address(_setToken));
 
@@ -374,7 +374,7 @@ contract CompoundLeverageModule is ModuleBase, ReentrancyGuard, Ownable {
     }
 
     /**
-     * CALLABLE BY ANYBODY: Sync Set positions with enabled Compound collateral and borrow positions. For collateral 
+     * CALLABLE BY ANYBODY: Sync Set positions with enabled Compound collateral and borrow positions. For collateral
      * assets, update cToken default position. For borrow assets, update external borrow position.
      * - Collateral assets may come out of sync when a position is liquidated
      * - Borrow assets may come out of sync when interest is accrued or position is liquidated and borrow is repaid
@@ -457,7 +457,7 @@ contract CompoundLeverageModule is ModuleBase, ReentrancyGuard, Ownable {
         for(uint256 i = 0; i < modules.length; i++) {
             try IDebtIssuanceModule(modules[i]).registerToIssuanceModule(_setToken) {} catch {}
         }
-        
+
         // Enable collateral and borrow assets on Compound
         addCollateralAssets(_setToken, _collateralAssets);
 
@@ -495,7 +495,7 @@ contract CompoundLeverageModule is ModuleBase, ReentrancyGuard, Ownable {
 
             delete collateralCTokenEnabled[setToken][cToken];
         }
-        
+
         delete enabledAssets[setToken];
 
         // Try if unregister exists on any of the modules
@@ -557,7 +557,7 @@ contract CompoundLeverageModule is ModuleBase, ReentrancyGuard, Ownable {
         for(uint256 i = 0; i < _collateralAssets.length; i++) {
             ICErc20 cToken = underlyingToCToken[_collateralAssets[i]];
             require(collateralCTokenEnabled[_setToken][cToken], "Collateral not enabled");
-            
+
             // Note: Will only exit market if cToken is not enabled as a borrow asset as well
             // If there is an existing borrow balance, will revert and market cannot be exited on Compound
             if (!borrowCTokenEnabled[_setToken][cToken]) {
@@ -611,7 +611,7 @@ contract CompoundLeverageModule is ModuleBase, ReentrancyGuard, Ownable {
         for(uint256 i = 0; i < _borrowAssets.length; i++) {
             ICErc20 cToken = underlyingToCToken[_borrowAssets[i]];
             require(borrowCTokenEnabled[_setToken][cToken], "Borrow not enabled");
-            
+
             // Note: Will only exit market if cToken is not enabled as a collateral asset as well
             // If there is an existing borrow balance, will revert and market cannot be exited on Compound
             if (!collateralCTokenEnabled[_setToken][cToken]) {
@@ -649,7 +649,7 @@ contract CompoundLeverageModule is ModuleBase, ReentrancyGuard, Ownable {
     /**
      * GOVERNANCE ONLY: Add Compound market to module with stored underlying to cToken mapping in case of market additions to Compound.
      *
-     * IMPORTANT: Validations are skipped in order to get contract under bytecode limit 
+     * IMPORTANT: Validations are skipped in order to get contract under bytecode limit
      *
      * @param _cToken                   Address of cToken to add
      * @param _underlying               Address of underlying token that maps to cToken
@@ -662,7 +662,7 @@ contract CompoundLeverageModule is ModuleBase, ReentrancyGuard, Ownable {
     /**
      * GOVERNANCE ONLY: Remove Compound market on stored underlying to cToken mapping in case of market removals
      *
-     * IMPORTANT: Validations are skipped in order to get contract under bytecode limit 
+     * IMPORTANT: Validations are skipped in order to get contract under bytecode limit
      *
      * @param _underlying               Address of underlying token to remove
      */
@@ -744,7 +744,7 @@ contract CompoundLeverageModule is ModuleBase, ReentrancyGuard, Ownable {
     /* ============ Internal Functions ============ */
 
     /**
-     * Mints the specified cToken from the underlying of the specified notional quantity. If cEther, the WETH must be 
+     * Mints the specified cToken from the underlying of the specified notional quantity. If cEther, the WETH must be
      * unwrapped as it only accepts the underlying ETH.
      */
     function _mintCToken(ISetToken _setToken, ICErc20 _cToken, IERC20 _underlyingToken, uint256 _mintNotional) internal {
@@ -847,7 +847,7 @@ contract CompoundLeverageModule is ModuleBase, ReentrancyGuard, Ownable {
      */
     function _accrueProtocolFee(ISetToken _setToken, IERC20 _receiveToken, uint256 _exchangedQuantity) internal returns(uint256) {
         uint256 protocolFeeTotal = getModuleFee(PROTOCOL_TRADE_FEE_INDEX, _exchangedQuantity);
-        
+
         payProtocolFeeFromSetToken(_setToken, address(_receiveToken), protocolFeeTotal);
 
         return protocolFeeTotal;

--- a/contracts/protocol/modules/CompoundLeverageModule.sol
+++ b/contracts/protocol/modules/CompoundLeverageModule.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/protocol/modules/CustomOracleNAVIssuanceModule.sol
+++ b/contracts/protocol/modules/CustomOracleNAVIssuanceModule.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/protocol/modules/CustomOracleNAVIssuanceModule.sol
+++ b/contracts/protocol/modules/CustomOracleNAVIssuanceModule.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 pragma experimental "ABIEncoderV2";
 
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
@@ -122,7 +122,7 @@ contract CustomOracleNavIssuanceModule is ModuleBase, ReentrancyGuard {
         uint256 premiumPercentage;                     // Premium percentage (0.01% = 1e14, 1% = 1e16). This premium is a buffer around oracle
                                                        // prices paid by user to the SetToken, which prevents arbitrage and oracle front running
         uint256 maxPremiumPercentage;                  // Maximum premium percentage manager is allowed to set (configured by manager)
-        uint256 minSetTokenSupply;                     // Minimum SetToken supply required for issuance and redemption 
+        uint256 minSetTokenSupply;                     // Minimum SetToken supply required for issuance and redemption
                                                        // to prevent dramatic inflationary changes to the SetToken's position multiplier
     }
 
@@ -148,7 +148,7 @@ contract CustomOracleNavIssuanceModule is ModuleBase, ReentrancyGuard {
 
     // Mapping of SetToken to NAV issuance settings struct
     mapping(ISetToken => NAVIssuanceSettings) public navIssuanceSettings;
-    
+
     // Mapping to efficiently check a SetToken's reserve asset validity
     // SetToken => reserveAsset => isReserveAsset
     mapping(ISetToken => mapping(address => bool)) public isReserveAsset;
@@ -184,7 +184,7 @@ contract CustomOracleNavIssuanceModule is ModuleBase, ReentrancyGuard {
     }
 
     /* ============ External Functions ============ */
-    
+
     /**
      * Deposits the allowed reserve asset into the SetToken and mints the appropriate % of Net Asset Value of the SetToken
      * to the specified _to address.
@@ -201,13 +201,13 @@ contract CustomOracleNavIssuanceModule is ModuleBase, ReentrancyGuard {
         uint256 _reserveAssetQuantity,
         uint256 _minSetTokenReceiveQuantity,
         address _to
-    ) 
+    )
         external
         nonReentrant
         onlyValidAndInitializedSet(_setToken)
     {
         _validateCommon(_setToken, _reserveAsset, _reserveAssetQuantity);
-        
+
         _callPreIssueHooks(_setToken, _reserveAsset, _reserveAssetQuantity, msg.sender, _to);
 
         ActionInfo memory issueInfo = _createIssuanceInfo(_setToken, _reserveAsset, _reserveAssetQuantity);
@@ -231,7 +231,7 @@ contract CustomOracleNavIssuanceModule is ModuleBase, ReentrancyGuard {
         ISetToken _setToken,
         uint256 _minSetTokenReceiveQuantity,
         address _to
-    ) 
+    )
         external
         payable
         nonReentrant
@@ -240,7 +240,7 @@ contract CustomOracleNavIssuanceModule is ModuleBase, ReentrancyGuard {
         weth.deposit{ value: msg.value }();
 
         _validateCommon(_setToken, address(weth), msg.value);
-        
+
         _callPreIssueHooks(_setToken, address(weth), msg.value, msg.sender, _to);
 
         ActionInfo memory issueInfo = _createIssuanceInfo(_setToken, address(weth), msg.value);
@@ -268,7 +268,7 @@ contract CustomOracleNavIssuanceModule is ModuleBase, ReentrancyGuard {
         uint256 _setTokenQuantity,
         uint256 _minReserveReceiveQuantity,
         address _to
-    ) 
+    )
         external
         nonReentrant
         onlyValidAndInitializedSet(_setToken)
@@ -309,7 +309,7 @@ contract CustomOracleNavIssuanceModule is ModuleBase, ReentrancyGuard {
         uint256 _setTokenQuantity,
         uint256 _minReserveReceiveQuantity,
         address payable _to
-    ) 
+    )
         external
         nonReentrant
         onlyValidAndInitializedSet(_setToken)
@@ -332,7 +332,7 @@ contract CustomOracleNavIssuanceModule is ModuleBase, ReentrancyGuard {
         );
 
         weth.withdraw(redeemInfo.netFlowQuantity);
-        
+
         _to.transfer(redeemInfo.netFlowQuantity);
 
         _handleRedemptionFees(_setToken, address(weth), redeemInfo);
@@ -348,7 +348,7 @@ contract CustomOracleNavIssuanceModule is ModuleBase, ReentrancyGuard {
      */
     function addReserveAsset(ISetToken _setToken, address _reserveAsset) external onlyManagerAndValidSet(_setToken) {
         require(!isReserveAsset[_setToken][_reserveAsset], "Reserve asset already exists");
-        
+
         navIssuanceSettings[_setToken].reserveAssets.push(_reserveAsset);
         isReserveAsset[_setToken][_reserveAsset] = true;
 
@@ -378,7 +378,7 @@ contract CustomOracleNavIssuanceModule is ModuleBase, ReentrancyGuard {
      */
     function editPremium(ISetToken _setToken, uint256 _premiumPercentage) external onlyManagerAndValidSet(_setToken) {
         require(_premiumPercentage <= navIssuanceSettings[_setToken].maxPremiumPercentage, "Premium must be less than maximum allowed");
-        
+
         navIssuanceSettings[_setToken].premiumPercentage = _premiumPercentage;
 
         emit PremiumEdited(_setToken, _premiumPercentage);
@@ -400,7 +400,7 @@ contract CustomOracleNavIssuanceModule is ModuleBase, ReentrancyGuard {
         onlyManagerAndValidSet(_setToken)
     {
         require(_managerFeePercentage <= navIssuanceSettings[_setToken].maxManagerFee, "Manager fee must be less than maximum allowed");
-        
+
         navIssuanceSettings[_setToken].managerFees[_managerFeeIndex] = _managerFeePercentage;
 
         emit ManagerFeeEdited(_setToken, _managerFeePercentage, _managerFeeIndex);
@@ -414,7 +414,7 @@ contract CustomOracleNavIssuanceModule is ModuleBase, ReentrancyGuard {
      */
     function editFeeRecipient(ISetToken _setToken, address _managerFeeRecipient) external onlyManagerAndValidSet(_setToken) {
         require(_managerFeeRecipient != address(0), "Fee recipient must not be 0 address");
-        
+
         navIssuanceSettings[_setToken].feeRecipient = _managerFeeRecipient;
 
         emit FeeRecipientEdited(_setToken, _managerFeeRecipient);
@@ -465,7 +465,7 @@ contract CustomOracleNavIssuanceModule is ModuleBase, ReentrancyGuard {
         for (uint256 i = 0; i < navIssuanceSettings[setToken].reserveAssets.length; i++) {
             delete isReserveAsset[setToken][navIssuanceSettings[setToken].reserveAssets[i]];
         }
-        
+
         delete navIssuanceSettings[setToken];
     }
 
@@ -782,7 +782,7 @@ contract CustomOracleNavIssuanceModule is ModuleBase, ReentrancyGuard {
         address _reserveAsset,
         address _to,
         ActionInfo memory _issueInfo
-    ) 
+    )
         internal
     {
         _setToken.editPositionMultiplier(_issueInfo.newPositionMultiplier);
@@ -800,7 +800,7 @@ contract CustomOracleNavIssuanceModule is ModuleBase, ReentrancyGuard {
             _issueInfo.setTokenQuantity,
             _issueInfo.managerFee,
             _issueInfo.protocolFees
-        );        
+        );
     }
 
     function _handleRedeemStateUpdates(
@@ -808,7 +808,7 @@ contract CustomOracleNavIssuanceModule is ModuleBase, ReentrancyGuard {
         address _reserveAsset,
         address _to,
         ActionInfo memory _redeemInfo
-    ) 
+    )
         internal
     {
         _setToken.editPositionMultiplier(_redeemInfo.newPositionMultiplier);
@@ -824,7 +824,7 @@ contract CustomOracleNavIssuanceModule is ModuleBase, ReentrancyGuard {
             _redeemInfo.setTokenQuantity,
             _redeemInfo.managerFee,
             _redeemInfo.protocolFees
-        );      
+        );
     }
 
     function _handleRedemptionFees(ISetToken _setToken, address _reserveAsset, ActionInfo memory _redeemInfo) internal {
@@ -932,7 +932,7 @@ contract CustomOracleNavIssuanceModule is ModuleBase, ReentrancyGuard {
         uint256 protocolDirectFeePercent = controller.getModuleFee(address(this), _protocolDirectFeeIndex);
         uint256 protocolManagerShareFeePercent = controller.getModuleFee(address(this), _protocolManagerFeeIndex);
         uint256 managerFeePercent = navIssuanceSettings[_setToken].managerFees[_managerFeeIndex];
-        
+
         // Calculate revenue share split percentage
         uint256 protocolRevenueSharePercentage = protocolManagerShareFeePercent.preciseMul(managerFeePercent);
         uint256 managerRevenueSharePercentage = managerFeePercent.sub(protocolRevenueSharePercentage);
@@ -997,7 +997,7 @@ contract CustomOracleNavIssuanceModule is ModuleBase, ReentrancyGuard {
      * The new position multiplier is calculated as follows:
      * inflationPercentage = (newSupply - oldSupply) / newSupply
      * newMultiplier = (1 - inflationPercentage) * positionMultiplier
-     */    
+     */
     function _getIssuePositionMultiplier(
         ISetToken _setToken,
         ActionInfo memory _issueInfo
@@ -1017,11 +1017,11 @@ contract CustomOracleNavIssuanceModule is ModuleBase, ReentrancyGuard {
 
     /**
      * Calculate deflation and new position multiplier. Note: Round deflation down in order to round position multiplier down
-     * 
+     *
      * The new position multiplier is calculated as follows:
      * deflationPercentage = (oldSupply - newSupply) / newSupply
      * newMultiplier = (1 + deflationPercentage) * positionMultiplier
-     */ 
+     */
     function _getRedeemPositionMultiplier(
         ISetToken _setToken,
         uint256 _setTokenQuantity,
@@ -1043,7 +1043,7 @@ contract CustomOracleNavIssuanceModule is ModuleBase, ReentrancyGuard {
      * The new position reserve asset unit is calculated as follows:
      * totalReserve = (oldUnit * oldSetTokenSupply) + reserveQuantity
      * newUnit = totalReserve / newSetTokenSupply
-     */ 
+     */
     function _getIssuePositionUnit(
         ISetToken _setToken,
         address _reserveAsset,
@@ -1065,7 +1065,7 @@ contract CustomOracleNavIssuanceModule is ModuleBase, ReentrancyGuard {
      * The new position reserve asset unit is calculated as follows:
      * totalReserve = (oldUnit * oldSetTokenSupply) - reserveQuantityToSendOut
      * newUnit = totalReserve / newSetTokenSupply
-     */ 
+     */
     function _getRedeemPositionUnit(
         ISetToken _setToken,
         address _reserveAsset,

--- a/contracts/protocol/modules/DebtIssuanceModule.sol
+++ b/contracts/protocol/modules/DebtIssuanceModule.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/protocol/modules/DebtIssuanceModule.sol
+++ b/contracts/protocol/modules/DebtIssuanceModule.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 pragma experimental "ABIEncoderV2";
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
@@ -98,7 +98,7 @@ contract DebtIssuanceModule is ModuleBase, ReentrancyGuard {
     /* ============ External Functions ============ */
 
     /**
-     * Deposits components to the SetToken, replicates any external module component positions and mints 
+     * Deposits components to the SetToken, replicates any external module component positions and mints
      * the SetToken. If the token has a debt position all collateral will be transferred in first then debt
      * will be returned to the minting address. If specified, a fee will be charged on issuance.
      *
@@ -151,7 +151,7 @@ contract DebtIssuanceModule is ModuleBase, ReentrancyGuard {
     }
 
     /**
-     * Returns components from the SetToken, unwinds any external module component positions and burns 
+     * Returns components from the SetToken, unwinds any external module component positions and burns
      * the SetToken. If the token has a debt position all debt will be paid down first then equity positions
      * will be returned to the minting address. If specified, a fee will be charged on redeem.
      *
@@ -362,7 +362,7 @@ contract DebtIssuanceModule is ModuleBase, ReentrancyGuard {
         IssuanceSettings memory setIssuanceSettings = issuanceSettings[_setToken];
         uint256 protocolFeeSplit = controller.getModuleFee(address(this), ISSUANCE_MODULE_PROTOCOL_FEE_SPLIT_INDEX);
         uint256 totalFeeRate = _isIssue ? setIssuanceSettings.managerIssueFee : setIssuanceSettings.managerRedeemFee;
-        
+
         uint256 totalFee = totalFeeRate.preciseMul(_quantity);
         protocolFee = totalFee.preciseMul(protocolFeeSplit);
         managerFee = totalFee.sub(protocolFee);
@@ -507,7 +507,7 @@ contract DebtIssuanceModule is ModuleBase, ReentrancyGuard {
             address[] memory externalPositions = _setToken.getExternalPositionModules(component);
 
             if (externalPositions.length > 0) {
-                for (uint256 j = 0; j < externalPositions.length; j++) { 
+                for (uint256 j = 0; j < externalPositions.length; j++) {
                     int256 externalPositionUnit = _setToken.getExternalPositionRealUnit(component, externalPositions[j]);
 
                     // If positionUnit <= 0 it will be "added" to debt position
@@ -608,7 +608,7 @@ contract DebtIssuanceModule is ModuleBase, ReentrancyGuard {
 
     /**
      * If any manager fees mints Sets to the defined feeRecipient. If protocol fee is enabled mints Sets to protocol
-     * feeRecipient. 
+     * feeRecipient.
      */
     function _resolveFees(ISetToken _setToken, uint256 managerFee, uint256 protocolFee) internal {
         if (managerFee > 0) {
@@ -642,7 +642,7 @@ contract DebtIssuanceModule is ModuleBase, ReentrancyGuard {
 
         return address(0);
     }
-    
+
     /**
      * Calls all modules that have registered with the DebtIssuanceModule that have a moduleIssueHook.
      */
@@ -664,7 +664,7 @@ contract DebtIssuanceModule is ModuleBase, ReentrancyGuard {
     }
 
     /**
-     * For each component's external module positions, calculate the total notional quantity, and 
+     * For each component's external module positions, calculate the total notional quantity, and
      * call the module's issue hook or redeem hook.
      * Note: It is possible that these hooks can cause the states of other modules to change.
      * It can be problematic if the hook called an external function that called back into a module, resulting in state inconsistencies.

--- a/contracts/protocol/modules/GeneralIndexModule.sol
+++ b/contracts/protocol/modules/GeneralIndexModule.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/protocol/modules/GeneralIndexModule.sol
+++ b/contracts/protocol/modules/GeneralIndexModule.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 pragma experimental "ABIEncoderV2";
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/contracts/protocol/modules/GovernanceModule.sol
+++ b/contracts/protocol/modules/GovernanceModule.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/protocol/modules/GovernanceModule.sol
+++ b/contracts/protocol/modules/GovernanceModule.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 pragma experimental "ABIEncoderV2";
 
 import { ReentrancyGuard } from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
@@ -33,7 +33,7 @@ import { ModuleBase } from "../lib/ModuleBase.sol";
  * @author Set Protocol
  *
  * A smart contract module that enables participating in governance of component tokens held in the SetToken.
- * Examples of intended protocols include Compound, Uniswap, and Maker governance. 
+ * Examples of intended protocols include Compound, Uniswap, and Maker governance.
  */
 contract GovernanceModule is ModuleBase, ReentrancyGuard {
     using Invoke for ISetToken;

--- a/contracts/protocol/modules/IssuanceModule.sol
+++ b/contracts/protocol/modules/IssuanceModule.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/protocol/modules/IssuanceModule.sol
+++ b/contracts/protocol/modules/IssuanceModule.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 pragma experimental "ABIEncoderV2";
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
@@ -38,7 +38,7 @@ import { PreciseUnitMath } from "../../lib/PreciseUnitMath.sol";
  * @title IssuanceModule
  * @author Set Protocol
  *
- * The IssuanceModule is a module that enables users to issue and redeem SetTokens that contain default and 
+ * The IssuanceModule is a module that enables users to issue and redeem SetTokens that contain default and
  * non-debt external Positions. Managers are able to set an external contract hook that is called before an
  * issuance is called.
  */
@@ -70,7 +70,7 @@ contract IssuanceModule is ModuleBase, ReentrancyGuard {
     /* ============ External Functions ============ */
 
     /**
-     * Deposits components to the SetToken and replicates any external module component positions and mints 
+     * Deposits components to the SetToken and replicates any external module component positions and mints
      * the SetToken. Any issuances with SetTokens that have external positions with negative unit will revert.
      *
      * @param _setToken             Instance of the SetToken contract
@@ -81,7 +81,7 @@ contract IssuanceModule is ModuleBase, ReentrancyGuard {
         ISetToken _setToken,
         uint256 _quantity,
         address _to
-    ) 
+    )
         external
         nonReentrant
         onlyValidAndInitializedSet(_setToken)
@@ -140,7 +140,7 @@ contract IssuanceModule is ModuleBase, ReentrancyGuard {
 
         for (uint256 i = 0; i < components.length; i++) {
             _executeExternalPositionHooks(_setToken, _quantity, IERC20(components[i]), false);
-            
+
             _setToken.strictInvokeTransfer(
                 components[i],
                 _to,
@@ -208,8 +208,8 @@ contract IssuanceModule is ModuleBase, ReentrancyGuard {
         for (uint256 i = 0; i < issuanceUnits.length; i++) {
             // Use preciseMulCeil to round up to ensure overcollateration when small issue quantities are provided
             // and preciseMul to round down to ensure overcollateration when small redeem quantities are provided
-            notionalUnits[i] = _isIssue ? 
-                issuanceUnits[i].preciseMulCeil(_quantity) : 
+            notionalUnits[i] = _isIssue ?
+                issuanceUnits[i].preciseMulCeil(_quantity) :
                 issuanceUnits[i].preciseMul(_quantity);
         }
 
@@ -244,7 +244,7 @@ contract IssuanceModule is ModuleBase, ReentrancyGuard {
             totalUnits[i] = cumulativeUnits.toUint256();
         }
 
-        return (components, totalUnits);        
+        return (components, totalUnits);
     }
 
     /**
@@ -271,7 +271,7 @@ contract IssuanceModule is ModuleBase, ReentrancyGuard {
     }
 
     /**
-     * For each component's external module positions, calculate the total notional quantity, and 
+     * For each component's external module positions, calculate the total notional quantity, and
      * call the module's issue hook or redeem hook.
      * Note: It is possible that these hooks can cause the states of other modules to change.
      * It can be problematic if the a hook called an external function that called back into a module, resulting in state inconsistencies.

--- a/contracts/protocol/modules/NAVIssuanceModule.sol
+++ b/contracts/protocol/modules/NAVIssuanceModule.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/protocol/modules/NAVIssuanceModule.sol
+++ b/contracts/protocol/modules/NAVIssuanceModule.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 pragma experimental "ABIEncoderV2";
 
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
@@ -121,7 +121,7 @@ contract NavIssuanceModule is ModuleBase, ReentrancyGuard {
         uint256 premiumPercentage;                     // Premium percentage (0.01% = 1e14, 1% = 1e16). This premium is a buffer around oracle
                                                        // prices paid by user to the SetToken, which prevents arbitrage and oracle front running
         uint256 maxPremiumPercentage;                  // Maximum premium percentage manager is allowed to set (configured by manager)
-        uint256 minSetTokenSupply;                     // Minimum SetToken supply required for issuance and redemption 
+        uint256 minSetTokenSupply;                     // Minimum SetToken supply required for issuance and redemption
                                                        // to prevent dramatic inflationary changes to the SetToken's position multiplier
     }
 
@@ -147,7 +147,7 @@ contract NavIssuanceModule is ModuleBase, ReentrancyGuard {
 
     // Mapping of SetToken to NAV issuance settings struct
     mapping(ISetToken => NAVIssuanceSettings) public navIssuanceSettings;
-    
+
     // Mapping to efficiently check a SetToken's reserve asset validity
     // SetToken => reserveAsset => isReserveAsset
     mapping(ISetToken => mapping(address => bool)) public isReserveAsset;
@@ -183,7 +183,7 @@ contract NavIssuanceModule is ModuleBase, ReentrancyGuard {
     }
 
     /* ============ External Functions ============ */
-    
+
     /**
      * Deposits the allowed reserve asset into the SetToken and mints the appropriate % of Net Asset Value of the SetToken
      * to the specified _to address.
@@ -200,13 +200,13 @@ contract NavIssuanceModule is ModuleBase, ReentrancyGuard {
         uint256 _reserveAssetQuantity,
         uint256 _minSetTokenReceiveQuantity,
         address _to
-    ) 
+    )
         external
         nonReentrant
         onlyValidAndInitializedSet(_setToken)
     {
         _validateCommon(_setToken, _reserveAsset, _reserveAssetQuantity);
-        
+
         _callPreIssueHooks(_setToken, _reserveAsset, _reserveAssetQuantity, msg.sender, _to);
 
         ActionInfo memory issueInfo = _createIssuanceInfo(_setToken, _reserveAsset, _reserveAssetQuantity);
@@ -230,7 +230,7 @@ contract NavIssuanceModule is ModuleBase, ReentrancyGuard {
         ISetToken _setToken,
         uint256 _minSetTokenReceiveQuantity,
         address _to
-    ) 
+    )
         external
         payable
         nonReentrant
@@ -239,7 +239,7 @@ contract NavIssuanceModule is ModuleBase, ReentrancyGuard {
         weth.deposit{ value: msg.value }();
 
         _validateCommon(_setToken, address(weth), msg.value);
-        
+
         _callPreIssueHooks(_setToken, address(weth), msg.value, msg.sender, _to);
 
         ActionInfo memory issueInfo = _createIssuanceInfo(_setToken, address(weth), msg.value);
@@ -267,7 +267,7 @@ contract NavIssuanceModule is ModuleBase, ReentrancyGuard {
         uint256 _setTokenQuantity,
         uint256 _minReserveReceiveQuantity,
         address _to
-    ) 
+    )
         external
         nonReentrant
         onlyValidAndInitializedSet(_setToken)
@@ -308,7 +308,7 @@ contract NavIssuanceModule is ModuleBase, ReentrancyGuard {
         uint256 _setTokenQuantity,
         uint256 _minReserveReceiveQuantity,
         address payable _to
-    ) 
+    )
         external
         nonReentrant
         onlyValidAndInitializedSet(_setToken)
@@ -331,7 +331,7 @@ contract NavIssuanceModule is ModuleBase, ReentrancyGuard {
         );
 
         weth.withdraw(redeemInfo.netFlowQuantity);
-        
+
         _to.transfer(redeemInfo.netFlowQuantity);
 
         _handleRedemptionFees(_setToken, address(weth), redeemInfo);
@@ -347,7 +347,7 @@ contract NavIssuanceModule is ModuleBase, ReentrancyGuard {
      */
     function addReserveAsset(ISetToken _setToken, address _reserveAsset) external onlyManagerAndValidSet(_setToken) {
         require(!isReserveAsset[_setToken][_reserveAsset], "Reserve asset already exists");
-        
+
         navIssuanceSettings[_setToken].reserveAssets.push(_reserveAsset);
         isReserveAsset[_setToken][_reserveAsset] = true;
 
@@ -377,7 +377,7 @@ contract NavIssuanceModule is ModuleBase, ReentrancyGuard {
      */
     function editPremium(ISetToken _setToken, uint256 _premiumPercentage) external onlyManagerAndValidSet(_setToken) {
         require(_premiumPercentage <= navIssuanceSettings[_setToken].maxPremiumPercentage, "Premium must be less than maximum allowed");
-        
+
         navIssuanceSettings[_setToken].premiumPercentage = _premiumPercentage;
 
         emit PremiumEdited(_setToken, _premiumPercentage);
@@ -399,7 +399,7 @@ contract NavIssuanceModule is ModuleBase, ReentrancyGuard {
         onlyManagerAndValidSet(_setToken)
     {
         require(_managerFeePercentage <= navIssuanceSettings[_setToken].maxManagerFee, "Manager fee must be less than maximum allowed");
-        
+
         navIssuanceSettings[_setToken].managerFees[_managerFeeIndex] = _managerFeePercentage;
 
         emit ManagerFeeEdited(_setToken, _managerFeePercentage, _managerFeeIndex);
@@ -413,7 +413,7 @@ contract NavIssuanceModule is ModuleBase, ReentrancyGuard {
      */
     function editFeeRecipient(ISetToken _setToken, address _managerFeeRecipient) external onlyManagerAndValidSet(_setToken) {
         require(_managerFeeRecipient != address(0), "Fee recipient must not be 0 address");
-        
+
         navIssuanceSettings[_setToken].feeRecipient = _managerFeeRecipient;
 
         emit FeeRecipientEdited(_setToken, _managerFeeRecipient);
@@ -464,7 +464,7 @@ contract NavIssuanceModule is ModuleBase, ReentrancyGuard {
         for (uint256 i = 0; i < navIssuanceSettings[setToken].reserveAssets.length; i++) {
             delete isReserveAsset[setToken][navIssuanceSettings[setToken].reserveAssets[i]];
         }
-        
+
         delete navIssuanceSettings[setToken];
     }
 
@@ -781,7 +781,7 @@ contract NavIssuanceModule is ModuleBase, ReentrancyGuard {
         address _reserveAsset,
         address _to,
         ActionInfo memory _issueInfo
-    ) 
+    )
         internal
     {
         _setToken.editPositionMultiplier(_issueInfo.newPositionMultiplier);
@@ -799,7 +799,7 @@ contract NavIssuanceModule is ModuleBase, ReentrancyGuard {
             _issueInfo.setTokenQuantity,
             _issueInfo.managerFee,
             _issueInfo.protocolFees
-        );        
+        );
     }
 
     function _handleRedeemStateUpdates(
@@ -807,7 +807,7 @@ contract NavIssuanceModule is ModuleBase, ReentrancyGuard {
         address _reserveAsset,
         address _to,
         ActionInfo memory _redeemInfo
-    ) 
+    )
         internal
     {
         _setToken.editPositionMultiplier(_redeemInfo.newPositionMultiplier);
@@ -823,7 +823,7 @@ contract NavIssuanceModule is ModuleBase, ReentrancyGuard {
             _redeemInfo.setTokenQuantity,
             _redeemInfo.managerFee,
             _redeemInfo.protocolFees
-        );      
+        );
     }
 
     function _handleRedemptionFees(ISetToken _setToken, address _reserveAsset, ActionInfo memory _redeemInfo) internal {
@@ -931,7 +931,7 @@ contract NavIssuanceModule is ModuleBase, ReentrancyGuard {
         uint256 protocolDirectFeePercent = controller.getModuleFee(address(this), _protocolDirectFeeIndex);
         uint256 protocolManagerShareFeePercent = controller.getModuleFee(address(this), _protocolManagerFeeIndex);
         uint256 managerFeePercent = navIssuanceSettings[_setToken].managerFees[_managerFeeIndex];
-        
+
         // Calculate revenue share split percentage
         uint256 protocolRevenueSharePercentage = protocolManagerShareFeePercent.preciseMul(managerFeePercent);
         uint256 managerRevenueSharePercentage = managerFeePercent.sub(protocolRevenueSharePercentage);
@@ -995,7 +995,7 @@ contract NavIssuanceModule is ModuleBase, ReentrancyGuard {
      * The new position multiplier is calculated as follows:
      * inflationPercentage = (newSupply - oldSupply) / newSupply
      * newMultiplier = (1 - inflationPercentage) * positionMultiplier
-     */    
+     */
     function _getIssuePositionMultiplier(
         ISetToken _setToken,
         ActionInfo memory _issueInfo
@@ -1015,11 +1015,11 @@ contract NavIssuanceModule is ModuleBase, ReentrancyGuard {
 
     /**
      * Calculate deflation and new position multiplier. Note: Round deflation down in order to round position multiplier down
-     * 
+     *
      * The new position multiplier is calculated as follows:
      * deflationPercentage = (oldSupply - newSupply) / newSupply
      * newMultiplier = (1 + deflationPercentage) * positionMultiplier
-     */ 
+     */
     function _getRedeemPositionMultiplier(
         ISetToken _setToken,
         uint256 _setTokenQuantity,
@@ -1041,7 +1041,7 @@ contract NavIssuanceModule is ModuleBase, ReentrancyGuard {
      * The new position reserve asset unit is calculated as follows:
      * totalReserve = (oldUnit * oldSetTokenSupply) + reserveQuantity
      * newUnit = totalReserve / newSetTokenSupply
-     */ 
+     */
     function _getIssuePositionUnit(
         ISetToken _setToken,
         address _reserveAsset,
@@ -1063,7 +1063,7 @@ contract NavIssuanceModule is ModuleBase, ReentrancyGuard {
      * The new position reserve asset unit is calculated as follows:
      * totalReserve = (oldUnit * oldSetTokenSupply) - reserveQuantityToSendOut
      * newUnit = totalReserve / newSetTokenSupply
-     */ 
+     */
     function _getRedeemPositionUnit(
         ISetToken _setToken,
         address _reserveAsset,

--- a/contracts/protocol/modules/SingleIndexModule.sol
+++ b/contracts/protocol/modules/SingleIndexModule.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/protocol/modules/SingleIndexModule.sol
+++ b/contracts/protocol/modules/SingleIndexModule.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 pragma experimental "ABIEncoderV2";
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
@@ -169,7 +169,7 @@ contract SingleIndexModule is ModuleBase, ReentrancyGuard {
     )
         external
         onlyManagerAndValidSet(index)
-    {   
+    {
         // Don't use validate arrays because empty arrays are valid
         require(_newComponents.length == _newComponentsTargetUnits.length, "Array length mismatch");
 
@@ -329,7 +329,7 @@ contract SingleIndexModule is ModuleBase, ReentrancyGuard {
     }
 
     /**
-     * MANAGER ONLY: Toggle ability for passed addresses to trade from current state 
+     * MANAGER ONLY: Toggle ability for passed addresses to trade from current state
      *
      * @param _traders           Array trader addresses to toggle status
      * @param _statuses          Booleans indicating if matching trader can trade
@@ -393,7 +393,7 @@ contract SingleIndexModule is ModuleBase, ReentrancyGuard {
      */
     function getTargetUnits(address[] calldata _components) external view returns(uint256[] memory) {
         uint256 currentPositionMultiplier = index.positionMultiplier().toUint256();
-        
+
         uint256[] memory targetUnits = new uint256[](_components.length);
         for (uint256 i = 0; i < _components.length; i++) {
             targetUnits[i] = _normalizeTargetUnit(_components[i], currentPositionMultiplier);
@@ -483,7 +483,7 @@ contract SingleIndexModule is ModuleBase, ReentrancyGuard {
         virtual
     {
         uint256 wethBalance = weth.balanceOf(address(index));
-        
+
         (
             address exchangeAddress,
             bytes memory tradeCallData
@@ -561,7 +561,7 @@ contract SingleIndexModule is ModuleBase, ReentrancyGuard {
             BALANCER_POOL_LIMIT
         );
 
-        return (exchangeAddress, tradeCallData);       
+        return (exchangeAddress, tradeCallData);
     }
 
     /**
@@ -579,7 +579,7 @@ contract SingleIndexModule is ModuleBase, ReentrancyGuard {
         returns(address, bytes memory)
     {
         address exchangeAddress = _exchange == uint256(ExchangeId.Uniswap) ? uniswapRouter : sushiswapRouter;
-        
+
         string memory functionSignature;
         address[] memory path = new address[](2);
         uint256 limit;
@@ -592,7 +592,7 @@ contract SingleIndexModule is ModuleBase, ReentrancyGuard {
         }
         path[0] = _sellComponent;
         path[1] = _buyComponent;
-        
+
         bytes memory tradeCallData = abi.encodeWithSignature(
             functionSignature,
             _amount,

--- a/contracts/protocol/modules/StakingModule.sol
+++ b/contracts/protocol/modules/StakingModule.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 pragma experimental "ABIEncoderV2";
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
@@ -179,7 +179,7 @@ contract StakingModule is ModuleBase, IModuleIssuanceHook {
     /**
      * MODULE ONLY: On issuance, replicates all staking positions for a given component by staking the component transferred into
      * the SetToken by an issuer. The amount staked should only be the notional amount required to replicate a _setTokenQuantity
-     * amount of a position. No updates to positions should take place. 
+     * amount of a position. No updates to positions should take place.
      *
      * @param _setToken                 Address of SetToken contract
      * @param _component                Address of token being staked
@@ -205,7 +205,7 @@ contract StakingModule is ModuleBase, IModuleIssuanceHook {
     /**
      * MODULE ONLY: On redemption, unwind all staking positions for a given asset by unstaking the given component. The amount
      * unstaked should only be the notional amount required to unwind a _setTokenQuantity amount of a position. No updates to
-     * positions should take place. 
+     * positions should take place.
      *
      * @param _setToken                 Address of SetToken contract
      * @param _component                Address of token being staked
@@ -266,7 +266,7 @@ contract StakingModule is ModuleBase, IModuleIssuanceHook {
     function hasStakingPosition(ISetToken _setToken, IERC20 _component, address _stakeContract) public view returns(bool) {
         return getStakingContracts(_setToken, _component).contains(_stakeContract);
     }
-    
+
     function getStakingContracts(ISetToken _setToken, IERC20 _component) public view returns(address[] memory) {
         return stakingPositions[_setToken][_component].stakingContracts;
     }
@@ -391,7 +391,7 @@ contract StakingModule is ModuleBase, IModuleIssuanceHook {
 
         uint256 newDefaultTokenUnit = _setToken.getDefaultPositionRealUnit(address(_component)).toUint256().sub(_componentPositionUnits);
         _setToken.editDefaultPosition(address(_component), newDefaultTokenUnit);
-        
+
         int256 newExternalTokenUnit = _setToken.getExternalPositionRealUnit(address(_component), address(this))
             .add(_componentPositionUnits.toInt256());
         _setToken.editExternalPosition(address(_component), address(this), newExternalTokenUnit, "");
@@ -417,7 +417,7 @@ contract StakingModule is ModuleBase, IModuleIssuanceHook {
         uint256 _componentPositionUnits
     )
         internal
-    {   
+    {
         uint256 remainingPositionUnits = getStakingPositionUnit(_setToken, _component, _stakeContract).sub(_componentPositionUnits);
 
         if (remainingPositionUnits > 0) {
@@ -428,12 +428,12 @@ contract StakingModule is ModuleBase, IModuleIssuanceHook {
         }
 
         uint256 newTokenUnit = _setToken.getDefaultPositionRealUnit(address(_component)).toUint256().add(_componentPositionUnits);
-        
+
         _setToken.editDefaultPosition(address(_component), newTokenUnit);
-        
+
         int256 newExternalTokenUnit = _setToken.getExternalPositionRealUnit(address(_component), address(this))
             .sub(_componentPositionUnits.toInt256());
-        
+
         _setToken.editExternalPosition(address(_component), address(this), newExternalTokenUnit, "");
     }
 }

--- a/contracts/protocol/modules/StakingModule.sol
+++ b/contracts/protocol/modules/StakingModule.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/protocol/modules/StreamingFeeModule.sol
+++ b/contracts/protocol/modules/StreamingFeeModule.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 pragma experimental "ABIEncoderV2";
 
 import { ReentrancyGuard } from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";

--- a/contracts/protocol/modules/StreamingFeeModule.sol
+++ b/contracts/protocol/modules/StreamingFeeModule.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/protocol/modules/TradeModule.sol
+++ b/contracts/protocol/modules/TradeModule.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/contracts/protocol/modules/TradeModule.sol
+++ b/contracts/protocol/modules/TradeModule.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity ^0.6.10;
+pragma solidity 0.6.12;
 pragma experimental "ABIEncoderV2";
 
 import { ReentrancyGuard } from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
@@ -289,9 +289,9 @@ contract TradeModule is ModuleBase, ReentrancyGuard {
      */
     function _accrueProtocolFee(TradeInfo memory _tradeInfo, uint256 _exchangedQuantity) internal returns (uint256) {
         uint256 protocolFeeTotal = getModuleFee(TRADE_MODULE_PROTOCOL_FEE_INDEX, _exchangedQuantity);
-        
+
         payProtocolFeeFromSetToken(_tradeInfo.setToken, _tradeInfo.receiveToken, protocolFeeTotal);
-        
+
         return protocolFeeTotal;
     }
 

--- a/contracts/protocol/modules/WrapModule.sol
+++ b/contracts/protocol/modules/WrapModule.sol
@@ -16,7 +16,7 @@
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 pragma experimental "ABIEncoderV2";
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
@@ -90,7 +90,7 @@ contract WrapModule is ModuleBase, ReentrancyGuard {
     }
 
     /* ============ External Functions ============ */
-    
+
     /**
      * MANAGER-ONLY: Instructs the SetToken to wrap an underlying asset into a wrappedToken via a specified adapter.
      *
@@ -106,7 +106,7 @@ contract WrapModule is ModuleBase, ReentrancyGuard {
         address _wrappedToken,
         uint256 _underlyingUnits,
         string calldata _integrationName
-    ) 
+    )
         external
         nonReentrant
         onlyManagerAndValidSet(_setToken)
@@ -148,7 +148,7 @@ contract WrapModule is ModuleBase, ReentrancyGuard {
         address _wrappedToken,
         uint256 _underlyingUnits,
         string calldata _integrationName
-    ) 
+    )
         external
         nonReentrant
         onlyManagerAndValidSet(_setToken)
@@ -290,7 +290,7 @@ contract WrapModule is ModuleBase, ReentrancyGuard {
         ISetToken _setToken,
         address _transactPosition,
         uint256 _transactPositionUnits
-    ) 
+    )
         internal
         view
     {
@@ -303,9 +303,9 @@ contract WrapModule is ModuleBase, ReentrancyGuard {
     }
 
     /**
-     * The WrapModule calculates the total notional underlying to wrap, approves the underlying to the 3rd party 
+     * The WrapModule calculates the total notional underlying to wrap, approves the underlying to the 3rd party
      * integration contract, then invokes the SetToken to call wrap by passing its calldata along. When raw ETH
-     * is being used (_usesEther = true) WETH position must first be unwrapped and underlyingAddress sent to 
+     * is being used (_usesEther = true) WETH position must first be unwrapped and underlyingAddress sent to
      * adapter must be external protocol's ETH representative address.
      *
      * Returns notional amount of underlying tokens and wrapped tokens that were wrapped.
@@ -317,7 +317,7 @@ contract WrapModule is ModuleBase, ReentrancyGuard {
         address _wrappedToken,
         uint256 _underlyingUnits,
         bool _usesEther
-    ) 
+    )
         internal
         returns (uint256, uint256)
     {
@@ -499,7 +499,7 @@ contract WrapModule is ModuleBase, ReentrancyGuard {
 
         return (
             underlyingTokenBalance,
-            wrapTokenBalance            
+            wrapTokenBalance
         );
     }
 }

--- a/contracts/protocol/modules/WrapModule.sol
+++ b/contracts/protocol/modules/WrapModule.sol
@@ -14,6 +14,8 @@
     limitations under the License.
 
     SPDX-License-Identifier: Apache License, Version 2.0
+
+    // @unsupported: ovm
 */
 
 pragma solidity 0.6.12;

--- a/external/contracts/aave/LendToAaveMigrator.sol
+++ b/external/contracts/aave/LendToAaveMigrator.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: agpl-3.0
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 import {IERC20} from "../interfaces/IERC20.sol";
 import {SafeMath} from "../open-zeppelin/SafeMath.sol";
@@ -9,7 +9,7 @@ import {VersionedInitializable} from "../utils/VersionedInitializable.sol";
 /**
 * @title LendToAaveMigrator
 * @notice This contract implements the migration from LEND to AAVE token
-* @author Aave 
+* @author Aave
 */
 contract LendToAaveMigrator is VersionedInitializable {
     using SafeMath for uint256;
@@ -18,7 +18,7 @@ contract LendToAaveMigrator is VersionedInitializable {
     IERC20 public immutable LEND;
     uint256 public immutable LEND_AAVE_RATIO;
     uint256 public constant REVISION = 1;
-    
+
     uint256 public _totalLendMigrated;
 
     /**
@@ -31,7 +31,7 @@ contract LendToAaveMigrator is VersionedInitializable {
     /**
     * @param aave the address of the AAVE token
     * @param lend the address of the LEND token
-    * @param lendAaveRatio the exchange rate between LEND and AAVE 
+    * @param lendAaveRatio the exchange rate between LEND and AAVE
      */
     constructor(IERC20 aave, IERC20 lend, uint256 lendAaveRatio) public {
         AAVE = aave;

--- a/external/contracts/aave/LendToAaveMigrator.sol
+++ b/external/contracts/aave/LendToAaveMigrator.sol
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: agpl-3.0
+// @unsupported: ovm
 pragma solidity 0.6.12;
 
 import {IERC20} from "../interfaces/IERC20.sol";

--- a/external/contracts/uniswap/lib/UniswapV2Library.sol
+++ b/external/contracts/uniswap/lib/UniswapV2Library.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.6.10;
+pragma solidity 0.6.12;
 
 import "../../../../contracts/interfaces/external/IUniswapV2Pair.sol";
 

--- a/external/contracts/uniswap/lib/UniswapV2Library.sol
+++ b/external/contracts/uniswap/lib/UniswapV2Library.sol
@@ -1,3 +1,4 @@
+// @unsupported: ovm
 pragma solidity 0.6.12;
 
 import "../../../../contracts/interfaces/external/IUniswapV2Pair.sol";

--- a/external/contracts/yearn/BaseStrategy.sol
+++ b/external/contracts/yearn/BaseStrategy.sol
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
+// @unsupported: ovm
 pragma solidity >=0.6.0 <0.7.0;
 pragma experimental ABIEncoderV2;
 

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -11,7 +11,7 @@ import "./tasks";
 
 const config: HardhatUserConfig = {
   solidity: {
-    version: "0.6.10",
+    version: "0.6.12",
     settings: {
       optimizer: { enabled: true, runs: 200 },
     },


### PR DESCRIPTION
This PR gets all contracts onto the same pragma as the Optimism 6 series compiler which should make `master` to `optimism` branch code comparison more straightforward. 

Pragma change is a two patch bump. I don't see anything notable in 0.6.11 or 0.6.12. It's mostly small bug fixes and solc jumped a major version after 0.6.12

+ [0.6.11 release notes][1]
+ [0.6.12 release notes][2]

Have also added a tag within each license header comment which tells the ovm compiler to skip that file. As ovm targets are added on the main optimism branch, the tag will be removed. Including it by default on `master` means that master/optimism diff comparison won't automatically contain 140 solidity files.

[1]: https://github.com/ethereum/solidity/releases/tag/v0.6.11
[2]: https://github.com/ethereum/solidity/releases/tag/v0.6.12





