### PR TITLE
Final review fixes for GeneralIndexModule

### DIFF
--- a/contracts/protocol/modules/GeneralIndexModule.sol
+++ b/contracts/protocol/modules/GeneralIndexModule.sol
@@ -195,11 +195,7 @@ contract GeneralIndexModule is ModuleBase, ReentrancyGuard {
         );
 
         for (uint256 i = 0; i < aggregateComponents.length; i++) {
-            require(
-                _setToken.getExternalPositionModules(aggregateComponents[i]).length == 0,
-                "External positions not allowed"
-            );
-
+            require(!_setToken.hasExternalPosition(aggregateComponents[i]), "External positions not allowed");
             executionInfo[_setToken][IERC20(aggregateComponents[i])].targetUnit = aggregateTargetUnits[i];
             emit TargetUnitsUpdated(_setToken, aggregateComponents[i], aggregateTargetUnits[i], _positionMultiplier);
         }
@@ -636,6 +632,8 @@ contract GeneralIndexModule is ModuleBase, ReentrancyGuard {
             componentInfo.lastTradeTimestamp.add(componentInfo.coolOffPeriod) <= block.timestamp,
             "Component cool off in progress"
         );
+
+        require(!_setToken.hasExternalPosition(address(_component)), "External positions not allowed");
     }
 
     /**

--- a/contracts/protocol/modules/GeneralIndexModule.sol
+++ b/contracts/protocol/modules/GeneralIndexModule.sol
@@ -106,7 +106,6 @@ contract GeneralIndexModule is ModuleBase, ReentrancyGuard {
 
     /* ============ Events ============ */
 
-    event TargetUnitsUpdated(ISetToken indexed _setToken, address indexed _component, uint256 _newUnit, uint256 _positionMultiplier);
     event TradeMaximumUpdated(ISetToken indexed _setToken, address indexed _component, uint256 _newMaximum);
     event AssetExchangeUpdated(ISetToken indexed _setToken, address indexed _component, string _newExchangeName);
     event CoolOffPeriodUpdated(ISetToken indexed _setToken, address indexed _component, uint256 _newCoolOffPeriod);
@@ -128,7 +127,12 @@ contract GeneralIndexModule is ModuleBase, ReentrancyGuard {
         uint256 _protocolFee
     );
 
-    event RebalanceStarted(ISetToken indexed _setToken);
+    event RebalanceStarted(
+        ISetToken indexed _setToken,
+        address[] aggregateComponents,
+        uint256[] aggregateTargetUnits,
+        uint256 indexed positionMultiplier
+    );
 
     /* ============ Constants ============ */
 
@@ -197,13 +201,12 @@ contract GeneralIndexModule is ModuleBase, ReentrancyGuard {
         for (uint256 i = 0; i < aggregateComponents.length; i++) {
             require(!_setToken.hasExternalPosition(aggregateComponents[i]), "External positions not allowed");
             executionInfo[_setToken][IERC20(aggregateComponents[i])].targetUnit = aggregateTargetUnits[i];
-            emit TargetUnitsUpdated(_setToken, aggregateComponents[i], aggregateTargetUnits[i], _positionMultiplier);
         }
 
         rebalanceInfo[_setToken].rebalanceComponents = aggregateComponents;
         rebalanceInfo[_setToken].positionMultiplier = _positionMultiplier;
 
-        emit RebalanceStarted(_setToken);
+        emit RebalanceStarted(_setToken, aggregateComponents, aggregateTargetUnits, _positionMultiplier);
     }
 
     /**

--- a/contracts/protocol/modules/GeneralIndexModule.sol
+++ b/contracts/protocol/modules/GeneralIndexModule.sol
@@ -635,30 +635,30 @@ contract GeneralIndexModule is ModuleBase, ReentrancyGuard {
      *
      * Step 1: Component --> WETH
      * ----------------------------------------------------------
-     *                     | Fixed |     Floating limit         |
+     *                     | Fixed  |     Floating limit        |
      * ----------------------------------------------------------
-     * send  (Component)   |  Yes  |                            |
-     * recieve (WETH)      |       |   Maximum trade size       |
+     * send  (Component)   |  YES   |                           |
+     * recieve (WETH)      |        |   Min WETH to receive     |
      * ----------------------------------------------------------
      *
      * Step 2: WETH --> Component
      * ----------------------------------------------------------
-     *                     | Fixed  |    Floating limit         |
+     *                     |  Fixed  |    Floating limit        |
      * ----------------------------------------------------------
-     * send  (WETH)        |   NO   |                           |
-     * recieve (Component) |        |  Min amount to receive    |
+     * send  (WETH)        |   NO    |  Max WETH to send        |
+     * recieve (Component) |   YES   |                          |
      * ----------------------------------------------------------
      *
      * Additionally, there is an edge case where price volatility during a rebalance
-     * results in remaindered WETH which needs to be allocated proportionately. In this case
+     * results in remaining WETH which needs to be allocated proportionately. In this case
      * the values are as below:
      *
-     * Edge case: Remaing WETH --> Component
+     * Edge case: Remaining WETH --> Component
      * ----------------------------------------------------------
      *                     | Fixed  |    Floating limit         |
      * ----------------------------------------------------------
      * send  (WETH)        |  YES   |                           |
-     * recieve (Component) |        |  Min amount to receive    |
+     * recieve (Component) |        | Min component to receive  |
      * ----------------------------------------------------------
     */
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@setprotocol/set-protocol-v2",
-  "version": "0.0.13",
+  "version": "0.0.35",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@setprotocol/set-protocol-v2",
-  "version": "0.0.34",
+  "version": "0.0.35",
   "description": "",
   "main": "dist",
   "types": "dist/types",

--- a/test/protocol/modules/generalIndexModule.spec.ts
+++ b/test/protocol/modules/generalIndexModule.spec.ts
@@ -357,8 +357,16 @@ describe("GeneralIndexModule", () => {
       });
 
       it("emits the correct RebalanceStarted event", async () => {
+        const currentComponents = await subjectSetToken.getComponents();
+        const expectedAggregateComponents = [...currentComponents, ...subjectNewComponents];
+        const expectedAggregateTargetUnits = [...subjectOldTargetUnits, ...subjectNewTargetUnits];
+        const expectedPositionMultiplier = await subjectSetToken.positionMultiplier();
+
         await expect(subject()).to.emit(indexModule, "RebalanceStarted").withArgs(
-          subjectSetToken.address
+          subjectSetToken.address,
+          expectedAggregateComponents,
+          expectedAggregateTargetUnits,
+          expectedPositionMultiplier
         );
       });
 

--- a/test/protocol/modules/generalIndexModule.spec.ts
+++ b/test/protocol/modules/generalIndexModule.spec.ts
@@ -1525,15 +1525,15 @@ describe("GeneralIndexModule", () => {
           });
 
           describe("when protocol fees is charged", async () => {
-            let feePercentage: BigNumber;
+            let subjectFeePercentage: BigNumber;
 
             beforeEach(async () => {
-              feePercentage = ether(0.05);
+              subjectFeePercentage = ether(0.05);
               setup.controller = setup.controller.connect(owner.wallet);
               await setup.controller.addFee(
                 indexModule.address,
                 ZERO, // Fee type on trade function denoted as 0
-                feePercentage // Set fee to 5 bps
+                subjectFeePercentage // Set fee to 5 bps
               );
             });
 
@@ -1545,7 +1545,7 @@ describe("GeneralIndexModule", () => {
 
               const lastBlockTimestamp = await getLastBlockTimestamp();
 
-              const protocolFee = expectedWbtcOut.mul(feePercentage).div(ether(1));
+              const protocolFee = expectedWbtcOut.mul(subjectFeePercentage).div(ether(1));
               const expectedWbtcPositionUnits = preciseDiv(currentWbtcAmount.add(expectedWbtcOut).sub(protocolFee), totalSupply);
 
               const wethPositionUnits = await subjectSetToken.getDefaultPositionRealUnit(setup.weth.address);
@@ -1565,14 +1565,14 @@ describe("GeneralIndexModule", () => {
 
               const wbtcBalance = await setup.wbtc.balanceOf(feeRecipient);
 
-              const protocolFee = expectedWbtcOut.mul(feePercentage).div(ether(1));
+              const protocolFee = expectedWbtcOut.mul(subjectFeePercentage).div(ether(1));
               const expectedWbtcBalance = beforeWbtcBalance.add(protocolFee);
 
               expect(wbtcBalance).to.eq(expectedWbtcBalance);
             });
 
             it("emits the correct TradeExecuted event", async () => {
-              const protocolFee = expectedWbtcOut.mul(feePercentage).div(ether(1));
+              const protocolFee = expectedWbtcOut.mul(subjectFeePercentage).div(ether(1));
               await expect(subject()).to.be.emit(indexModule, "TradeExecuted").withArgs(
                 subjectSetToken.address,
                 setup.weth.address,
@@ -1583,6 +1583,36 @@ describe("GeneralIndexModule", () => {
                 expectedWbtcOut.sub(protocolFee),
                 protocolFee,
               );
+            });
+
+            describe("when the prototol fee percentage is 100", async () => {
+              beforeEach(async() => {
+                subjectFeePercentage = ether(100);
+                await setup.controller.editFee(
+                  indexModule.address,
+                  ZERO, // Fee type on trade function denoted as 0
+                  subjectFeePercentage
+                );
+              });
+
+              it("should revert", async () => {
+                await expect(subject()).to.be.revertedWith("transfer amount exceeds balance");
+              });
+            });
+
+            describe("when the prototol fee percentage is MAX_UINT_256", async () => {
+              beforeEach(async() => {
+                subjectFeePercentage = ether(100);
+                await setup.controller.editFee(
+                  indexModule.address,
+                  ZERO, // Fee type on trade function denoted as 0
+                  subjectFeePercentage
+                );
+              });
+
+              it("should revert", async () => {
+                await expect(subject()).to.be.revertedWith("transfer amount exceeds balance");
+              });
             });
           });
 
@@ -2051,6 +2081,8 @@ describe("GeneralIndexModule", () => {
     });
 
     describe("#raiseAssetTargets", async () => {
+      let subjectRaiseTargetPercentage: BigNumber;
+
       before(async () => {
         // current units [ether(86.9565217), bitcoin(.01111111), ether(100)]
         oldTargetUnits = [ether(60.869565), bitcoin(.015), ether(50)];
@@ -2073,7 +2105,7 @@ describe("GeneralIndexModule", () => {
           await indexModule.connect(trader.wallet).trade(subjectSetToken.address, setup.wbtc.address, MAX_UINT_256);
         }
 
-        await indexModule.setRaiseTargetPercentage(subjectSetToken.address, ether(.0025));
+        await indexModule.setRaiseTargetPercentage(subjectSetToken.address, subjectRaiseTargetPercentage);
       };
 
       async function subject(): Promise<ContractTransaction> {
@@ -2088,8 +2120,9 @@ describe("GeneralIndexModule", () => {
       describe("with default target units", () => {
         beforeEach(async () => {
           initialializeSubjectVariables();
+          subjectRaiseTargetPercentage = ether(.0025);
+          await startRebalance();
         });
-        cacheBeforeEach(startRebalance);
 
         it("the position units and lastTradeTimestamp should be set as expected", async () => {
           const prePositionMultiplier = (await indexModule.rebalanceInfo(subjectSetToken.address)).positionMultiplier;
@@ -2111,7 +2144,7 @@ describe("GeneralIndexModule", () => {
 
           const expectedPositionMultiplier = preciseDiv(
             prePositionMultiplier,
-            PRECISE_UNIT.add(ether(.0025))
+            PRECISE_UNIT.add(subjectRaiseTargetPercentage)
           );
 
           await expect(subject()).to.emit(indexModule, "AssetTargetsRaised").withArgs(
@@ -2131,26 +2164,46 @@ describe("GeneralIndexModule", () => {
         });
       });
 
-      describe("when the position multiplier is less than 1", () => {
+      describe("when the raiseTargetPercentage is the lowest valid decimal (1e-6)", () => {
         beforeEach(async () => {
           initialializeSubjectVariables();
-
-          await startRebalance(true, true);
+          subjectRaiseTargetPercentage = ether(.000001);
+          await startRebalance();
         });
 
-        it("the position units and lastTradeTimestamp should be set as expected", async () => {
+        afterEach(() => {
+          subjectRaiseTargetPercentage = ether(.0025);
+        });
+
+        it("the position multiplier should be set as expected", async () => {
           const prePositionMultiplier = (await indexModule.rebalanceInfo(subjectSetToken.address)).positionMultiplier;
 
           await subject();
 
           const expectedPositionMultiplier = preciseDiv(
             prePositionMultiplier,
-            PRECISE_UNIT.add(ether(.0025))
+            PRECISE_UNIT.add(subjectRaiseTargetPercentage)
           );
 
           const positionMultiplier = (await indexModule.rebalanceInfo(subjectSetToken.address)).positionMultiplier;
 
           expect(positionMultiplier).to.eq(expectedPositionMultiplier);
+        });
+      });
+
+      describe("when the raiseTargetPercentage is MAX_UINT_256", () => {
+        beforeEach(async () => {
+          initialializeSubjectVariables();
+          subjectRaiseTargetPercentage = MAX_UINT_256;
+          await startRebalance();
+        });
+
+        afterEach(() => {
+          subjectRaiseTargetPercentage = ether(.0025);
+        });
+
+        it("it should revert", async () => {
+          await expect(subject()).to.be.revertedWith("addition overflow");
         });
       });
 


### PR DESCRIPTION
**Review Fixes Summary** 

+ **Note**: Even though external positions are not allowed during rebalance instantiation, external positions can be added during the rebalance itself. 
  + cbcd4d9: Check added to the trade parameter validation method
+ **Line 198**: If we expect this to be reused, consider moving this require into the Position.sol library
  + cbcd4d9: uses Position's `hasExternalPosition` helper in the `require`
+ **Line 245**: nit - add linebreak
  + 95c6809
+ **nit**: Consider moving the lowest level functions  to the bottom of the file 
  + 95c6809: internal functions re-ordered

+ **[Line 204][3]**: Instead of emitting an event per component, what would the advantage / disadvantage be of emitting a  a single event?

> [Chris]:  Uncertain about this...
> [Brian/Felix] (from meeting), yes this would be better as a single event...
 + 63f9b05: Fixed

+  **[Line 859][4]**: Instead of “isSendTokenFixed”, I grasp “isSellComponent / isBuyComponent” more intuitively
_getNormalizedTargetUnit

> [Chris]: There was a lot of back and forth about this in #75 / commit 3f0112d. [Brian argues in this PR comment][1] that buy/sell is more intuitive but fundamentally mis-labels these variables and it's necessary to accept the fixed/floating naming convention (unless there's a 3rd way to clarity).  
  + 3b8d415: Added a clarifying comment / table at the top of the internal methods block diagramming how fixed / floating maps onto the permutations of buying and selling at different stages in the rebalance process: 

**Wont Fix**
+ **[Line 630][2]**: If we can find a way to check the component quicker than O(n), that would be nice. 

> [Chris]: It seems like we'd need a mapping for the rebalanceComponents which has to be kept in sync with the array. To get an upper bound for the impact of optimizing here I ran cost analysis for completely removing the check. Diff was small relative to the overall cost of the trades (with 4 components).

Contract | with check | without check | $ diff |
|----|----|----|----|
|trade|364066|354202| - $2 |
|tradeRemainingWeth|286393|284885| < $1 |

+  **[Line 670][5]**: (Brian) It would be better to revert on an `ethQuantityLimit` which is too large than quietly trade the remainder. Would prefer passing `_ethQuantityLimit` directly here.  
  + Decided not to do this because it's incompatible with Balancer's param validation. 

[1]: https://github.com/SetProtocol/set-protocol-v2/pull/75#issuecomment-824209756
[2]: https://github.com/SetProtocol/set-protocol-v2/blob/eb8801d6cdcad8dbce133d33cd28e774f69b790c/contracts/protocol/modules/GeneralIndexModule.sol#L630
[3]: https://github.com/SetProtocol/set-protocol-v2/blob/eb8801d6cdcad8dbce133d33cd28e774f69b790c/contracts/protocol/modules/GeneralIndexModule.sol#L204
[4]: https://github.com/SetProtocol/set-protocol-v2/blob/eb8801d6cdcad8dbce133d33cd28e774f69b790c/contracts/protocol/modules/GeneralIndexModule.sol#L859
[5]: https://github.com/SetProtocol/set-protocol-v2/blob/eb8801d6cdcad8dbce133d33cd28e774f69b790c/contracts/protocol/modules/GeneralIndexModule.sol#L670
