### PR TITLE
Restructure SetToken to reduce size & make deployable to ovm

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,12 @@
 version: 2
 
 jobs:
-  install:
+  checkout_and_compile:
     docker:
       - image: circleci/node:10.16.0
+        environment:
+          NODE_OPTIONS: --max_old_space_size=8192
+    resource_class: large
     working_directory: ~/set-protocol-v2
     steps:
       - checkout
@@ -37,7 +40,7 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: false
       - restore_cache:
-          key: module-cache-{{ checksum "yarn.lock" }}
+          key: compiled-env-{{ .Environment.CIRCLE_SHA1 }}
       - run:
           name: Set Up Environment Variables
           command: cp .env.default .env

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,9 @@
 version: 2
 
 jobs:
-  checkout_and_compile:
+  install:
     docker:
       - image: circleci/node:10.16.0
-        environment:
-          NODE_OPTIONS: --max_old_space_size=8192
-    resource_class: large
     working_directory: ~/set-protocol-v2
     steps:
       - checkout
@@ -40,7 +37,7 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: false
       - restore_cache:
-          key: compiled-env-{{ .Environment.CIRCLE_SHA1 }}
+          key: module-cache-{{ checksum "yarn.lock" }}
       - run:
           name: Set Up Environment Variables
           command: cp .env.default .env

--- a/contracts/interfaces/ISetToken.sol
+++ b/contracts/interfaces/ISetToken.sol
@@ -114,10 +114,15 @@ interface ISetToken is IERC20 {
 
     function manager() external view returns (address);
     function moduleStates(address _module) external view returns (ModuleState);
+    function modules() external view returns (address[] memory);
     function getModules() external view returns (address[] memory);
 
+    function components() external view returns (address[] memory);
     function getDefaultPositionRealUnit(address _component) external view returns(int256);
     function getExternalPositionRealUnit(address _component, address _positionModule) external view returns(int256);
+    function getExternalPositionVirtualUnit(address _component, address _module) external view returns (int256);
+    function getDefaultPositionVirtualUnit(address _component) external view returns (int256);
+    function getComponentExternalPosition(address _component, address _positionModule) external view returns (ExternalPosition memory);
     function getComponents() external view returns(address[] memory);
     function getExternalPositionModules(address _component) external view returns(address[] memory);
     function getExternalPositionData(address _component, address _positionModule) external view returns(bytes memory);

--- a/contracts/protocol/SetTokenCreator.sol
+++ b/contracts/protocol/SetTokenCreator.sol
@@ -75,13 +75,13 @@ contract SetTokenCreator {
         returns (address)
     {
         require(_components.length > 0, "Must have at least 1 component");
-        require(_components.length == _units.length, "Component and unit lengths must be the same");
-        require(!_components.hasDuplicate(), "Components must not have a duplicate");
+        require(_components.length == _units.length, "Comp. & unit lengths not equal");
+        require(!_components.hasDuplicate(), "Duplicate component");
         require(_modules.length > 0, "Must have at least 1 module");
         require(_manager != address(0), "Manager must not be empty");
 
         for (uint256 i = 0; i < _components.length; i++) {
-            require(_components[i] != address(0), "Component must not be null address");
+            require(_components[i] != address(0), "Component is null address");
             require(_units[i] > 0, "Units must be greater than 0");
         }
 

--- a/contracts/protocol/lib/SetTokenDataUtils.sol
+++ b/contracts/protocol/lib/SetTokenDataUtils.sol
@@ -1,0 +1,225 @@
+/*
+    Copyright 2020 Set Labs Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    SPDX-License-Identifier: Apache License, Version 2.0
+*/
+
+pragma solidity 0.6.12;
+pragma experimental "ABIEncoderV2";
+
+import { Address } from "../../../external/contracts/openzeppelin/utils/Address.sol";
+import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import { SafeCast } from "@openzeppelin/contracts/utils/SafeCast.sol";
+import { SafeMath } from "@openzeppelin/contracts/math/SafeMath.sol";
+import { SignedSafeMath } from "@openzeppelin/contracts/math/SignedSafeMath.sol";
+
+import { IController } from "../../interfaces/IController.sol";
+import { IModule } from "../../interfaces/IModule.sol";
+import { ISetToken } from "../../interfaces/ISetToken.sol";
+import { Position } from "../lib/Position.sol";
+import { PreciseUnitMath } from "../../lib/PreciseUnitMath.sol";
+import { AddressArrayUtils } from "../../lib/AddressArrayUtils.sol";
+
+
+/**
+ * @title SetTokenDataUtils
+ * @author Set Protocol
+ *
+ * Getters and status methods for contracts interacting with SetToken, packaged as an externally
+ * linked library to reduce contract size.
+ */
+library SetTokenDataUtils {
+    using SafeMath for uint256;
+    using SafeCast for int256;
+    using SafeCast for uint256;
+    using SignedSafeMath for int256;
+    using PreciseUnitMath for int256;
+    using Address for address;
+    using AddressArrayUtils for address[];
+
+    /* ============ Constants ============ */
+
+    /*
+        The PositionState is the status of the Position, whether it is Default (held on the SetToken)
+        or otherwise held on a separate smart contract (whether a module or external source).
+        There are issues with cross-usage of enums, so we are defining position states
+        as a uint8.
+    */
+    uint8 internal constant DEFAULT = 0;
+    uint8 internal constant EXTERNAL = 1;
+
+    /* ============ Public Getter Functions ============ */
+
+    function getComponents(ISetToken _setToken) external view returns(address[] memory) {
+        return _setToken.components();
+    }
+
+    function getDefaultPositionRealUnit(ISetToken _setToken, address _component) public view returns(int256) {
+        int256 virtualUnit = _setToken.getDefaultPositionVirtualUnit(_component);
+        return _convertVirtualToRealUnit(_setToken, virtualUnit);
+    }
+
+    function getExternalPositionRealUnit(
+        ISetToken _setToken,
+        address _component,
+        address _positionModule
+    )
+        public
+        view
+        returns(int256)
+    {
+
+        int256 virtualUnit = _setToken.getComponentExternalPosition(_component, _positionModule).virtualUnit;
+        return _convertVirtualToRealUnit(_setToken, virtualUnit);
+    }
+
+    function getModules(ISetToken _setToken) public view returns (address[] memory) {
+        return _setToken.modules();
+    }
+
+    /**
+     * Returns the total Real Units for a given component, summing the default and public position units.
+     */
+    function getTotalComponentRealUnits(
+        ISetToken _setToken,
+        address _component
+    )
+        public
+        view
+        returns(int256)
+    {
+        int256 totalUnits = getDefaultPositionRealUnit(_setToken, _component);
+
+        address[] memory externalModules = _setToken.getExternalPositionModules(_component);
+        for (uint256 i = 0; i < externalModules.length; i++) {
+            // We will perform the summation no matter what, as an external position virtual unit can be negative
+            totalUnits = totalUnits.add(
+                getExternalPositionRealUnit(_setToken, _component, externalModules[i])
+            );
+        }
+
+        return totalUnits;
+    }
+
+    /**
+     * Only ModuleStates of INITIALIZED modules are considered enabled
+     */
+    function isInitializedModule(ISetToken _setToken, address _module) external view returns (bool) {
+        return _setToken.moduleStates(_module) == ISetToken.ModuleState.INITIALIZED;
+    }
+
+    /**
+     * Returns whether the module is in a pending state
+     */
+    function isPendingModule(ISetToken _setToken, address _module) external view returns (bool) {
+        return _setToken.moduleStates(_module) == ISetToken.ModuleState.PENDING;
+    }
+
+    function isComponent(ISetToken _setToken, address _component) public view returns(bool) {
+        return _setToken.components().contains(_component);
+    }
+
+    function isExternalPositionModule(
+        ISetToken _setToken,
+        address _component,
+        address _module
+    )
+        public
+        view
+        returns(bool)
+    {
+        return _setToken.getExternalPositionModules(_component).contains(_module);
+    }
+
+    /**
+     * Returns a list of Positions, through traversing the components. Each component with a non-zero virtual unit
+     * is considered a Default Position, and each externalPositionModule will generate a unique position.
+     * Virtual units are converted to real units. This function is typically used off-chain for data presentation purposes.
+     */
+    function getPositions(ISetToken _setToken) public view returns (ISetToken.Position[] memory) {
+        ISetToken.Position[] memory positions = new ISetToken.Position[](
+            _getPositionCount(_setToken)
+        );
+        uint256 positionCount = 0;
+
+        for (uint256 i = 0; i < _setToken.components().length; i++) {
+            address component = _setToken.components()[i];
+
+            // A default position exists if the default virtual unit is > 0
+            if (_setToken.getDefaultPositionVirtualUnit(component) > 0) {
+                positions[positionCount] = ISetToken.Position({
+                    component: component,
+                    module: address(0),
+                    unit: getDefaultPositionRealUnit(_setToken, component),
+                    positionState: DEFAULT,
+                    data: ""
+                });
+
+                positionCount++;
+            }
+
+            address[] memory externalModules = _setToken.getExternalPositionModules(component);
+            for (uint256 j = 0; j < externalModules.length; j++) {
+                address currentModule = externalModules[j];
+
+                positions[positionCount] = ISetToken.Position({
+                    component: component,
+                    module: currentModule,
+                    unit: getExternalPositionRealUnit(_setToken, component, currentModule),
+                    positionState: EXTERNAL,
+                    data: _setToken.getExternalPositionData(component, currentModule)
+                });
+
+                positionCount++;
+            }
+        }
+
+        return positions;
+    }
+
+    /**
+     * Takes a virtual unit and multiplies by the position multiplier to return the real unit
+     */
+    function _convertVirtualToRealUnit(ISetToken _setToken, int256 _virtualUnit) internal view returns(int256) {
+        return _virtualUnit.conservativePreciseMul(_setToken.positionMultiplier());
+    }
+
+    /**
+     * Gets the total number of positions, defined as the following:
+     * - Each component has a default position if its virtual unit is > 0
+     * - Each component's external positions module is counted as a position
+     */
+    function _getPositionCount(ISetToken _setToken) internal view returns (uint256) {
+        uint256 positionCount;
+        address[] memory components = _setToken.components();
+
+        for (uint256 i = 0; i < components.length; i++) {
+            address component = components[i];
+
+            // Increment the position count if the default position is > 0
+            if (_setToken.getDefaultPositionVirtualUnit(component) > 0) {
+                positionCount++;
+            }
+
+            // Increment the position count by each external position module
+            uint256 externalModulesLength = _setToken.getExternalPositionModules(component).length;
+            if (externalModulesLength > 0) {
+                positionCount = positionCount.add(externalModulesLength);
+            }
+        }
+
+        return positionCount;
+    }
+}

--- a/contracts/protocol/lib/SetTokenInternalUtils.sol
+++ b/contracts/protocol/lib/SetTokenInternalUtils.sol
@@ -1,0 +1,107 @@
+/*
+    Copyright 2020 Set Labs Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    SPDX-License-Identifier: Apache License, Version 2.0
+*/
+
+pragma solidity 0.6.12;
+pragma experimental "ABIEncoderV2";
+
+import { Address } from "../../../external/contracts/openzeppelin/utils/Address.sol";
+import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import { SafeCast } from "@openzeppelin/contracts/utils/SafeCast.sol";
+import { SafeMath } from "@openzeppelin/contracts/math/SafeMath.sol";
+import { SignedSafeMath } from "@openzeppelin/contracts/math/SignedSafeMath.sol";
+
+import { IController } from "../../interfaces/IController.sol";
+import { IModule } from "../../interfaces/IModule.sol";
+import { ISetToken } from "../../interfaces/ISetToken.sol";
+import { Position } from "../lib/Position.sol";
+import { PreciseUnitMath } from "../../lib/PreciseUnitMath.sol";
+import { AddressArrayUtils } from "../../lib/AddressArrayUtils.sol";
+
+
+/**
+ * @title SetTokenInternalUtils
+ * @author Set Protocol
+ *
+ * Utilities SetToken can invoke on itself. These are located an externally linked library to
+ * reduce contract size.
+ */
+library SetTokenInternalUtils {
+    using SafeMath for uint256;
+    using SafeCast for int256;
+    using SafeCast for uint256;
+    using SignedSafeMath for int256;
+    using PreciseUnitMath for int256;
+    using Address for address;
+    using AddressArrayUtils for address[];
+
+    /**
+     * To prevent virtual to real unit conversion issues (where real unit may be 0), the
+     * product of the positionMultiplier and the lowest absolute virtualUnit value (across default and
+     * external positions) must be greater than 0.
+     */
+    function validateNewMultiplier(address _setToken, int256 _newMultiplier) external view {
+        int256 minVirtualUnit = _getPositionsAbsMinimumVirtualUnit(ISetToken(_setToken));
+
+        require(minVirtualUnit.conservativePreciseMul(_newMultiplier) > 0, "New multiplier too small");
+    }
+
+    /**
+     * Loops through all of the positions and returns the smallest absolute value of
+     * the virtualUnit.
+     *
+     * @return Min virtual unit across positions denominated as int256
+     */
+    function _getPositionsAbsMinimumVirtualUnit(ISetToken _setToken) internal view returns(int256) {
+        // Additional assignment happens in the loop below
+        uint256 minimumUnit = uint256(-1);
+        address[] memory components = _setToken.components();
+
+        for (uint256 i = 0; i < components.length; i++) {
+            address component = components[i];
+
+            // A default position exists if the default virtual unit is > 0
+            uint256 defaultUnit = _setToken.getDefaultPositionVirtualUnit(component).toUint256();
+            if (defaultUnit > 0 && defaultUnit < minimumUnit) {
+                minimumUnit = defaultUnit;
+            }
+
+            address[] memory externalModules = _setToken.getExternalPositionModules(component);
+            for (uint256 j = 0; j < externalModules.length; j++) {
+                address currentModule = externalModules[j];
+
+                uint256 virtualUnit = _absoluteValue(
+                    _setToken.getExternalPositionVirtualUnit(component, currentModule)
+                );
+                if (virtualUnit > 0 && virtualUnit < minimumUnit) {
+                    minimumUnit = virtualUnit;
+                }
+            }
+        }
+
+        return minimumUnit.toInt256();
+    }
+
+    /**
+     * Returns the absolute value of the signed integer value
+     * @param _a Signed interger value
+     * @return Returns the absolute value in uint256
+     */
+    function _absoluteValue(int256 _a) internal pure returns(uint256) {
+        return _a >= 0 ? _a.toUint256() : (-_a).toUint256();
+    }
+}

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -30,3 +30,5 @@ export const ONE_YEAR_IN_SECONDS = BigNumber.from(31557600);
 
 export const PRECISE_UNIT = constants.WeiPerEther;
 export const ETH_ADDRESS = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
+export const SET_TOKEN_INTERNAL_UTILS_LIB_PATH = "contracts/protocol/lib/SetTokenInternalUtils.sol:SetTokenInternalUtils";
+export const SET_TOKEN_DATA_UTILS_LIB_PATH = "contracts/protocol/lib/SetTokenDataUtils.sol:SetTokenDataUtils";

--- a/utils/contracts/index.ts
+++ b/utils/contracts/index.ts
@@ -62,6 +62,7 @@ export { ProtocolViewer } from "../../typechain/ProtocolViewer";
 export { ResourceIdentifierMock } from "../../typechain/ResourceIdentifierMock";
 export { SetToken } from "../../typechain/SetToken";
 export { SetTokenCreator } from "../../typechain/SetTokenCreator";
+export { SetTokenInternalUtils } from "../../typechain/SetTokenInternalUtils";
 export { SetValuer } from "../../typechain/SetValuer";
 export { SingleIndexModule } from "../../typechain/SingleIndexModule";
 export { SnapshotGovernanceAdapter } from "../../typechain/SnapshotGovernanceAdapter";

--- a/utils/deploys/deployCoreContracts.ts
+++ b/utils/deploys/deployCoreContracts.ts
@@ -7,7 +7,8 @@ import {
   PriceOracle,
   SetToken,
   SetTokenCreator,
-  SetValuer
+  SetValuer,
+  SetTokenInternalUtils
 } from "./../contracts";
 
 import { Address } from "./../types";
@@ -18,6 +19,9 @@ import { PriceOracle__factory } from "../../typechain/factories/PriceOracle__fac
 import { SetToken__factory } from "../../typechain/factories/SetToken__factory";
 import { SetTokenCreator__factory } from "../../typechain/factories/SetTokenCreator__factory";
 import { SetValuer__factory } from "../../typechain/factories/SetValuer__factory";
+import { SetTokenInternalUtils__factory } from "../../typechain/factories/SetTokenInternalUtils__factory";
+
+import { convertLibraryNameToLinkId } from "../common";
 
 export default class DeployCoreContracts {
   private _deployerSigner: Signer;
@@ -34,12 +38,39 @@ export default class DeployCoreContracts {
     return await new Controller__factory(this._deployerSigner).attach(controllerAddress);
   }
 
-  public async deploySetTokenCreator(controller: Address): Promise<SetTokenCreator> {
-    return await new SetTokenCreator__factory(this._deployerSigner).deploy(controller);
+  public async deploySetTokenInternalUtils(): Promise<SetTokenInternalUtils> {
+    return await new SetTokenInternalUtils__factory(this._deployerSigner).deploy();
   }
 
-  public async getSetTokenCreator(setTokenCreatorAddress: Address): Promise<SetTokenCreator> {
-    return await new SetTokenCreator__factory(this._deployerSigner).attach(setTokenCreatorAddress);
+  public async deploySetTokenCreator(
+    controller: Address,
+    libraryName: string,
+    libraryAddress: Address
+  ): Promise<SetTokenCreator> {
+    const linkId = convertLibraryNameToLinkId(libraryName);
+    return await new SetTokenCreator__factory(
+      // @ts-ignore
+      {
+        [linkId]: libraryAddress,
+      },
+      this._deployerSigner
+    ).deploy(controller);
+  }
+
+  public async getSetTokenCreator(
+    setTokenCreatorAddress: Address,
+    libraryName: string,
+    libraryAddress: Address
+  ): Promise<SetTokenCreator> {
+    const linkId = convertLibraryNameToLinkId(libraryName);
+
+    return await new SetTokenCreator__factory(
+      // @ts-ignore
+      {
+        [linkId]: libraryAddress,
+      },
+      this._deployerSigner
+    ).attach(setTokenCreatorAddress);
   }
 
   public async deploySetToken(
@@ -50,8 +81,18 @@ export default class DeployCoreContracts {
     _manager: Address,
     _name: string,
     _symbol: string,
+    _libraryName: string,
+    _libraryAddress: Address,
   ): Promise<SetToken> {
-    return await new SetToken__factory(this._deployerSigner).deploy(
+    const linkId = convertLibraryNameToLinkId(_libraryName);
+
+    return await new SetToken__factory(
+      // @ts-ignore
+      {
+        [linkId]: _libraryAddress,
+      },
+      this._deployerSigner
+    ).deploy(
       _components,
       _units,
       _modules,
@@ -62,8 +103,20 @@ export default class DeployCoreContracts {
     );
   }
 
-  public async getSetToken(setTokenAddress: Address): Promise<SetToken> {
-    return await new SetToken__factory(this._deployerSigner).attach(setTokenAddress);
+  public async getSetToken(
+    setTokenAddress: Address,
+    libraryName: string,
+    libraryAddress: Address
+  ): Promise<SetToken> {
+    const linkId = convertLibraryNameToLinkId(libraryName);
+
+    return await new SetToken__factory(
+      // @ts-ignore
+      {
+        [linkId]: libraryAddress,
+      },
+      this._deployerSigner
+    ).attach(setTokenAddress);
   }
 
   public async deployPriceOracle(


### PR DESCRIPTION
**DO NOT MERGE: TARGETS #82**

(Very WIP) 
+ Moves SetToken public getters and some internal logic into externally linked libraries.
+ Makes all reason strings < 32 bytes

This gets us just under the effective contract size limit (as measured in practice when trying to deploy to Optimism client)

Reduces ovm compiled size of SetTokenCreator from 24.1KB to 22.16KB.


