### PR TITLE
KNC Migration Adapter

### DIFF
--- a/contracts/protocol/integration/wrap/KyberMigrationAdapter.sol
+++ b/contracts/protocol/integration/wrap/KyberMigrationAdapter.sol
@@ -1,5 +1,5 @@
 /*
-    Copyright 2020 Set Labs Inc.
+    Copyright 2021 Set Labs Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -22,19 +22,14 @@ pragma solidity 0.6.10;
  * @title KyberMigrationAdapter
  * @author Set Protocol
  *
- * Wrap adapter for one time token migration that returns data for wrapping KNC Legacy into KNC
+ * Wrap adapter for one time token migration that returns data for wrapping KNC Legacy into KNC.
+ * Note: KNC can not be unwrapped into KNC Legacy, because migration can not be reversed.
  */
 contract KyberMigrationWrapAdapter {
 
     /* ============ State Variables ============ */
 
-    // Address of KNC migration contract proxy
-    address public immutable kncLegacyToKncMigrationProxy;
-
-    // Address of KNC Legacy token
     address public immutable kncLegacyToken;
-
-    // Address of KNC token
     address public immutable kncToken;
 
     /* ============ Constructor ============ */
@@ -42,18 +37,15 @@ contract KyberMigrationWrapAdapter {
     /**
      * Set state variables
      *
-     * @param _kncLegacyToKncMigrationProxy     Address of KNC migration contract proxy
      * @param _kncLegacyToken                   Address of KNC Legacy token
      * @param _kncToken                         Address of KNC token
      */
     constructor(
-        address _kncLegacyToKncMigrationProxy,
         address _kncLegacyToken,
         address _kncToken
     )
         public
     {
-        kncLegacyToKncMigrationProxy = _kncLegacyToKncMigrationProxy;
         kncLegacyToken = _kncLegacyToken;
         kncToken = _kncToken;
     }
@@ -86,16 +78,11 @@ contract KyberMigrationWrapAdapter {
         // mintWithOldKnc(uint256 amount)
         bytes memory callData = abi.encodeWithSignature("mintWithOldKnc(uint256)", _underlyingUnits);
 
-        return (kncLegacyToKncMigrationProxy, 0, callData);
+        return (kncToken, 0, callData);
     }
 
     /**
-     * Generates the calldata to unwrap a wrapped asset into its underlying. Note: Migration cannot be reversed. This function
-     * will revert.
-     *
-     * @return address              Target contract address
-     * @return uint256              Total quantity of wrapped token units to unwrap. This will always be 0 for unwrapping
-     * @return bytes                Unwrap calldata
+     * This function will revert, since migration cannot be reversed.
      */
     function getUnwrapCallData(
         address /* _underlyingToken */,
@@ -103,7 +90,7 @@ contract KyberMigrationWrapAdapter {
         uint256 /* _wrappedTokenUnits */
     )
         external
-        view
+        pure
         returns (address, uint256, bytes memory)
     {
         revert("KNC migration cannot be reversed");
@@ -115,6 +102,6 @@ contract KyberMigrationWrapAdapter {
      * @return address        Address of the contract to approve tokens to
      */
     function getSpenderAddress(address /* _underlyingToken */, address /* _wrappedToken */) external view returns(address) {
-        return kncLegacyToKncMigrationProxy;
+        return kncToken;
     }
 }

--- a/contracts/protocol/integration/wrap/KyberMigrationAdapter.sol
+++ b/contracts/protocol/integration/wrap/KyberMigrationAdapter.sol
@@ -1,0 +1,120 @@
+/*
+    Copyright 2020 Set Labs Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    SPDX-License-Identifier: Apache License, Version 2.0
+*/
+
+pragma solidity 0.6.10;
+
+/**
+ * @title KyberMigrationAdapter
+ * @author Set Protocol
+ *
+ * Wrap adapter for one time token migration that returns data for wrapping KNC Legacy into KNC
+ */
+contract KyberMigrationWrapAdapter {
+
+    /* ============ State Variables ============ */
+
+    // Address of KNC migration contract proxy
+    address public immutable kncLegacyToKncMigrationProxy;
+
+    // Address of KNC Legacy token
+    address public immutable kncLegacyToken;
+
+    // Address of KNC token
+    address public immutable kncToken;
+
+    /* ============ Constructor ============ */
+
+    /**
+     * Set state variables
+     *
+     * @param _kncLegacyToKncMigrationProxy     Address of KNC migration contract proxy
+     * @param _kncLegacyToken                   Address of KNC Legacy token
+     * @param _kncToken                         Address of KNC token
+     */
+    constructor(
+        address _kncLegacyToKncMigrationProxy,
+        address _kncLegacyToken,
+        address _kncToken
+    )
+        public
+    {
+        kncLegacyToKncMigrationProxy = _kncLegacyToKncMigrationProxy;
+        kncLegacyToken = _kncLegacyToken;
+        kncToken = _kncToken;
+    }
+
+    /* ============ External Getter Functions ============ */
+
+    /**
+     * Generates the calldata to migrate KNC Legacy to KNC.
+     *
+     * @param _underlyingToken      Address of the component to be wrapped
+     * @param _wrappedToken         Address of the wrapped component
+     * @param _underlyingUnits      Total quantity of underlying units to wrap
+     *
+     * @return address              Target contract address
+     * @return uint256              Total quantity of underlying units (if underlying is ETH)
+     * @return bytes                Wrap calldata
+     */
+    function getWrapCallData(
+        address _underlyingToken,
+        address _wrappedToken,
+        uint256 _underlyingUnits
+    )
+        external
+        view
+        returns (address, uint256, bytes memory)
+    {
+        require(_underlyingToken == kncLegacyToken, "Must be KNC Legacy token");
+        require(_wrappedToken == kncToken, "Must be KNC token");
+
+        // mintWithOldKnc(uint256 amount)
+        bytes memory callData = abi.encodeWithSignature("mintWithOldKnc(uint256)", _underlyingUnits);
+
+        return (kncLegacyToKncMigrationProxy, 0, callData);
+    }
+
+    /**
+     * Generates the calldata to unwrap a wrapped asset into its underlying. Note: Migration cannot be reversed. This function
+     * will revert.
+     *
+     * @return address              Target contract address
+     * @return uint256              Total quantity of wrapped token units to unwrap. This will always be 0 for unwrapping
+     * @return bytes                Unwrap calldata
+     */
+    function getUnwrapCallData(
+        address /* _underlyingToken */,
+        address /* _wrappedToken */,
+        uint256 /* _wrappedTokenUnits */
+    )
+        external
+        view
+        returns (address, uint256, bytes memory)
+    {
+        revert("KNC migration cannot be reversed");
+    }
+
+    /**
+     * Returns the address to approve source tokens for wrapping.
+     *
+     * @return address        Address of the contract to approve tokens to
+     */
+    function getSpenderAddress(address /* _underlyingToken */, address /* _wrappedToken */) external view returns(address) {
+        return kncLegacyToKncMigrationProxy;
+    }
+}

--- a/external/abi/kyber/KyberNetworkTokenV2.json
+++ b/external/abi/kyber/KyberNetworkTokenV2.json
@@ -1,0 +1,524 @@
+[
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "owner",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "spender",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "value",
+                "type": "uint256"
+            }
+        ],
+        "name": "Approval",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            }
+        ],
+        "name": "Migrated",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "minter",
+                "type": "address"
+            }
+        ],
+        "name": "Minted",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "oldMinter",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "newMinter",
+                "type": "address"
+            }
+        ],
+        "name": "MinterChanged",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "previousOwner",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "newOwner",
+                "type": "address"
+            }
+        ],
+        "name": "OwnershipTransferred",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "from",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "to",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "value",
+                "type": "uint256"
+            }
+        ],
+        "name": "Transfer",
+        "type": "event"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "owner",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "spender",
+                "type": "address"
+            }
+        ],
+        "name": "allowance",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "spender",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            }
+        ],
+        "name": "approve",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            }
+        ],
+        "name": "balanceOf",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            }
+        ],
+        "name": "burn",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            }
+        ],
+        "name": "burnFrom",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "newMinter",
+                "type": "address"
+            }
+        ],
+        "name": "changeMinter",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "decimals",
+        "outputs": [
+            {
+                "internalType": "uint8",
+                "name": "",
+                "type": "uint8"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "spender",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "subtractedValue",
+                "type": "uint256"
+            }
+        ],
+        "name": "decreaseAllowance",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "contract IERC20",
+                "name": "token",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            }
+        ],
+        "name": "emergencyERC20Drain",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "spender",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "addedValue",
+                "type": "uint256"
+            }
+        ],
+        "name": "increaseAllowance",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "_oldKNC",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "_minter",
+                "type": "address"
+            }
+        ],
+        "name": "initialize",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            }
+        ],
+        "name": "mint",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            }
+        ],
+        "name": "mintWithOldKnc",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "minter",
+        "outputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "name",
+        "outputs": [
+            {
+                "internalType": "string",
+                "name": "",
+                "type": "string"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "oldKNC",
+        "outputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "owner",
+        "outputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "renounceOwnership",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "symbol",
+        "outputs": [
+            {
+                "internalType": "string",
+                "name": "",
+                "type": "string"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "totalSupply",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "recipient",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            }
+        ],
+        "name": "transfer",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "sender",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "recipient",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            }
+        ],
+        "name": "transferFrom",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "newOwner",
+                "type": "address"
+            }
+        ],
+        "name": "transferOwnership",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    }
+]

--- a/external/abi/kyber/KyberNetworkTokenV2.json
+++ b/external/abi/kyber/KyberNetworkTokenV2.json
@@ -1,524 +1,531 @@
-[
+{
+  "contractName": "KyberNetworkTokenV2",
+  "abi": [
     {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "owner",
-                "type": "address"
-            },
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "spender",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "value",
-                "type": "uint256"
-            }
-        ],
-        "name": "Approval",
-        "type": "event"
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "Approval",
+      "type": "event"
     },
     {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "account",
-                "type": "address"
-            },
-            {
-                "indexed": true,
-                "internalType": "uint256",
-                "name": "amount",
-                "type": "uint256"
-            }
-        ],
-        "name": "Migrated",
-        "type": "event"
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "Migrated",
+      "type": "event"
     },
     {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "account",
-                "type": "address"
-            },
-            {
-                "indexed": true,
-                "internalType": "uint256",
-                "name": "amount",
-                "type": "uint256"
-            },
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "minter",
-                "type": "address"
-            }
-        ],
-        "name": "Minted",
-        "type": "event"
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "minter",
+          "type": "address"
+        }
+      ],
+      "name": "Minted",
+      "type": "event"
     },
     {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "oldMinter",
-                "type": "address"
-            },
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "newMinter",
-                "type": "address"
-            }
-        ],
-        "name": "MinterChanged",
-        "type": "event"
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "oldMinter",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "newMinter",
+          "type": "address"
+        }
+      ],
+      "name": "MinterChanged",
+      "type": "event"
     },
     {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "previousOwner",
-                "type": "address"
-            },
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "newOwner",
-                "type": "address"
-            }
-        ],
-        "name": "OwnershipTransferred",
-        "type": "event"
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "previousOwner",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "newOwner",
+          "type": "address"
+        }
+      ],
+      "name": "OwnershipTransferred",
+      "type": "event"
     },
     {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "from",
-                "type": "address"
-            },
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "to",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "value",
-                "type": "uint256"
-            }
-        ],
-        "name": "Transfer",
-        "type": "event"
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "from",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "Transfer",
+      "type": "event"
     },
     {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "owner",
-                "type": "address"
-            },
-            {
-                "internalType": "address",
-                "name": "spender",
-                "type": "address"
-            }
-        ],
-        "name": "allowance",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        }
+      ],
+      "name": "allowance",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
     },
     {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "spender",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "amount",
-                "type": "uint256"
-            }
-        ],
-        "name": "approve",
-        "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
-        ],
-        "stateMutability": "nonpayable",
-        "type": "function"
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "approve",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
     },
     {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "account",
-                "type": "address"
-            }
-        ],
-        "name": "balanceOf",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "balanceOf",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
     },
     {
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "amount",
-                "type": "uint256"
-            }
-        ],
-        "name": "burn",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "burn",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
     },
     {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "account",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "amount",
-                "type": "uint256"
-            }
-        ],
-        "name": "burnFrom",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "burnFrom",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
     },
     {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "newMinter",
-                "type": "address"
-            }
-        ],
-        "name": "changeMinter",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "newMinter",
+          "type": "address"
+        }
+      ],
+      "name": "changeMinter",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
     },
     {
-        "inputs": [],
-        "name": "decimals",
-        "outputs": [
-            {
-                "internalType": "uint8",
-                "name": "",
-                "type": "uint8"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
+      "inputs": [],
+      "name": "decimals",
+      "outputs": [
+        {
+          "internalType": "uint8",
+          "name": "",
+          "type": "uint8"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
     },
     {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "spender",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "subtractedValue",
-                "type": "uint256"
-            }
-        ],
-        "name": "decreaseAllowance",
-        "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
-        ],
-        "stateMutability": "nonpayable",
-        "type": "function"
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "subtractedValue",
+          "type": "uint256"
+        }
+      ],
+      "name": "decreaseAllowance",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
     },
     {
-        "inputs": [
-            {
-                "internalType": "contract IERC20",
-                "name": "token",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "amount",
-                "type": "uint256"
-            }
-        ],
-        "name": "emergencyERC20Drain",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
+      "inputs": [
+        {
+          "internalType": "contract IERC20",
+          "name": "token",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "emergencyERC20Drain",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
     },
     {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "spender",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "addedValue",
-                "type": "uint256"
-            }
-        ],
-        "name": "increaseAllowance",
-        "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
-        ],
-        "stateMutability": "nonpayable",
-        "type": "function"
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "addedValue",
+          "type": "uint256"
+        }
+      ],
+      "name": "increaseAllowance",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
     },
     {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "_oldKNC",
-                "type": "address"
-            },
-            {
-                "internalType": "address",
-                "name": "_minter",
-                "type": "address"
-            }
-        ],
-        "name": "initialize",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_oldKNC",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "_minter",
+          "type": "address"
+        }
+      ],
+      "name": "initialize",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
     },
     {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "account",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "amount",
-                "type": "uint256"
-            }
-        ],
-        "name": "mint",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "mint",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
     },
     {
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "amount",
-                "type": "uint256"
-            }
-        ],
-        "name": "mintWithOldKnc",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "mintWithOldKnc",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
     },
     {
-        "inputs": [],
-        "name": "minter",
-        "outputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
+      "inputs": [],
+      "name": "minter",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
     },
     {
-        "inputs": [],
-        "name": "name",
-        "outputs": [
-            {
-                "internalType": "string",
-                "name": "",
-                "type": "string"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
+      "inputs": [],
+      "name": "name",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
     },
     {
-        "inputs": [],
-        "name": "oldKNC",
-        "outputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
+      "inputs": [],
+      "name": "oldKNC",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
     },
     {
-        "inputs": [],
-        "name": "owner",
-        "outputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
+      "inputs": [],
+      "name": "owner",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
     },
     {
-        "inputs": [],
-        "name": "renounceOwnership",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
+      "inputs": [],
+      "name": "renounceOwnership",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
     },
     {
-        "inputs": [],
-        "name": "symbol",
-        "outputs": [
-            {
-                "internalType": "string",
-                "name": "",
-                "type": "string"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
+      "inputs": [],
+      "name": "symbol",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
     },
     {
-        "inputs": [],
-        "name": "totalSupply",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
+      "inputs": [],
+      "name": "totalSupply",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
     },
     {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "recipient",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "amount",
-                "type": "uint256"
-            }
-        ],
-        "name": "transfer",
-        "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
-        ],
-        "stateMutability": "nonpayable",
-        "type": "function"
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "recipient",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "transfer",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
     },
     {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "sender",
-                "type": "address"
-            },
-            {
-                "internalType": "address",
-                "name": "recipient",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "amount",
-                "type": "uint256"
-            }
-        ],
-        "name": "transferFrom",
-        "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
-        ],
-        "stateMutability": "nonpayable",
-        "type": "function"
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "recipient",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "transferFrom",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
     },
     {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "newOwner",
-                "type": "address"
-            }
-        ],
-        "name": "transferOwnership",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "newOwner",
+          "type": "address"
+        }
+      ],
+      "name": "transferOwnership",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
     }
-]
+  ],
+  "bytecode": "0x608060405234801561001057600080fd5b50611e67806100206000396000f3fe608060405234801561001057600080fd5b506004361061017d5760003560e01c806370a08231116100e3578063a9059cbb1161008c578063db0e16f111610066578063db0e16f114610483578063dd62ed3e146104af578063f2fde38b146104dd5761017d565b8063a9059cbb14610432578063b43461691461045e578063c49fc085146104665761017d565b80638da5cb5b116100bd5780638da5cb5b146103f657806395d89b41146103fe578063a457c2d7146104065761017d565b806370a082311461039c578063715018a6146103c257806379cc6790146103ca5761017d565b80632c4d4d181161014557806340c10f191161011f57806340c10f191461032557806342966c6814610351578063485cc9551461036e5761017d565b80632c4d4d18146102b3578063313ce567146102db57806339509351146102f95761017d565b806306fdde031461018257806307546172146101ff578063095ea7b31461022357806318160ddd1461026357806323b872dd1461027d575b600080fd5b61018a610503565b6040805160208082528351818301528351919283929083019185019080838360005b838110156101c45781810151838201526020016101ac565b50505050905090810190601f1680156101f15780820380516001836020036101000a031916815260200191505b509250505060405180910390f35b61020761059a565b604080516001600160a01b039092168252519081900360200190f35b61024f6004803603604081101561023957600080fd5b506001600160a01b0381351690602001356105a9565b604080519115158252519081900360200190f35b61026b6105c6565b60408051918252519081900360200190f35b61024f6004803603606081101561029357600080fd5b506001600160a01b038135811691602081013590911690604001356105cc565b6102d9600480360360208110156102c957600080fd5b50356001600160a01b031661065a565b005b6102e3610761565b6040805160ff9092168252519081900360200190f35b61024f6004803603604081101561030f57600080fd5b506001600160a01b03813516906020013561076a565b6102d96004803603604081101561033b57600080fd5b506001600160a01b0381351690602001356107be565b6102d96004803603602081101561036757600080fd5b5035610857565b6102d96004803603604081101561038457600080fd5b506001600160a01b0381358116916020013516610868565b61026b600480360360208110156103b257600080fd5b50356001600160a01b0316610a37565b6102d9610a52565b6102d9600480360360408110156103e057600080fd5b506001600160a01b038135169060200135610b10565b610207610b6b565b61018a610b7a565b61024f6004803603604081101561041c57600080fd5b506001600160a01b038135169060200135610bdb565b61024f6004803603604081101561044857600080fd5b506001600160a01b038135169060200135610c49565b610207610c5d565b6102d96004803603602081101561047c57600080fd5b5035610c6c565b6102d96004803603604081101561049957600080fd5b506001600160a01b038135169060200135610d27565b61026b600480360360408110156104c557600080fd5b506001600160a01b0381358116916020013516610dc1565b6102d9600480360360208110156104f357600080fd5b50356001600160a01b0316610dec565b60688054604080516020601f600260001961010060018816150201909516949094049384018190048102820181019092528281526060939092909183018282801561058f5780601f106105645761010080835404028352916020019161058f565b820191906000526020600020905b81548152906001019060200180831161057257829003601f168201915b505050505090505b90565b60ca546001600160a01b031681565b60006105bd6105b6610f01565b8484610f05565b50600192915050565b60675490565b60006105d9848484610ff1565b61064f846105e5610f01565b61064a85604051806060016040528060288152602001611d2d602891396001600160a01b038a16600090815260666020526040812090610623610f01565b6001600160a01b03168152602081019190915260400160002054919063ffffffff61115a16565b610f05565b5060015b9392505050565b60ca546001600160a01b031633146106a7576040805162461bcd60e51b815260206004820152600b60248201526a37b7363c9036b4b73a32b960a91b604482015290519081900360640190fd5b6001600160a01b0381166106f3576040805162461bcd60e51b815260206004820152600e60248201526d34b73b30b634b21036b4b73a32b960911b604482015290519081900360640190fd5b60ca546001600160a01b0382811691161461075e5760ca546040516001600160a01b038084169216907f3b0007eb941cf645526cbb3a4fdaecda9d28ce4843167d9263b536a1f1edc0f690600090a360ca80546001600160a01b0319166001600160a01b0383161790555b50565b606a5460ff1690565b60006105bd610777610f01565b8461064a8560666000610788610f01565b6001600160a01b03908116825260208083019390935260409182016000908120918c16815292529020549063ffffffff6111f116565b60ca546001600160a01b0316331461080b576040805162461bcd60e51b815260206004820152600b60248201526a37b7363c9036b4b73a32b960a91b604482015290519081900360640190fd5b610815828261124b565b60ca546040516001600160a01b03918216918391908516907ffd1ba5519feb014ad2f631cbd516bd3cec96be935749391554d122972593e7bf90600090a45050565b61075e610862610f01565b82611349565b600054610100900460ff16806108815750610881611451565b8061088f575060005460ff16155b6108ca5760405162461bcd60e51b815260040180806020018281038252602e815260200180611cff602e913960400191505060405180910390fd5b600054610100900460ff161580156108f5576000805460ff1961ff0019909116610100171660011790555b61094f6040518060400160405280601881526020017f4b79626572204e6574776f726b204372797374616c2076320000000000000000815250604051806040016040528060038152602001624b4e4360e81b815250611462565b610957611517565b6001600160a01b0383166109a4576040805162461bcd60e51b815260206004820152600f60248201526e696e76616c6964206f6c64206b6e6360881b604482015290519081900360640190fd5b6001600160a01b0382166109f0576040805162461bcd60e51b815260206004820152600e60248201526d34b73b30b634b21036b4b73a32b960911b604482015290519081900360640190fd5b60c980546001600160a01b038086166001600160a01b03199283161790925560ca8054928516929091169190911790558015610a32576000805461ff00191690555b505050565b6001600160a01b031660009081526065602052604090205490565b610a5a610f01565b6001600160a01b0316610a6b610b6b565b6001600160a01b031614610ac6576040805162461bcd60e51b815260206004820181905260248201527f4f776e61626c653a2063616c6c6572206973206e6f7420746865206f776e6572604482015290519081900360640190fd5b6033546040516000916001600160a01b0316907f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0908390a3603380546001600160a01b0319169055565b6000610b4d82604051806060016040528060248152602001611d5560249139610b4086610b3b610f01565b610dc1565b919063ffffffff61115a16565b9050610b6183610b5b610f01565b83610f05565b610a328383611349565b6033546001600160a01b031690565b60698054604080516020601f600260001961010060018816150201909516949094049384018190048102820181019092528281526060939092909183018282801561058f5780601f106105645761010080835404028352916020019161058f565b60006105bd610be8610f01565b8461064a85604051806060016040528060258152602001611e0d6025913960666000610c12610f01565b6001600160a01b03908116825260208083019390935260409182016000908120918d1681529252902054919063ffffffff61115a16565b60006105bd610c56610f01565b8484610ff1565b60c9546001600160a01b031681565b60c9546040805163079cc67960e41b81523360048201526024810184905290516001600160a01b03909216916379cc6790916044808201926020929091908290030181600087803b158015610cc057600080fd5b505af1158015610cd4573d6000803e3d6000fd5b505050506040513d6020811015610cea57600080fd5b50610cf79050338261124b565b604051819033907f8b80bd19aea7b735bc6d75db8d6adbe18b28c30d62b3555245eb67b2340caedc90600090a350565b610d2f610f01565b6001600160a01b0316610d40610b6b565b6001600160a01b031614610d9b576040805162461bcd60e51b815260206004820181905260248201527f4f776e61626c653a2063616c6c6572206973206e6f7420746865206f776e6572604482015290519081900360640190fd5b610dbd610da6610b6b565b6001600160a01b038416908363ffffffff6115c816565b5050565b6001600160a01b03918216600090815260666020908152604080832093909416825291909152205490565b610df4610f01565b6001600160a01b0316610e05610b6b565b6001600160a01b031614610e60576040805162461bcd60e51b815260206004820181905260248201527f4f776e61626c653a2063616c6c6572206973206e6f7420746865206f776e6572604482015290519081900360640190fd5b6001600160a01b038116610ea55760405162461bcd60e51b8152600401808060200182810382526026815260200180611c6b6026913960400191505060405180910390fd5b6033546040516001600160a01b038084169216907f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e090600090a3603380546001600160a01b0319166001600160a01b0392909216919091179055565b3390565b6001600160a01b038316610f4a5760405162461bcd60e51b8152600401808060200182810382526024815260200180611dbf6024913960400191505060405180910390fd5b6001600160a01b038216610f8f5760405162461bcd60e51b8152600401808060200182810382526022815260200180611c916022913960400191505060405180910390fd5b6001600160a01b03808416600081815260666020908152604080832094871680845294825291829020859055815185815291517f8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b9259281900390910190a3505050565b6001600160a01b0383166110365760405162461bcd60e51b8152600401808060200182810382526025815260200180611d9a6025913960400191505060405180910390fd5b6001600160a01b03821661107b5760405162461bcd60e51b8152600401808060200182810382526023815260200180611c266023913960400191505060405180910390fd5b611086838383610a32565b6110c981604051806060016040528060268152602001611cb3602691396001600160a01b038616600090815260656020526040902054919063ffffffff61115a16565b6001600160a01b0380851660009081526065602052604080822093909355908416815220546110fe908263ffffffff6111f116565b6001600160a01b0380841660008181526065602090815260409182902094909455805185815290519193928716927fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef92918290030190a3505050565b600081848411156111e95760405162461bcd60e51b81526004018080602001828103825283818151815260200191508051906020019080838360005b838110156111ae578181015183820152602001611196565b50505050905090810190601f1680156111db5780820380516001836020036101000a031916815260200191505b509250505060405180910390fd5b505050900390565b600082820183811015610653576040805162461bcd60e51b815260206004820152601b60248201527f536166654d6174683a206164646974696f6e206f766572666c6f770000000000604482015290519081900360640190fd5b6001600160a01b0382166112a6576040805162461bcd60e51b815260206004820152601f60248201527f45524332303a206d696e7420746f20746865207a65726f206164647265737300604482015290519081900360640190fd5b6112b260008383610a32565b6067546112c5908263ffffffff6111f116565b6067556001600160a01b0382166000908152606560205260409020546112f1908263ffffffff6111f116565b6001600160a01b03831660008181526065602090815260408083209490945583518581529351929391927fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef9281900390910190a35050565b6001600160a01b03821661138e5760405162461bcd60e51b8152600401808060200182810382526021815260200180611d796021913960400191505060405180910390fd5b61139a82600083610a32565b6113dd81604051806060016040528060228152602001611c49602291396001600160a01b038516600090815260656020526040902054919063ffffffff61115a16565b6001600160a01b038316600090815260656020526040902055606754611409908263ffffffff61162f16565b6067556040805182815290516000916001600160a01b038516917fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef9181900360200190a35050565b600061145c3061168c565b15905090565b600054610100900460ff168061147b575061147b611451565b80611489575060005460ff16155b6114c45760405162461bcd60e51b815260040180806020018281038252602e815260200180611cff602e913960400191505060405180910390fd5b600054610100900460ff161580156114ef576000805460ff1961ff0019909116610100171660011790555b6114f7611692565b6115018383611732565b8015610a32576000805461ff0019169055505050565b600054610100900460ff16806115305750611530611451565b8061153e575060005460ff16155b6115795760405162461bcd60e51b815260040180806020018281038252602e815260200180611cff602e913960400191505060405180910390fd5b600054610100900460ff161580156115a4576000805460ff1961ff0019909116610100171660011790555b6115ac611692565b6115b461180a565b801561075e576000805461ff001916905550565b604080516001600160a01b038416602482015260448082018490528251808303909101815260649091019091526020810180517bffffffffffffffffffffffffffffffffffffffffffffffffffffffff1663a9059cbb60e01b179052610a32908490611903565b600082821115611686576040805162461bcd60e51b815260206004820152601e60248201527f536166654d6174683a207375627472616374696f6e206f766572666c6f770000604482015290519081900360640190fd5b50900390565b3b151590565b600054610100900460ff16806116ab57506116ab611451565b806116b9575060005460ff16155b6116f45760405162461bcd60e51b815260040180806020018281038252602e815260200180611cff602e913960400191505060405180910390fd5b600054610100900460ff161580156115b4576000805460ff1961ff001990911661010017166001179055801561075e576000805461ff001916905550565b600054610100900460ff168061174b575061174b611451565b80611759575060005460ff16155b6117945760405162461bcd60e51b815260040180806020018281038252602e815260200180611cff602e913960400191505060405180910390fd5b600054610100900460ff161580156117bf576000805460ff1961ff0019909116610100171660011790555b82516117d2906068906020860190611b8d565b5081516117e6906069906020850190611b8d565b50606a805460ff191660121790558015610a32576000805461ff0019169055505050565b600054610100900460ff16806118235750611823611451565b80611831575060005460ff16155b61186c5760405162461bcd60e51b815260040180806020018281038252602e815260200180611cff602e913960400191505060405180910390fd5b600054610100900460ff16158015611897576000805460ff1961ff0019909116610100171660011790555b60006118a1610f01565b603380546001600160a01b0319166001600160a01b038316908117909155604051919250906000907f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0908290a350801561075e576000805461ff001916905550565b6060611958826040518060400160405280602081526020017f5361666545524332303a206c6f772d6c6576656c2063616c6c206661696c6564815250856001600160a01b03166119b49092919063ffffffff16565b805190915015610a325780806020019051602081101561197757600080fd5b5051610a325760405162461bcd60e51b815260040180806020018281038252602a815260200180611de3602a913960400191505060405180910390fd5b60606119c384846000856119cb565b949350505050565b606082471015611a0c5760405162461bcd60e51b8152600401808060200182810382526026815260200180611cd96026913960400191505060405180910390fd5b611a158561168c565b611a66576040805162461bcd60e51b815260206004820152601d60248201527f416464726573733a2063616c6c20746f206e6f6e2d636f6e7472616374000000604482015290519081900360640190fd5b60006060866001600160a01b031685876040518082805190602001908083835b60208310611aa55780518252601f199092019160209182019101611a86565b6001836020036101000a03801982511681845116808217855250505050505090500191505060006040518083038185875af1925050503d8060008114611b07576040519150601f19603f3d011682016040523d82523d6000602084013e611b0c565b606091505b5091509150611b1c828286611b27565b979650505050505050565b60608315611b36575081610653565b825115611b465782518084602001fd5b60405162461bcd60e51b81526020600482018181528451602484015284518593919283926044019190850190808383600083156111ae578181015183820152602001611196565b828054600181600116156101000203166002900490600052602060002090601f016020900481019282601f10611bce57805160ff1916838001178555611bfb565b82800160010185558215611bfb579182015b82811115611bfb578251825591602001919060010190611be0565b50611c07929150611c0b565b5090565b61059791905b80821115611c075760008155600101611c1156fe45524332303a207472616e7366657220746f20746865207a65726f206164647265737345524332303a206275726e20616d6f756e7420657863656564732062616c616e63654f776e61626c653a206e6577206f776e657220697320746865207a65726f206164647265737345524332303a20617070726f766520746f20746865207a65726f206164647265737345524332303a207472616e7366657220616d6f756e7420657863656564732062616c616e6365416464726573733a20696e73756666696369656e742062616c616e636520666f722063616c6c496e697469616c697a61626c653a20636f6e747261637420697320616c726561647920696e697469616c697a656445524332303a207472616e7366657220616d6f756e74206578636565647320616c6c6f77616e636545524332303a206275726e20616d6f756e74206578636565647320616c6c6f77616e636545524332303a206275726e2066726f6d20746865207a65726f206164647265737345524332303a207472616e736665722066726f6d20746865207a65726f206164647265737345524332303a20617070726f76652066726f6d20746865207a65726f20616464726573735361666545524332303a204552433230206f7065726174696f6e20646964206e6f74207375636365656445524332303a2064656372656173656420616c6c6f77616e63652062656c6f77207a65726fa2646970667358221220da4ae83b1cea35864a3f5b542dc5ae1d0750fb745d86f1448c53c641186d0a8d64736f6c63430006060033",
+  "deployedBytecode": "0x608060405234801561001057600080fd5b506004361061017d5760003560e01c806370a08231116100e3578063a9059cbb1161008c578063db0e16f111610066578063db0e16f114610483578063dd62ed3e146104af578063f2fde38b146104dd5761017d565b8063a9059cbb14610432578063b43461691461045e578063c49fc085146104665761017d565b80638da5cb5b116100bd5780638da5cb5b146103f657806395d89b41146103fe578063a457c2d7146104065761017d565b806370a082311461039c578063715018a6146103c257806379cc6790146103ca5761017d565b80632c4d4d181161014557806340c10f191161011f57806340c10f191461032557806342966c6814610351578063485cc9551461036e5761017d565b80632c4d4d18146102b3578063313ce567146102db57806339509351146102f95761017d565b806306fdde031461018257806307546172146101ff578063095ea7b31461022357806318160ddd1461026357806323b872dd1461027d575b600080fd5b61018a610503565b6040805160208082528351818301528351919283929083019185019080838360005b838110156101c45781810151838201526020016101ac565b50505050905090810190601f1680156101f15780820380516001836020036101000a031916815260200191505b509250505060405180910390f35b61020761059a565b604080516001600160a01b039092168252519081900360200190f35b61024f6004803603604081101561023957600080fd5b506001600160a01b0381351690602001356105a9565b604080519115158252519081900360200190f35b61026b6105c6565b60408051918252519081900360200190f35b61024f6004803603606081101561029357600080fd5b506001600160a01b038135811691602081013590911690604001356105cc565b6102d9600480360360208110156102c957600080fd5b50356001600160a01b031661065a565b005b6102e3610761565b6040805160ff9092168252519081900360200190f35b61024f6004803603604081101561030f57600080fd5b506001600160a01b03813516906020013561076a565b6102d96004803603604081101561033b57600080fd5b506001600160a01b0381351690602001356107be565b6102d96004803603602081101561036757600080fd5b5035610857565b6102d96004803603604081101561038457600080fd5b506001600160a01b0381358116916020013516610868565b61026b600480360360208110156103b257600080fd5b50356001600160a01b0316610a37565b6102d9610a52565b6102d9600480360360408110156103e057600080fd5b506001600160a01b038135169060200135610b10565b610207610b6b565b61018a610b7a565b61024f6004803603604081101561041c57600080fd5b506001600160a01b038135169060200135610bdb565b61024f6004803603604081101561044857600080fd5b506001600160a01b038135169060200135610c49565b610207610c5d565b6102d96004803603602081101561047c57600080fd5b5035610c6c565b6102d96004803603604081101561049957600080fd5b506001600160a01b038135169060200135610d27565b61026b600480360360408110156104c557600080fd5b506001600160a01b0381358116916020013516610dc1565b6102d9600480360360208110156104f357600080fd5b50356001600160a01b0316610dec565b60688054604080516020601f600260001961010060018816150201909516949094049384018190048102820181019092528281526060939092909183018282801561058f5780601f106105645761010080835404028352916020019161058f565b820191906000526020600020905b81548152906001019060200180831161057257829003601f168201915b505050505090505b90565b60ca546001600160a01b031681565b60006105bd6105b6610f01565b8484610f05565b50600192915050565b60675490565b60006105d9848484610ff1565b61064f846105e5610f01565b61064a85604051806060016040528060288152602001611d2d602891396001600160a01b038a16600090815260666020526040812090610623610f01565b6001600160a01b03168152602081019190915260400160002054919063ffffffff61115a16565b610f05565b5060015b9392505050565b60ca546001600160a01b031633146106a7576040805162461bcd60e51b815260206004820152600b60248201526a37b7363c9036b4b73a32b960a91b604482015290519081900360640190fd5b6001600160a01b0381166106f3576040805162461bcd60e51b815260206004820152600e60248201526d34b73b30b634b21036b4b73a32b960911b604482015290519081900360640190fd5b60ca546001600160a01b0382811691161461075e5760ca546040516001600160a01b038084169216907f3b0007eb941cf645526cbb3a4fdaecda9d28ce4843167d9263b536a1f1edc0f690600090a360ca80546001600160a01b0319166001600160a01b0383161790555b50565b606a5460ff1690565b60006105bd610777610f01565b8461064a8560666000610788610f01565b6001600160a01b03908116825260208083019390935260409182016000908120918c16815292529020549063ffffffff6111f116565b60ca546001600160a01b0316331461080b576040805162461bcd60e51b815260206004820152600b60248201526a37b7363c9036b4b73a32b960a91b604482015290519081900360640190fd5b610815828261124b565b60ca546040516001600160a01b03918216918391908516907ffd1ba5519feb014ad2f631cbd516bd3cec96be935749391554d122972593e7bf90600090a45050565b61075e610862610f01565b82611349565b600054610100900460ff16806108815750610881611451565b8061088f575060005460ff16155b6108ca5760405162461bcd60e51b815260040180806020018281038252602e815260200180611cff602e913960400191505060405180910390fd5b600054610100900460ff161580156108f5576000805460ff1961ff0019909116610100171660011790555b61094f6040518060400160405280601881526020017f4b79626572204e6574776f726b204372797374616c2076320000000000000000815250604051806040016040528060038152602001624b4e4360e81b815250611462565b610957611517565b6001600160a01b0383166109a4576040805162461bcd60e51b815260206004820152600f60248201526e696e76616c6964206f6c64206b6e6360881b604482015290519081900360640190fd5b6001600160a01b0382166109f0576040805162461bcd60e51b815260206004820152600e60248201526d34b73b30b634b21036b4b73a32b960911b604482015290519081900360640190fd5b60c980546001600160a01b038086166001600160a01b03199283161790925560ca8054928516929091169190911790558015610a32576000805461ff00191690555b505050565b6001600160a01b031660009081526065602052604090205490565b610a5a610f01565b6001600160a01b0316610a6b610b6b565b6001600160a01b031614610ac6576040805162461bcd60e51b815260206004820181905260248201527f4f776e61626c653a2063616c6c6572206973206e6f7420746865206f776e6572604482015290519081900360640190fd5b6033546040516000916001600160a01b0316907f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0908390a3603380546001600160a01b0319169055565b6000610b4d82604051806060016040528060248152602001611d5560249139610b4086610b3b610f01565b610dc1565b919063ffffffff61115a16565b9050610b6183610b5b610f01565b83610f05565b610a328383611349565b6033546001600160a01b031690565b60698054604080516020601f600260001961010060018816150201909516949094049384018190048102820181019092528281526060939092909183018282801561058f5780601f106105645761010080835404028352916020019161058f565b60006105bd610be8610f01565b8461064a85604051806060016040528060258152602001611e0d6025913960666000610c12610f01565b6001600160a01b03908116825260208083019390935260409182016000908120918d1681529252902054919063ffffffff61115a16565b60006105bd610c56610f01565b8484610ff1565b60c9546001600160a01b031681565b60c9546040805163079cc67960e41b81523360048201526024810184905290516001600160a01b03909216916379cc6790916044808201926020929091908290030181600087803b158015610cc057600080fd5b505af1158015610cd4573d6000803e3d6000fd5b505050506040513d6020811015610cea57600080fd5b50610cf79050338261124b565b604051819033907f8b80bd19aea7b735bc6d75db8d6adbe18b28c30d62b3555245eb67b2340caedc90600090a350565b610d2f610f01565b6001600160a01b0316610d40610b6b565b6001600160a01b031614610d9b576040805162461bcd60e51b815260206004820181905260248201527f4f776e61626c653a2063616c6c6572206973206e6f7420746865206f776e6572604482015290519081900360640190fd5b610dbd610da6610b6b565b6001600160a01b038416908363ffffffff6115c816565b5050565b6001600160a01b03918216600090815260666020908152604080832093909416825291909152205490565b610df4610f01565b6001600160a01b0316610e05610b6b565b6001600160a01b031614610e60576040805162461bcd60e51b815260206004820181905260248201527f4f776e61626c653a2063616c6c6572206973206e6f7420746865206f776e6572604482015290519081900360640190fd5b6001600160a01b038116610ea55760405162461bcd60e51b8152600401808060200182810382526026815260200180611c6b6026913960400191505060405180910390fd5b6033546040516001600160a01b038084169216907f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e090600090a3603380546001600160a01b0319166001600160a01b0392909216919091179055565b3390565b6001600160a01b038316610f4a5760405162461bcd60e51b8152600401808060200182810382526024815260200180611dbf6024913960400191505060405180910390fd5b6001600160a01b038216610f8f5760405162461bcd60e51b8152600401808060200182810382526022815260200180611c916022913960400191505060405180910390fd5b6001600160a01b03808416600081815260666020908152604080832094871680845294825291829020859055815185815291517f8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b9259281900390910190a3505050565b6001600160a01b0383166110365760405162461bcd60e51b8152600401808060200182810382526025815260200180611d9a6025913960400191505060405180910390fd5b6001600160a01b03821661107b5760405162461bcd60e51b8152600401808060200182810382526023815260200180611c266023913960400191505060405180910390fd5b611086838383610a32565b6110c981604051806060016040528060268152602001611cb3602691396001600160a01b038616600090815260656020526040902054919063ffffffff61115a16565b6001600160a01b0380851660009081526065602052604080822093909355908416815220546110fe908263ffffffff6111f116565b6001600160a01b0380841660008181526065602090815260409182902094909455805185815290519193928716927fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef92918290030190a3505050565b600081848411156111e95760405162461bcd60e51b81526004018080602001828103825283818151815260200191508051906020019080838360005b838110156111ae578181015183820152602001611196565b50505050905090810190601f1680156111db5780820380516001836020036101000a031916815260200191505b509250505060405180910390fd5b505050900390565b600082820183811015610653576040805162461bcd60e51b815260206004820152601b60248201527f536166654d6174683a206164646974696f6e206f766572666c6f770000000000604482015290519081900360640190fd5b6001600160a01b0382166112a6576040805162461bcd60e51b815260206004820152601f60248201527f45524332303a206d696e7420746f20746865207a65726f206164647265737300604482015290519081900360640190fd5b6112b260008383610a32565b6067546112c5908263ffffffff6111f116565b6067556001600160a01b0382166000908152606560205260409020546112f1908263ffffffff6111f116565b6001600160a01b03831660008181526065602090815260408083209490945583518581529351929391927fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef9281900390910190a35050565b6001600160a01b03821661138e5760405162461bcd60e51b8152600401808060200182810382526021815260200180611d796021913960400191505060405180910390fd5b61139a82600083610a32565b6113dd81604051806060016040528060228152602001611c49602291396001600160a01b038516600090815260656020526040902054919063ffffffff61115a16565b6001600160a01b038316600090815260656020526040902055606754611409908263ffffffff61162f16565b6067556040805182815290516000916001600160a01b038516917fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef9181900360200190a35050565b600061145c3061168c565b15905090565b600054610100900460ff168061147b575061147b611451565b80611489575060005460ff16155b6114c45760405162461bcd60e51b815260040180806020018281038252602e815260200180611cff602e913960400191505060405180910390fd5b600054610100900460ff161580156114ef576000805460ff1961ff0019909116610100171660011790555b6114f7611692565b6115018383611732565b8015610a32576000805461ff0019169055505050565b600054610100900460ff16806115305750611530611451565b8061153e575060005460ff16155b6115795760405162461bcd60e51b815260040180806020018281038252602e815260200180611cff602e913960400191505060405180910390fd5b600054610100900460ff161580156115a4576000805460ff1961ff0019909116610100171660011790555b6115ac611692565b6115b461180a565b801561075e576000805461ff001916905550565b604080516001600160a01b038416602482015260448082018490528251808303909101815260649091019091526020810180517bffffffffffffffffffffffffffffffffffffffffffffffffffffffff1663a9059cbb60e01b179052610a32908490611903565b600082821115611686576040805162461bcd60e51b815260206004820152601e60248201527f536166654d6174683a207375627472616374696f6e206f766572666c6f770000604482015290519081900360640190fd5b50900390565b3b151590565b600054610100900460ff16806116ab57506116ab611451565b806116b9575060005460ff16155b6116f45760405162461bcd60e51b815260040180806020018281038252602e815260200180611cff602e913960400191505060405180910390fd5b600054610100900460ff161580156115b4576000805460ff1961ff001990911661010017166001179055801561075e576000805461ff001916905550565b600054610100900460ff168061174b575061174b611451565b80611759575060005460ff16155b6117945760405162461bcd60e51b815260040180806020018281038252602e815260200180611cff602e913960400191505060405180910390fd5b600054610100900460ff161580156117bf576000805460ff1961ff0019909116610100171660011790555b82516117d2906068906020860190611b8d565b5081516117e6906069906020850190611b8d565b50606a805460ff191660121790558015610a32576000805461ff0019169055505050565b600054610100900460ff16806118235750611823611451565b80611831575060005460ff16155b61186c5760405162461bcd60e51b815260040180806020018281038252602e815260200180611cff602e913960400191505060405180910390fd5b600054610100900460ff16158015611897576000805460ff1961ff0019909116610100171660011790555b60006118a1610f01565b603380546001600160a01b0319166001600160a01b038316908117909155604051919250906000907f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0908290a350801561075e576000805461ff001916905550565b6060611958826040518060400160405280602081526020017f5361666545524332303a206c6f772d6c6576656c2063616c6c206661696c6564815250856001600160a01b03166119b49092919063ffffffff16565b805190915015610a325780806020019051602081101561197757600080fd5b5051610a325760405162461bcd60e51b815260040180806020018281038252602a815260200180611de3602a913960400191505060405180910390fd5b60606119c384846000856119cb565b949350505050565b606082471015611a0c5760405162461bcd60e51b8152600401808060200182810382526026815260200180611cd96026913960400191505060405180910390fd5b611a158561168c565b611a66576040805162461bcd60e51b815260206004820152601d60248201527f416464726573733a2063616c6c20746f206e6f6e2d636f6e7472616374000000604482015290519081900360640190fd5b60006060866001600160a01b031685876040518082805190602001908083835b60208310611aa55780518252601f199092019160209182019101611a86565b6001836020036101000a03801982511681845116808217855250505050505090500191505060006040518083038185875af1925050503d8060008114611b07576040519150601f19603f3d011682016040523d82523d6000602084013e611b0c565b606091505b5091509150611b1c828286611b27565b979650505050505050565b60608315611b36575081610653565b825115611b465782518084602001fd5b60405162461bcd60e51b81526020600482018181528451602484015284518593919283926044019190850190808383600083156111ae578181015183820152602001611196565b828054600181600116156101000203166002900490600052602060002090601f016020900481019282601f10611bce57805160ff1916838001178555611bfb565b82800160010185558215611bfb579182015b82811115611bfb578251825591602001919060010190611be0565b50611c07929150611c0b565b5090565b61059791905b80821115611c075760008155600101611c1156fe45524332303a207472616e7366657220746f20746865207a65726f206164647265737345524332303a206275726e20616d6f756e7420657863656564732062616c616e63654f776e61626c653a206e6577206f776e657220697320746865207a65726f206164647265737345524332303a20617070726f766520746f20746865207a65726f206164647265737345524332303a207472616e7366657220616d6f756e7420657863656564732062616c616e6365416464726573733a20696e73756666696369656e742062616c616e636520666f722063616c6c496e697469616c697a61626c653a20636f6e747261637420697320616c726561647920696e697469616c697a656445524332303a207472616e7366657220616d6f756e74206578636565647320616c6c6f77616e636545524332303a206275726e20616d6f756e74206578636565647320616c6c6f77616e636545524332303a206275726e2066726f6d20746865207a65726f206164647265737345524332303a207472616e736665722066726f6d20746865207a65726f206164647265737345524332303a20617070726f76652066726f6d20746865207a65726f20616464726573735361666545524332303a204552433230206f7065726174696f6e20646964206e6f74207375636365656445524332303a2064656372656173656420616c6c6f77616e63652062656c6f77207a65726fa2646970667358221220da4ae83b1cea35864a3f5b542dc5ae1d0750fb745d86f1448c53c641186d0a8d64736f6c63430006060033",
+  "linkReferences": {},
+  "deployedLinkReferences": {}
+}

--- a/external/contracts/kyber/KyberNetworkTokenV2.sol
+++ b/external/contracts/kyber/KyberNetworkTokenV2.sol
@@ -1,0 +1,66 @@
+pragma solidity 0.6.6;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
+import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20BurnableUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
+
+interface IERC20Burnable {
+    function burnFrom(address _from, uint256 _value) external returns (bool);
+}
+
+contract KyberNetworkTokenV2 is OwnableUpgradeable, ERC20BurnableUpgradeable {
+    using SafeERC20 for IERC20;
+
+    address public oldKNC;
+    address public minter;
+
+    event Minted(address indexed account, uint256 indexed amount, address indexed minter);
+    event Migrated(address indexed account, uint256 indexed amount);
+    event MinterChanged(address indexed oldMinter, address indexed newMinter);
+
+    modifier onlyMinter() {
+        require(msg.sender == minter, "only minter");
+        _;
+    }
+
+    function initialize(address _oldKNC, address _minter)
+        external
+        initializer
+    {
+        __ERC20_init("Kyber Network Crystal v2", "KNC");
+        __Ownable_init();
+        require(_oldKNC != address(0), "invalid old knc");
+        require(_minter != address(0), "invalid minter");
+        oldKNC = _oldKNC;
+        minter = _minter;
+    }
+
+    function mint(address account, uint256 amount) external onlyMinter {
+        super._mint(account, amount);
+        emit Minted(account, amount, minter);
+    }
+
+    /// @dev burn old knc and mint new knc for msg.sender, ratio 1:1
+    function mintWithOldKnc(uint256 amount) external {
+        IERC20Burnable(oldKNC).burnFrom(msg.sender, amount);
+
+        super._mint(msg.sender, amount);
+        emit Migrated(msg.sender, amount);
+    }
+
+    function changeMinter(address newMinter) external onlyMinter {
+        require(newMinter != address(0), "invalid minter");
+        if (minter != newMinter) {
+            emit MinterChanged(minter, newMinter);
+            minter = newMinter;
+        }
+    }
+
+    /// @dev emergency withdraw ERC20, can only call by the owner
+    /// to withdraw tokens that have been sent to this address
+    function emergencyERC20Drain(IERC20 token, uint256 amount) external onlyOwner {
+        token.safeTransfer(owner(), amount);
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@setprotocol/set-protocol-v2",
-  "version": "0.0.35",
+  "version": "0.0.36",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@setprotocol/set-protocol-v2",
-  "version": "0.0.35",
+  "version": "0.0.36",
   "description": "",
   "main": "dist",
   "types": "dist/types",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,6 @@
     "web3": "^1.2.9"
   },
   "dependencies": {
-    "@openzeppelin/contracts-upgradeable": "3.4.1",
     "fs-extra": "^5.0.0",
     "module-alias": "^2.2.2",
     "replace-in-file": "^6.1.0",

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "web3": "^1.2.9"
   },
   "dependencies": {
+    "@openzeppelin/contracts-upgradeable": "3.4.1",
     "fs-extra": "^5.0.0",
     "module-alias": "^2.2.2",
     "replace-in-file": "^6.1.0",

--- a/test/protocol/integration/wrap/kyberMigrationWrapAdapter.spec.ts
+++ b/test/protocol/integration/wrap/kyberMigrationWrapAdapter.spec.ts
@@ -1,0 +1,173 @@
+import "module-alias/register";
+import { BigNumber } from "@ethersproject/bignumber";
+
+import { Address } from "@utils/types";
+import { Account } from "@utils/test/types";
+import { KyberMigrationWrapAdapter } from "@utils/contracts";
+import DeployHelper from "@utils/deploys";
+import {
+  ether,
+} from "@utils/index";
+import {
+  addSnapshotBeforeRestoreAfterEach,
+  getAccounts,
+  getWaffleExpect
+} from "@utils/test/index";
+
+
+const expect = getWaffleExpect();
+
+describe("KyberMigrationWrapAdapter", () => {
+  let owner: Account;
+  let deployer: DeployHelper;
+  let kyberMigrationWrapAdapter: KyberMigrationWrapAdapter;
+
+  let kncLegacyToKncMigrationProxy: Account;
+  let kncLegacyToken: Account;
+  let kncToken: Account;
+  let mockOtherUnderlyingToken: Account;
+  let mockOtherWrappedToken: Account;
+
+  before(async () => {
+    [
+      owner,
+      kncLegacyToKncMigrationProxy,
+      kncLegacyToken,
+      kncToken,
+      mockOtherUnderlyingToken,
+      mockOtherWrappedToken,
+    ] = await getAccounts();
+
+    deployer = new DeployHelper(owner.wallet);
+
+    kyberMigrationWrapAdapter = await deployer.adapters.deployKyberMigrationWrapAdapter(
+        kncLegacyToKncMigrationProxy.address,
+        kncLegacyToken.address,
+        kncToken.address
+    );
+  });
+
+  addSnapshotBeforeRestoreAfterEach();
+
+  describe("#constructor", async () => {
+    let subjectKncLegacyToKncMigrationProxy: Address;
+    let subjectKncLegacyToken: Address;
+    let subjectKncToken: Address;
+
+    beforeEach(async () => {
+      subjectKncLegacyToKncMigrationProxy = kncLegacyToKncMigrationProxy.address;
+      subjectKncLegacyToken = kncLegacyToken.address;
+      subjectKncToken = kncToken.address;
+    });
+
+    async function subject(): Promise<any> {
+      return deployer.adapters.deployKyberMigrationWrapAdapter(
+        subjectKncLegacyToKncMigrationProxy,
+        subjectKncLegacyToken,
+        subjectKncToken
+      );
+    }
+
+    it("should have the correct migration proxy address", async () => {
+      const deployKyberMigrationWrapAdapter = await subject();
+
+      const expectedKncLegacyToKncMigrationProxy = await deployKyberMigrationWrapAdapter.kncLegacyToKncMigrationProxy();
+      expect(expectedKncLegacyToKncMigrationProxy).to.eq(subjectKncLegacyToKncMigrationProxy);
+    });
+
+    it("should have the correct KNC Legacy token address", async () => {
+      const deployKyberMigrationWrapAdapter = await subject();
+
+      const expectedKncLegacyToken = await deployKyberMigrationWrapAdapter.kncLegacyToken();
+      expect(expectedKncLegacyToken).to.eq(subjectKncLegacyToken);
+    });
+
+    it("should have the correct KNC token address", async () => {
+        const deployKyberMigrationWrapAdapter = await subject();
+
+        const expectedKncToken = await deployKyberMigrationWrapAdapter.kncToken();
+        expect(expectedKncToken).to.eq(subjectKncToken);
+    });
+  });
+
+  describe("#getSpenderAddress", async () => {
+    async function subject(): Promise<any> {
+      return kyberMigrationWrapAdapter.getSpenderAddress(
+        kncLegacyToken.address,
+        kncToken.address,
+      );
+    }
+
+    it("should return the correct spender address", async () => {
+      const spender = await subject();
+
+      expect(spender).to.eq(kncLegacyToKncMigrationProxy.address);
+    });
+  });
+
+  describe("#getWrapCallData", async () => {
+    let subjectUnderlyingToken: Address;
+    let subjectWrappedToken: Address;
+    let subjectUnderlyingUnits: BigNumber;
+
+    beforeEach(async () => {
+      subjectUnderlyingToken = kncLegacyToken.address;
+      subjectWrappedToken = kncToken.address;
+      subjectUnderlyingUnits = ether(2);
+    });
+
+    async function subject(): Promise<any> {
+      return kyberMigrationWrapAdapter.getWrapCallData(subjectUnderlyingToken, subjectWrappedToken, subjectUnderlyingUnits);
+    }
+
+    // it("should return correct data for valid pair", async () => {
+    //   const [targetAddress, ethValue, callData] = await subject();
+
+    //   const expectedCallData = kncLegacyToKncWrapAdapter.interface.encodeFunctionData("mintWithOldKnc", [subjectUnderlyingUnits]);
+
+    //   expect(targetAddress).to.eq(kncLegacyToKncMigrationProxy.address);
+    //   expect(ethValue).to.eq(ZERO);
+    //   expect(callData).to.eq(expectedCallData);
+    // });
+
+    describe("when underlying asset is not KNC Legacy token", () => {
+      beforeEach(async () => {
+        subjectUnderlyingToken = mockOtherUnderlyingToken.address;
+      });
+
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith("Must be KNC Legacy token");
+      });
+    });
+
+    describe("when wrapped asset is not KNC token", () => {
+      beforeEach(async () => {
+        subjectWrappedToken = mockOtherWrappedToken.address;
+      });
+
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith("Must be KNC token");
+      });
+    });
+  });
+
+  describe("#getUnwrapCallData", async () => {
+    let subjectUnderlyingToken: Address;
+    let subjectWrappedToken: Address;
+    let subjectWrappedTokenUnits: BigNumber;
+
+    beforeEach(async () => {
+      subjectUnderlyingToken = mockOtherUnderlyingToken.address;
+      subjectWrappedToken = mockOtherWrappedToken.address;
+      subjectWrappedTokenUnits = ether(2);
+    });
+
+    async function subject(): Promise<any> {
+      return kyberMigrationWrapAdapter.getUnwrapCallData(subjectUnderlyingToken, subjectWrappedToken, subjectWrappedTokenUnits);
+    }
+
+    it("should revert", async () => {
+      await expect(subject()).to.be.revertedWith("KNC migration cannot be reversed");
+    });
+  });
+});

--- a/test/protocol/integration/wrap/kyberMigrationWrapAdapter.spec.ts
+++ b/test/protocol/integration/wrap/kyberMigrationWrapAdapter.spec.ts
@@ -4,7 +4,8 @@ import { BigNumber } from "@ethersproject/bignumber";
 import { Address } from "@utils/types";
 import { Account } from "@utils/test/types";
 import { ZERO } from "@utils/constants";
-import { KyberMigrationWrapAdapter, KyberNetworkTokenV2 } from "@utils/contracts";
+import { KyberMigrationWrapAdapter } from "@utils/contracts";
+import { KyberNetworkTokenV2 } from "@utils/contracts/kyber";
 import DeployHelper from "@utils/deploys";
 import {
   ether,
@@ -70,15 +71,19 @@ describe("KyberMigrationWrapAdapter", () => {
     it("should have the correct KNC Legacy token address", async () => {
       const deployKyberMigrationWrapAdapter = await subject();
 
-      const expectedKncLegacyToken = await deployKyberMigrationWrapAdapter.kncLegacyToken();
-      expect(expectedKncLegacyToken).to.eq(subjectKncLegacyToken);
+      const kncLegacyToken = await deployKyberMigrationWrapAdapter.kncLegacyToken();
+      const expectedKncLegacyToken = subjectKncLegacyToken;
+
+      expect(kncLegacyToken).to.eq(expectedKncLegacyToken);
     });
 
     it("should have the correct KNC token address", async () => {
         const deployKyberMigrationWrapAdapter = await subject();
 
-        const expectedKncToken = await deployKyberMigrationWrapAdapter.kncToken();
-        expect(expectedKncToken).to.eq(subjectKncToken);
+        const kncToken = await deployKyberMigrationWrapAdapter.kncToken();
+        const expectedKncToken = subjectKncToken;
+
+        expect(kncToken).to.eq(expectedKncToken);
     });
   });
 

--- a/utils/contracts/index.ts
+++ b/utils/contracts/index.ts
@@ -42,6 +42,7 @@ export { IssuanceModule } from "../../typechain/IssuanceModule";
 export { KyberExchangeAdapter } from "../../typechain/KyberExchangeAdapter";
 export { KyberMigrationWrapAdapter } from "../../typechain/KyberMigrationWrapAdapter";
 export { KyberNetworkProxyMock } from "../../typechain/KyberNetworkProxyMock";
+export { KyberNetworkTokenV2 } from "../../typechain/KyberNetworkTokenV2";
 export { LendToAaveMigrator } from "../../typechain/LendToAaveMigrator";
 export { ManagerIssuanceHookMock } from "../../typechain/ManagerIssuanceHookMock";
 export { ModuleBaseMock } from "../../typechain/ModuleBaseMock";

--- a/utils/contracts/index.ts
+++ b/utils/contracts/index.ts
@@ -42,7 +42,6 @@ export { IssuanceModule } from "../../typechain/IssuanceModule";
 export { KyberExchangeAdapter } from "../../typechain/KyberExchangeAdapter";
 export { KyberMigrationWrapAdapter } from "../../typechain/KyberMigrationWrapAdapter";
 export { KyberNetworkProxyMock } from "../../typechain/KyberNetworkProxyMock";
-export { KyberNetworkTokenV2 } from "../../typechain/KyberNetworkTokenV2";
 export { LendToAaveMigrator } from "../../typechain/LendToAaveMigrator";
 export { ManagerIssuanceHookMock } from "../../typechain/ManagerIssuanceHookMock";
 export { ModuleBaseMock } from "../../typechain/ModuleBaseMock";

--- a/utils/contracts/index.ts
+++ b/utils/contracts/index.ts
@@ -40,6 +40,7 @@ export { InvokeMock } from "../../typechain/InvokeMock";
 export { ISetValuer } from "../../typechain/ISetValuer";
 export { IssuanceModule } from "../../typechain/IssuanceModule";
 export { KyberExchangeAdapter } from "../../typechain/KyberExchangeAdapter";
+export { KyberMigrationWrapAdapter } from "../../typechain/KyberMigrationWrapAdapter";
 export { KyberNetworkProxyMock } from "../../typechain/KyberNetworkProxyMock";
 export { LendToAaveMigrator } from "../../typechain/LendToAaveMigrator";
 export { ManagerIssuanceHookMock } from "../../typechain/ManagerIssuanceHookMock";

--- a/utils/contracts/kyber.ts
+++ b/utils/contracts/kyber.ts
@@ -1,0 +1,2 @@
+// External Kyber contracts
+export { KyberNetworkTokenV2 } from "../../typechain/KyberNetworkTokenV2";

--- a/utils/deploys/deployAdapters.ts
+++ b/utils/deploys/deployAdapters.ts
@@ -104,11 +104,10 @@ export default class DeployAdapters {
   }
 
   public async deployKyberMigrationWrapAdapter(
-    kncLegacyToKncMigrationProxy: Address,
     kncLegacyToken: Address,
     kncToken: Address
   ): Promise<KyberMigrationWrapAdapter> {
-    return await new KyberMigrationWrapAdapter__factory(this._deployerSigner).deploy(kncLegacyToKncMigrationProxy, kncLegacyToken, kncToken);
+    return await new KyberMigrationWrapAdapter__factory(this._deployerSigner).deploy(kncLegacyToken, kncToken);
   }
 
   public async deployAaveWrapAdapter(aaveLendingPool: Address): Promise<AaveWrapAdapter> {

--- a/utils/deploys/deployAdapters.ts
+++ b/utils/deploys/deployAdapters.ts
@@ -7,6 +7,7 @@ import {
   CompoundLikeGovernanceAdapter,
   CurveStakingAdapter,
   KyberExchangeAdapter,
+  KyberMigrationWrapAdapter,
   OneInchExchangeAdapter,
   AaveMigrationWrapAdapter,
   AaveWrapAdapter,
@@ -31,6 +32,7 @@ import { BalancerV1IndexExchangeAdapter__factory } from "../../typechain/factori
 import { CompoundLikeGovernanceAdapter__factory } from "../../typechain/factories/CompoundLikeGovernanceAdapter__factory";
 import { CurveStakingAdapter__factory } from "../../typechain/factories/CurveStakingAdapter__factory";
 import { KyberExchangeAdapter__factory } from "../../typechain/factories/KyberExchangeAdapter__factory";
+import { KyberMigrationWrapAdapter__factory } from "../../typechain/factories/KyberMigrationWrapAdapter__factory";
 import { OneInchExchangeAdapter__factory } from "../../typechain/factories/OneInchExchangeAdapter__factory";
 import { ZeroExApiAdapter__factory } from "../../typechain/factories/ZeroExApiAdapter__factory";
 import { AaveMigrationWrapAdapter__factory } from "../../typechain/factories/AaveMigrationWrapAdapter__factory";
@@ -99,6 +101,14 @@ export default class DeployAdapters {
     aaveToken: Address
   ): Promise<AaveMigrationWrapAdapter> {
     return await new AaveMigrationWrapAdapter__factory(this._deployerSigner).deploy(aaveMigrationProxy, lendToken, aaveToken);
+  }
+
+  public async deployKyberMigrationWrapAdapter(
+    kncLegacyToKncMigrationProxy: Address,
+    kncLegacyToken: Address,
+    kncToken: Address
+  ): Promise<KyberMigrationWrapAdapter> {
+    return await new KyberMigrationWrapAdapter__factory(this._deployerSigner).deploy(kncLegacyToKncMigrationProxy, kncLegacyToken, kncToken);
   }
 
   public async deployAaveWrapAdapter(aaveLendingPool: Address): Promise<AaveWrapAdapter> {

--- a/utils/deploys/deployExternal.ts
+++ b/utils/deploys/deployExternal.ts
@@ -131,6 +131,9 @@ import {
 import { Registry__factory } from "../../typechain/factories/Registry__factory";
 import { Vault__factory } from "../../typechain/factories/Vault__factory";
 
+import { KyberNetworkTokenV2 } from "../../typechain/KyberNetworkTokenV2";
+import { KyberNetworkTokenV2__factory } from "../../typechain/factories/KyberNetworkTokenV2__factory";
+
 
 export default class DeployExternalContracts {
   private _deployerSigner: Signer;
@@ -540,4 +543,8 @@ export default class DeployExternalContracts {
     return await new Registry__factory(this._deployerSigner).deploy();
   }
 
+  // KYBER
+  public async deployKyberNetworkTokenV2(): Promise<KyberNetworkTokenV2> {
+    return await new KyberNetworkTokenV2__factory(this._deployerSigner).deploy();
+  }
 }

--- a/utils/deploys/deployExternal.ts
+++ b/utils/deploys/deployExternal.ts
@@ -131,7 +131,7 @@ import {
 import { Registry__factory } from "../../typechain/factories/Registry__factory";
 import { Vault__factory } from "../../typechain/factories/Vault__factory";
 
-import { KyberNetworkTokenV2 } from "../../typechain/KyberNetworkTokenV2";
+import { KyberNetworkTokenV2 } from "../contracts/kyber";
 import { KyberNetworkTokenV2__factory } from "../../typechain/factories/KyberNetworkTokenV2__factory";
 
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -510,6 +510,11 @@
     "@types/sinon-chai" "^3.2.3"
     "@types/web3" "1.0.19"
 
+"@openzeppelin/contracts-upgradeable@3.4.1":
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-3.4.1.tgz#38dfdfa86fda0a088c6fcdebe6870cfaf897b471"
+  integrity sha512-wBGlUzEkOxcj/ghtcF2yKc8ZYh+PTUtm1mK38zoENulJ6aplij7eH8quo3lMugfzPJy+V6V5qI8QhdQmCn7hkQ==
+
 "@openzeppelin/contracts@^3.1.0":
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-3.3.0.tgz#ffdb693c5c349fc33bba420248dd3ac0a2d7c408"

--- a/yarn.lock
+++ b/yarn.lock
@@ -510,11 +510,6 @@
     "@types/sinon-chai" "^3.2.3"
     "@types/web3" "1.0.19"
 
-"@openzeppelin/contracts-upgradeable@3.4.1":
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-3.4.1.tgz#38dfdfa86fda0a088c6fcdebe6870cfaf897b471"
-  integrity sha512-wBGlUzEkOxcj/ghtcF2yKc8ZYh+PTUtm1mK38zoENulJ6aplij7eH8quo3lMugfzPJy+V6V5qI8QhdQmCn7hkQ==
-
 "@openzeppelin/contracts@^3.1.0":
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-3.3.0.tgz#ffdb693c5c349fc33bba420248dd3ac0a2d7c408"


### PR DESCRIPTION
Add KNC Migration Wrap Adapter to facilitate migration from Legacy KNC tokens to new KNC tokens held within DPI.

KNC Token Migration Guide: https://blog.kyber.network/knc-token-migration-guide-fda08bfe62c2

Old KNC token contract: https://etherscan.io/token/0xdd974d5c2e2928dea5f71b9825b8b646686bd200
New KNC token contract: https://etherscan.io/token/0xdeFA4e8a7bcBA345F687a2f1456F5Edd9CE97202
Migration ratio: 1:1 (1 old KNC will be migrated to 1 new ERC-20 KNC token)

Method to be used for migration: [`mintWithOldKnc(uint256)`](https://github.com/KyberNetwork/kyber_protocol_sc/blob/4a3a961ee8c8f121cc8b48bf220daa849172275a/contracts/sol6/token/KyberNetworkTokenV2.sol#L46)
