### PR TITLE
ZeroExAdapter null recipient fix

### DIFF
--- a/test/protocol/integration/exchange/zeroExApiAdapter.spec.ts
+++ b/test/protocol/integration/exchange/zeroExApiAdapter.spec.ts
@@ -10,7 +10,7 @@ import { take } from "lodash";
 
 const expect = getWaffleExpect();
 
-describe.only("ZeroExApiAdapter", () => {
+describe("ZeroExApiAdapter", () => {
   let owner: Account;
   const sourceToken = "0x6cf5f1d59fddae3a688210953a512b6aee6ea643";
   const destToken = "0x5e5d0bea9d4a15db2d0837aff0435faba166190d";

--- a/test/protocol/modules/tradeModule.spec.ts
+++ b/test/protocol/modules/tradeModule.spec.ts
@@ -132,7 +132,7 @@ describe("TradeModule", () => {
         BigNumber.from(100000000), // 1 WBTC
         wbtcRate, // Trades for 33 WETH
     );
-    zeroExApiAdapter = await deployer.adapters.deployZeroExApiAdapter(zeroExMock.address);
+    zeroExApiAdapter = await deployer.adapters.deployZeroExApiAdapter(zeroExMock.address, setup.weth.address);
 
 
     kyberAdapterName = "KYBER";

--- a/utils/deploys/deployAdapters.ts
+++ b/utils/deploys/deployAdapters.ts
@@ -173,8 +173,8 @@ export default class DeployAdapters {
     return await new UniswapPairPriceAdapter__factory(this._deployerSigner).attach(uniswapAdapterAddress);
   }
 
-  public async deployZeroExApiAdapter(zeroExAddress: Address): Promise<ZeroExApiAdapter> {
-    return await new ZeroExApiAdapter__factory(this._deployerSigner).deploy(zeroExAddress);
+  public async deployZeroExApiAdapter(zeroExAddress: Address, wethAddress: Address): Promise<ZeroExApiAdapter> {
+    return await new ZeroExApiAdapter__factory(this._deployerSigner).deploy(zeroExAddress, wethAddress);
   }
 
   public async deploySnapshotGovernanceAdapter(delegateRegistry: Address): Promise<SnapshotGovernanceAdapter> {


### PR DESCRIPTION
- Allow any destination address if a null recipient is found in liquidity provider and uniswap v3 calldata.
- Check for prescence of WETH token in paths for uniswap v3 in ETH selling/buying calldata.
  - Pretty sure you guys don't use ETH but might as well include it for completeness.

# Code Review Processes
## New Feature Review
Before submitting a pull request for new review, make sure the following is done:
* Design doc is created and posted here: [Insert Link]
* Code cleanliness and completeness is addressed via [guidelines](https://app.gitbook.com/@setprotocol-1/s/set/smart-contract-engineering/sc-code-review-process)

README Checks
- [] README has proper context for the reviewer to understand what the code includes, any important design considerations, and areas to pay more attention to

Code Checks
- [] Add explanatory comments. If there is complex code that requires specific context or understanding, note that in a comment
- [] Remove unncessary comments. Any comments that do not add additional context, information, etc. should be removed
- [] Add javadocs. 
- [] Scrub through the code for inconsistencies (e.g. removing extra spaces)
- [] Ensure there are not any .onlys in spec files


Broader Considerations
- [] Ensure variable, function and event naming is clear, consistent, and reflective for the scope of the code.
- [] Consider if certain pieces of logic should be placed in a different library, module
