### PR TITLE
Fix broken imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@setprotocol/set-protocol-v2",
-  "version": "0.0.38",
+  "version": "0.0.39",
   "description": "",
   "main": "dist",
   "types": "dist/types",

--- a/utils/fixtures/uniswapV3Fixture.ts
+++ b/utils/fixtures/uniswapV3Fixture.ts
@@ -1,5 +1,5 @@
-import DeployHelper from "@utils/deploys";
-import { MAX_UINT_256 } from "@utils/constants";
+import DeployHelper from "../deploys";
+import { MAX_UINT_256 } from "../constants";
 import { JsonRpcProvider, Web3Provider } from "@ethersproject/providers";
 import { BigNumber, BigNumberish, Signer } from "ethers";
 import { Address } from "../types";
@@ -15,9 +15,9 @@ import {
 } from "../contracts/uniswapV3";
 
 import { UniswapV3Pool__factory } from "../../typechain/factories/UniswapV3Pool__factory";
-import { ether } from "@utils/common";
-import { StandardTokenMock } from "@typechain/StandardTokenMock";
-import { WETH9 } from "@typechain/WETH9";
+import { ether } from "../index";
+import { StandardTokenMock } from "../../typechain/StandardTokenMock";
+import { WETH9 } from "../../typechain/WETH9";
 import { parseEther } from "ethers/lib/utils";
 
 type Token = StandardTokenMock | WETH9;

--- a/utils/test/index.ts
+++ b/utils/test/index.ts
@@ -2,9 +2,8 @@
 import { ethers } from "hardhat";
 import { Address } from "../types";
 
-import { AaveFixture, BalancerFixture, CompoundFixture, CurveFixture, SystemFixture, UniswapFixture, YearnFixture } from "../fixtures";
+import { AaveFixture, BalancerFixture, CompoundFixture, CurveFixture, SystemFixture, UniswapFixture, YearnFixture, UniswapV3Fixture } from "../fixtures";
 import { Blockchain, ProtocolUtils } from "../common";
-import { UniswapV3Fixture } from "@utils/fixtures/uniswapV3Fixture";
 
 // Hardhat-Provider Aware Exports
 const provider = ethers.provider;


### PR DESCRIPTION
Some imports from the Uniswap V3 fixture caused the repo to compile fine when running standalone but failed when running as a library.
