### PR TITLE
Fix Solidity warnings

### DIFF
--- a/contracts/interfaces/external/ICErc20.sol
+++ b/contracts/interfaces/external/ICErc20.sol
@@ -12,6 +12,8 @@
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
+
+    SPDX-License-Identifier: Apache License, Version 2.0
 */
 
 pragma solidity 0.6.10;

--- a/contracts/interfaces/external/ICEth.sol
+++ b/contracts/interfaces/external/ICEth.sol
@@ -12,6 +12,8 @@
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
+
+    SPDX-License-Identifier: Apache License, Version 2.0
 */
 
 pragma solidity 0.6.10;

--- a/contracts/interfaces/external/IComptroller.sol
+++ b/contracts/interfaces/external/IComptroller.sol
@@ -12,6 +12,8 @@
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
+
+    SPDX-License-Identifier: Apache License, Version 2.0
 */
 
 pragma solidity 0.6.10;

--- a/contracts/interfaces/external/IUniswapV2Factory.sol
+++ b/contracts/interfaces/external/IUniswapV2Factory.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache License, Version 2.0
 pragma solidity 0.6.10;
 
 interface IUniswapV2Factory {

--- a/contracts/interfaces/external/IWETH.sol
+++ b/contracts/interfaces/external/IWETH.sol
@@ -12,6 +12,8 @@
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
+
+    SPDX-License-Identifier: Apache License, Version 2.0
 */
 
 pragma solidity 0.6.10;

--- a/contracts/mocks/AddressArrayUtilsMock.sol
+++ b/contracts/mocks/AddressArrayUtilsMock.sol
@@ -51,23 +51,23 @@ contract AddressArrayUtilsMock {
         return A.pop(index);
     }
 
-    function testValidatePairsWithArrayUint(address[] memory A, uint[] memory a) external view {
+    function testValidatePairsWithArrayUint(address[] memory A, uint[] memory a) external pure {
         A.validatePairsWithArray(a);
     }
 
-    function testValidatePairsWithArrayBool(address[] memory A, bool[] memory a) external view {
+    function testValidatePairsWithArrayBool(address[] memory A, bool[] memory a) external pure {
         A.validatePairsWithArray(a);
     }
 
-    function testValidatePairsWithArrayString(address[] memory A, string[] memory a) external view {
+    function testValidatePairsWithArrayString(address[] memory A, string[] memory a) external pure {
         A.validatePairsWithArray(a);
     }
 
-    function testValidatePairsWithArrayAddress(address[] memory A, address[] memory a) external view {
+    function testValidatePairsWithArrayAddress(address[] memory A, address[] memory a) external pure {
         A.validatePairsWithArray(a);
     }
 
-    function testValidatePairsWithArrayBytes(address[] memory A, bytes[] memory a) external view {
+    function testValidatePairsWithArrayBytes(address[] memory A, bytes[] memory a) external pure {
         A.validatePairsWithArray(a);
     }
 

--- a/contracts/mocks/external/ComptrollerMock.sol
+++ b/contracts/mocks/external/ComptrollerMock.sol
@@ -49,7 +49,7 @@ contract ComptrollerMock {
     }
 
     // Return empty array
-    function enterMarkets(address[] memory _cTokens) public returns (uint256[] memory) {
+    function enterMarkets(address[] memory _cTokens) public pure returns (uint256[] memory) {
         return new uint256[](_cTokens.length);
     }
 

--- a/contracts/mocks/external/SynthetixExchangerMock.sol
+++ b/contracts/mocks/external/SynthetixExchangerMock.sol
@@ -65,6 +65,7 @@ contract SynthetixExchangerMock {
         address /* destinationAddress */
     )
         external
+        view
         returns (uint256 amountReceived)
     {
 
@@ -87,6 +88,7 @@ contract SynthetixExchangerMock {
         bytes32 _destinationCurrencyKey
     )
         public
+        view
         returns (
             uint256 amountReceived,
             uint256 fee,

--- a/contracts/mocks/external/SynthetixExchangerMock.sol
+++ b/contracts/mocks/external/SynthetixExchangerMock.sol
@@ -58,11 +58,11 @@ contract SynthetixExchangerMock {
     }
 
     function exchange(
-        address from,
+        address /* from */,
         bytes32 sourceCurrencyKey,
         uint256 sourceAmount,
         bytes32 destinationCurrencyKey,
-        address destinationAddress
+        address /* destinationAddress */
     )
         external
         returns (uint256 amountReceived)

--- a/contracts/mocks/integrations/StakingAdapterMock.sol
+++ b/contracts/mocks/integrations/StakingAdapterMock.sol
@@ -66,7 +66,7 @@ contract StakingAdapterMock {
         uint256 _notionalAmount
     )
         external
-        view 
+        pure
         returns(address, uint256, bytes memory)
     {
         bytes memory callData = abi.encodeWithSignature("stake(uint256)", _notionalAmount);
@@ -78,7 +78,7 @@ contract StakingAdapterMock {
         uint256 _notionalAmount
     )
         external
-        view 
+        pure
         returns(address, uint256, bytes memory)
     {
         bytes memory callData = abi.encodeWithSignature("unstake(uint256)", _notionalAmount);

--- a/contracts/mocks/integrations/WrapAdapterMock.sol
+++ b/contracts/mocks/integrations/WrapAdapterMock.sol
@@ -79,7 +79,7 @@ contract WrapAdapterMock is ERC20 {
 
     function getUnwrapCallData(
         address _underlyingToken,
-        address _wrappedToken,
+        address /* _wrappedToken */,
         uint256 _wrappedTokenUnits
     ) external view returns (address _subject, uint256 _value, bytes memory _calldata) {
         bytes memory callData = abi.encodeWithSignature("withdraw(address,uint256)", _underlyingToken, _wrappedTokenUnits);

--- a/contracts/mocks/protocol/CustomSetValuerMock.sol
+++ b/contracts/mocks/protocol/CustomSetValuerMock.sol
@@ -42,16 +42,15 @@ contract CustomSetValuerMock is ISetValuer {
      * Gets the valuation of a SetToken using data from the price oracle. Reverts
      * if no price exists for a component in the SetToken. Note: this works for external
      * positions and negative (debt) positions.
-     * 
+     *
      * Note: There is a risk that the valuation is off if airdrops aren't retrieved or
      * debt builds up via interest and its not reflected in the position
      *
-     * @param _setToken        SetToken instance to get valuation
      * @param _quoteAsset      Address of token to quote valuation in
      *
      * @return                 SetToken valuation in terms of quote asset in precise units 1e18
      */
-    function calculateSetTokenValuation(ISetToken _setToken, address _quoteAsset) external view override returns (uint256) {
+    function calculateSetTokenValuation(ISetToken /* _setToken */, address _quoteAsset) external view override returns (uint256) {
         return valuation[_quoteAsset];
     }
 }

--- a/contracts/mocks/protocol/module/DebtModuleMock.sol
+++ b/contracts/mocks/protocol/module/DebtModuleMock.sol
@@ -1,3 +1,21 @@
+/*
+    Copyright 2021 Set Labs Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    SPDX-License-Identifier: Apache License, Version 2.0
+*/
+
 pragma solidity 0.6.10;
 pragma experimental "ABIEncoderV2";
 
@@ -37,7 +55,7 @@ contract DebtModuleMock is ModuleBase {
 
     function moduleIssueHook(ISetToken /*_setToken*/, uint256 /*_setTokenQuantity*/) external { moduleIssueHookCalled = true; }
     function moduleRedeemHook(ISetToken /*_setToken*/, uint256 /*_setTokenQuantity*/) external { moduleRedeemHookCalled = true; }
-    
+
     function componentIssueHook(
         ISetToken _setToken,
         uint256 _setTokenQuantity,

--- a/contracts/protocol-viewers/ERC20Viewer.sol
+++ b/contracts/protocol-viewers/ERC20Viewer.sol
@@ -1,14 +1,19 @@
 /*
     Copyright 2021 Set Labs Inc.
+
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
+
+    SPDX-License-Identifier: Apache License, Version 2.0
 */
 pragma solidity 0.6.10;
 
@@ -41,7 +46,7 @@ contract ERC20Viewer {
     {
         // Cache length of addresses to fetch balances for
         uint256 addressesCount = _tokenAddresses.length;
-        
+
         // Instantiate output array in memory
         uint256[] memory balances = new uint256[](addressesCount);
 
@@ -72,7 +77,7 @@ contract ERC20Viewer {
     {
         // Cache length of addresses to fetch allowances for
         uint256 addressesCount = _tokenAddresses.length;
-        
+
         // Instantiate output array in memory
         uint256[] memory allowances = new uint256[](addressesCount);
 

--- a/contracts/protocol/integration/exchange/UniswapV2ExchangeAdapterV2.sol
+++ b/contracts/protocol/integration/exchange/UniswapV2ExchangeAdapterV2.sol
@@ -62,8 +62,6 @@ contract UniswapV2ExchangeAdapterV2 {
      * Note: When selecting the swap for exact tokens function, _sourceQuantity is defined as the max token quantity you are willing to trade, and
      * _minDestinationQuantity is the exact quantity of token you are receiving.
      *
-     * @param  _sourceToken              Address of source token to be sold
-     * @param  _destinationToken         Address of destination token to buy
      * @param  _destinationAddress       Address that assets should be transferred to
      * @param  _sourceQuantity           Fixed/Max amount of source token to sell
      * @param  _destinationQuantity      Min/Fixed amount of destination token to buy
@@ -74,8 +72,8 @@ contract UniswapV2ExchangeAdapterV2 {
      * @return bytes                     Trade calldata
      */
     function getTradeCalldata(
-        address _sourceToken,
-        address _destinationToken,
+        address /* _sourceToken */,
+        address /* _destinationToken */,
         address _destinationAddress,
         uint256 _sourceQuantity,
         uint256 _destinationQuantity,
@@ -84,7 +82,7 @@ contract UniswapV2ExchangeAdapterV2 {
         external
         view
         returns (address, uint256, bytes memory)
-    {   
+    {
         (
             address[] memory path,
             bool shouldSwapExactTokensForTokens
@@ -104,16 +102,16 @@ contract UniswapV2ExchangeAdapterV2 {
     /**
      * Generate data parameter to be passed to `getTradeCallData`. Returns encoded trade paths and bool to select trade function.
      *
-     * @param _sourceToken          Address of the source token to be sold        
+     * @param _sourceToken          Address of the source token to be sold
      * @param _destinationToken     Address of the destination token to buy
      * @param _fixIn                Boolean representing if input tokens amount is fixed
-     * 
-     * @return bytes                Data parameter to be passed to `getTradeCallData`          
+     *
+     * @return bytes                Data parameter to be passed to `getTradeCallData`
      */
     function generateDataParam(address _sourceToken, address _destinationToken, bool _fixIn)
         external
         pure
-        returns (bytes memory) 
+        returns (bytes memory)
     {
         address[] memory path = new address[](2);
         path[0] = _sourceToken;
@@ -138,4 +136,4 @@ contract UniswapV2ExchangeAdapterV2 {
     function getUniswapExchangeData(address[] memory _path, bool _shouldSwapExactTokensForTokens) external pure returns (bytes memory) {
         return abi.encode(_path, _shouldSwapExactTokensForTokens);
     }
-} 
+}

--- a/contracts/protocol/integration/governance/AaveGovernanceAdapter.sol
+++ b/contracts/protocol/integration/governance/AaveGovernanceAdapter.sol
@@ -84,28 +84,28 @@ contract AaveGovernanceAdapter {
     /**
      * Reverts as AAVE currently does not have a delegation mechanism in governance
      */
-    function getDelegateCalldata(address /* _delegatee */) external view returns (address, uint256, bytes memory) {
+    function getDelegateCalldata(address /* _delegatee */) external pure returns (address, uint256, bytes memory) {
         revert("No delegation available in AAVE governance");
     }
 
     /**
      * Reverts as AAVE currently does not have a register mechanism in governance
      */
-    function getRegisterCalldata(address /* _setToken */) external view returns (address, uint256, bytes memory) {
+    function getRegisterCalldata(address /* _setToken */) external pure returns (address, uint256, bytes memory) {
         revert("No register available in AAVE governance");
     }
 
     /**
      * Reverts as AAVE currently does not have a revoke mechanism in governance
      */
-    function getRevokeCalldata() external view returns (address, uint256, bytes memory) {
+    function getRevokeCalldata() external pure returns (address, uint256, bytes memory) {
         revert("No revoke available in AAVE governance");
     }
 
     /**
      * Reverts as creating a proposal is only available to AAVE genesis team
      */
-    function getProposeCalldata(bytes memory /* _proposalData */) external view returns (address, uint256, bytes memory) {
+    function getProposeCalldata(bytes memory /* _proposalData */) external pure returns (address, uint256, bytes memory) {
         revert("Creation of new proposal only available to AAVE genesis team");
     }
 }

--- a/contracts/protocol/integration/governance/AaveGovernanceV2Adapter.sol
+++ b/contracts/protocol/integration/governance/AaveGovernanceV2Adapter.sol
@@ -132,14 +132,14 @@ contract AaveGovernanceV2Adapter {
     /**
      * Reverts as AAVE currently does not have a register mechanism in governance
      */
-    function getRegisterCalldata(address /* _setToken */) external view returns (address, uint256, bytes memory) {
+    function getRegisterCalldata(address /* _setToken */) external pure returns (address, uint256, bytes memory) {
         revert("No register available in AAVE governance");
     }
 
     /**
      * Reverts as AAVE currently does not have a revoke mechanism in governance
      */
-    function getRevokeCalldata() external view returns (address, uint256, bytes memory) {
+    function getRevokeCalldata() external pure returns (address, uint256, bytes memory) {
         revert("No revoke available in AAVE governance");
     }
 }

--- a/contracts/protocol/integration/index-exchange/UniswapV3IndexExchangeAdapter.sol
+++ b/contracts/protocol/integration/index-exchange/UniswapV3IndexExchangeAdapter.sol
@@ -34,14 +34,14 @@ import { IIndexExchangeAdapter } from "../../../interfaces/IIndexExchangeAdapter
 contract UniswapV3IndexExchangeAdapter is IIndexExchangeAdapter {
 
     using BytesLib for bytes;
-    
+
     /* ============ Constants ============ */
 
     // Uniswap router function string for swapping exact amount of input tokens for a minimum of output tokens
     string internal constant SWAP_EXACT_INPUT = "exactInputSingle((address,address,uint24,address,uint256,uint256,uint256,uint160))";
     // Uniswap router function string for swapping max amoutn of input tokens for an exact amount of output tokens
     string internal constant SWAP_EXACT_OUTPUT = "exactOutputSingle((address,address,uint24,address,uint256,uint256,uint256,uint160))";
-    
+
     /* ============ State Variables ============ */
 
     // Address of Uniswap V3 SwapRouter contract
@@ -61,16 +61,16 @@ contract UniswapV3IndexExchangeAdapter is IIndexExchangeAdapter {
     /* ============ External Getter Functions ============ */
 
     /**
-     * Return calldata for trading with Uniswap V3 SwapRouter. Trade paths are created from _sourceToken, 
-     * _destinationToken and pool fees (which is encoded in _data). 
+     * Return calldata for trading with Uniswap V3 SwapRouter. Trade paths are created from _sourceToken,
+     * _destinationToken and pool fees (which is encoded in _data).
      *
      * ---------------------------------------------------------------------------------------------------------------
      *   _isSendTokenFixed   |     Parameter             |       Amount                                              |
      * ---------------------------------------------------------------------------------------------------------------
-     *      True             |   _sourceQuantity         |   Fixed amount of _sourceToken to trade                   |        
+     *      True             |   _sourceQuantity         |   Fixed amount of _sourceToken to trade                   |
      *                       |   _destinationQuantity    |   Minimum amount of _destinationToken willing to receive  |
      * ---------------------------------------------------------------------------------------------------------------
-     *      False            |   _sourceQuantity         |   Maximum amount of _sourceToken to trade                 |        
+     *      False            |   _sourceQuantity         |   Maximum amount of _sourceToken to trade                 |
      *                       |   _destinationQuantity    |   Fixed amount of _destinationToken want to receive       |
      * ---------------------------------------------------------------------------------------------------------------
      *
@@ -80,11 +80,11 @@ contract UniswapV3IndexExchangeAdapter is IIndexExchangeAdapter {
      * @param _isSendTokenFixed         Boolean indicating if the send quantity is fixed, used to determine correct trade interface
      * @param _sourceQuantity           Fixed/Max amount of source token to sell
      * @param _destinationQuantity      Min/Fixed amount of destination token to buy
-     * @param _data                     Arbitrary bytes containing fees value, expressed in hundredths of a bip, 
+     * @param _data                     Arbitrary bytes containing fees value, expressed in hundredths of a bip,
      *                                  used to determine the pool to trade among similar asset pools on Uniswap V3.
-     *                                  Note: SetToken manager must set the appropriate pool fees via `setExchangeData` in GeneralIndexModule 
-     *                                  for each component that needs to be traded on UniswapV3. This is different from UniswapV3ExchangeAdapter, 
-     *                                  where `_data` represents UniswapV3 trade path vs just the pool fees percentage. 
+     *                                  Note: SetToken manager must set the appropriate pool fees via `setExchangeData` in GeneralIndexModule
+     *                                  for each component that needs to be traded on UniswapV3. This is different from UniswapV3ExchangeAdapter,
+     *                                  where `_data` represents UniswapV3 trade path vs just the pool fees percentage.
      *
      * @return address                  Target contract address
      * @return uint256                  Call value
@@ -103,36 +103,36 @@ contract UniswapV3IndexExchangeAdapter is IIndexExchangeAdapter {
         view
         override
         returns (address, uint256, bytes memory)
-    {   
+    {
         uint24 fee = _data.toUint24(0);
-        
+
         bytes memory callData = _isSendTokenFixed
             ? abi.encodeWithSignature(
                 SWAP_EXACT_INPUT,
                 ISwapRouter.ExactInputSingleParams(
-                    _sourceToken, 
-                    _destinationToken, 
-                    fee, 
-                    _destinationAddress, 
-                    block.timestamp, 
-                    _sourceQuantity, 
-                    _destinationQuantity, 
+                    _sourceToken,
+                    _destinationToken,
+                    fee,
+                    _destinationAddress,
+                    block.timestamp,
+                    _sourceQuantity,
+                    _destinationQuantity,
                     0
                 )
             ) : abi.encodeWithSignature(
-                SWAP_EXACT_OUTPUT,                
+                SWAP_EXACT_OUTPUT,
                 ISwapRouter.ExactOutputSingleParams(
-                    _sourceToken, 
-                    _destinationToken, 
-                    fee, 
+                    _sourceToken,
+                    _destinationToken,
+                    fee,
                     _destinationAddress,
                     block.timestamp,
-                    _destinationQuantity, 
+                    _destinationQuantity,
                     _sourceQuantity,
                     0
                 )
             );
-        
+
         return (router, 0, callData);
     }
 
@@ -152,7 +152,7 @@ contract UniswapV3IndexExchangeAdapter is IIndexExchangeAdapter {
      *
      * @return bytes               Encoded fee value
      */
-    function getEncodedFeeData(uint24 fee) external view returns (bytes memory) {
+    function getEncodedFeeData(uint24 fee) external pure returns (bytes memory) {
         return abi.encodePacked(fee);
     }
-} 
+}

--- a/contracts/protocol/integration/oracles/CTokenOracle.sol
+++ b/contracts/protocol/integration/oracles/CTokenOracle.sol
@@ -1,14 +1,19 @@
 /*
     Copyright 2021 Set Labs Inc.
+
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
+
+    SPDX-License-Identifier: Apache License, Version 2.0
 */
 
 pragma solidity 0.6.10;

--- a/contracts/protocol/integration/oracles/YearnVaultOracle.sol
+++ b/contracts/protocol/integration/oracles/YearnVaultOracle.sol
@@ -1,14 +1,19 @@
 /*
     Copyright 2021 Set Labs Inc.
+
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
+
+    SPDX-License-Identifier: Apache License, Version 2.0
 */
 
 pragma solidity 0.6.10;

--- a/contracts/protocol/integration/staking/CurveStakingAdapter.sol
+++ b/contracts/protocol/integration/staking/CurveStakingAdapter.sol
@@ -97,7 +97,7 @@ contract CurveStakingAdapter {
      *
      * @return address                  Address of the contract to approve tokens transfers to
      */
-    function getSpenderAddress(address _stakingContract) external view returns(address) {
+    function getSpenderAddress(address _stakingContract) external pure returns(address) {
         return _stakingContract;
     }
 

--- a/contracts/protocol/integration/wrap/AaveMigrationWrapAdapter.sol
+++ b/contracts/protocol/integration/wrap/AaveMigrationWrapAdapter.sol
@@ -103,7 +103,7 @@ contract AaveMigrationWrapAdapter {
         uint256 /* _wrappedTokenUnits */
     )
         external
-        view
+        pure
         returns (address, uint256, bytes memory)
     {
         revert("AAVE migration cannot be reversed");

--- a/contracts/protocol/integration/wrap/CompoundWrapAdapter.sol
+++ b/contracts/protocol/integration/wrap/CompoundWrapAdapter.sol
@@ -75,7 +75,6 @@ contract CompoundWrapAdapter {
     /**
      * Generates the calldata to unwrap a wrapped asset into its underlying.
      *
-     * @param _underlyingToken      Address of the underlying asset
      * @param _wrappedToken         Address of the component to be unwrapped
      * @param _wrappedTokenUnits    Total quantity of wrapped token units to unwrap
      *
@@ -84,7 +83,7 @@ contract CompoundWrapAdapter {
      * @return bytes                Unwrap calldata
      */
     function getUnwrapCallData(
-        address _underlyingToken,
+        address /* _underlyingToken */,
         address _wrappedToken,
         uint256 _wrappedTokenUnits
     )

--- a/contracts/protocol/integration/wrap/CompoundWrapAdapter.sol
+++ b/contracts/protocol/integration/wrap/CompoundWrapAdapter.sol
@@ -56,7 +56,7 @@ contract CompoundWrapAdapter {
         uint256 _underlyingUnits
     )
         external
-        view
+        pure
         returns (address, uint256, bytes memory)
     {
         uint256 value;
@@ -88,7 +88,7 @@ contract CompoundWrapAdapter {
         uint256 _wrappedTokenUnits
     )
         external
-        view
+        pure
         returns (address, uint256, bytes memory)
     {
         ( , , bytes memory callData) = ICErc20(_wrappedToken).getRedeemCalldata(_wrappedTokenUnits);
@@ -100,7 +100,7 @@ contract CompoundWrapAdapter {
      * @param _wrappedToken         Address of the wrapped token
      * @return address              Address of the contract to approve tokens to
      */
-     function getSpenderAddress(address /* _underlyingToken */, address _wrappedToken) external view returns(address) {
+     function getSpenderAddress(address /* _underlyingToken */, address _wrappedToken) external pure returns(address) {
          return address(_wrappedToken);
      }
 

--- a/contracts/protocol/integration/wrap/YearnWrapAdapter.sol
+++ b/contracts/protocol/integration/wrap/YearnWrapAdapter.sol
@@ -100,7 +100,7 @@ contract YearnWrapAdapter {
      *
      * @return address        Address of the contract to approve tokens to
      */
-    function getSpenderAddress(address /* _underlyingToken */, address  _wrappedToken) external view returns(address) {
+    function getSpenderAddress(address /* _underlyingToken */, address  _wrappedToken) external pure returns(address) {
         return address(_wrappedToken);
     }
 

--- a/contracts/protocol/modules/CompoundLeverageModule.sol
+++ b/contracts/protocol/modules/CompoundLeverageModule.sol
@@ -37,7 +37,7 @@ import { ModuleBase } from "../lib/ModuleBase.sol";
  * @author Set Protocol
  *
  * Smart contract that enables leverage trading using Compound as the lending protocol. This module is paired with a debt issuance module that will call
- * functions on this module to keep interest accrual and liquidation state updated. This does not allow borrowing of assets from Compound alone. Each 
+ * functions on this module to keep interest accrual and liquidation state updated. This does not allow borrowing of assets from Compound alone. Each
  * asset is leveraged when using this module.
  *
  * Note: Do not use this module in conjunction with other debt modules that allow Compound debt positions as it could lead to double counting of
@@ -106,7 +106,7 @@ contract CompoundLeverageModule is ModuleBase, ReentrancyGuard, Ownable {
     );
 
     event AnySetAllowedUpdated(
-        bool indexed _anySetAllowed    
+        bool indexed _anySetAllowed
     );
 
     /* ============ Constants ============ */
@@ -155,7 +155,7 @@ contract CompoundLeverageModule is ModuleBase, ReentrancyGuard, Ownable {
 
     /**
      * Instantiate addresses. Underlying to cToken mapping is created.
-     * 
+     *
      * @param _controller               Address of controller contract
      * @param _compToken                Address of COMP token
      * @param _comptroller              Address of Compound Comptroller
@@ -214,7 +214,7 @@ contract CompoundLeverageModule is ModuleBase, ReentrancyGuard, Ownable {
         nonReentrant
         onlyManagerAndValidSet(_setToken)
     {
-        // For levering up, send quantity is derived from borrow asset and receive quantity is derived from 
+        // For levering up, send quantity is derived from borrow asset and receive quantity is derived from
         // collateral asset
         ActionInfo memory leverInfo = _createAndValidateActionInfo(
             _setToken,
@@ -273,7 +273,7 @@ contract CompoundLeverageModule is ModuleBase, ReentrancyGuard, Ownable {
         nonReentrant
         onlyManagerAndValidSet(_setToken)
     {
-        // Note: for delevering, send quantity is derived from collateral asset and receive quantity is derived from 
+        // Note: for delevering, send quantity is derived from collateral asset and receive quantity is derived from
         // repay asset
         ActionInfo memory deleverInfo = _createAndValidateActionInfo(
             _setToken,
@@ -332,7 +332,7 @@ contract CompoundLeverageModule is ModuleBase, ReentrancyGuard, Ownable {
         onlyManagerAndValidSet(_setToken)
     {
         uint256 notionalRedeemQuantity = _redeemQuantity.preciseMul(_setToken.totalSupply());
-        
+
         require(borrowCTokenEnabled[_setToken][underlyingToCToken[_repayAsset]], "Borrow not enabled");
         uint256 notionalRepayQuantity = underlyingToCToken[_repayAsset].borrowBalanceCurrent(address(_setToken));
 
@@ -348,7 +348,7 @@ contract CompoundLeverageModule is ModuleBase, ReentrancyGuard, Ownable {
 
         _redeemUnderlying(deleverInfo.setToken, deleverInfo.collateralCTokenAsset, deleverInfo.notionalSendQuantity);
 
-        uint256 postTradeReceiveQuantity = _executeTrade(deleverInfo, _collateralAsset, _repayAsset, _tradeData);
+        _executeTrade(deleverInfo, _collateralAsset, _repayAsset, _tradeData);
 
         // We use notionalRepayQuantity vs. Compound's max value uint256(-1) to handle WETH properly
         _repayBorrow(deleverInfo.setToken, deleverInfo.borrowCTokenAsset, _repayAsset, notionalRepayQuantity);
@@ -374,7 +374,7 @@ contract CompoundLeverageModule is ModuleBase, ReentrancyGuard, Ownable {
     }
 
     /**
-     * CALLABLE BY ANYBODY: Sync Set positions with enabled Compound collateral and borrow positions. For collateral 
+     * CALLABLE BY ANYBODY: Sync Set positions with enabled Compound collateral and borrow positions. For collateral
      * assets, update cToken default position. For borrow assets, update external borrow position.
      * - Collateral assets may come out of sync when a position is liquidated
      * - Borrow assets may come out of sync when interest is accrued or position is liquidated and borrow is repaid
@@ -457,7 +457,7 @@ contract CompoundLeverageModule is ModuleBase, ReentrancyGuard, Ownable {
         for(uint256 i = 0; i < modules.length; i++) {
             try IDebtIssuanceModule(modules[i]).registerToIssuanceModule(_setToken) {} catch {}
         }
-        
+
         // Enable collateral and borrow assets on Compound
         addCollateralAssets(_setToken, _collateralAssets);
 
@@ -495,7 +495,7 @@ contract CompoundLeverageModule is ModuleBase, ReentrancyGuard, Ownable {
 
             delete collateralCTokenEnabled[setToken][cToken];
         }
-        
+
         delete enabledAssets[setToken];
 
         // Try if unregister exists on any of the modules
@@ -557,7 +557,7 @@ contract CompoundLeverageModule is ModuleBase, ReentrancyGuard, Ownable {
         for(uint256 i = 0; i < _collateralAssets.length; i++) {
             ICErc20 cToken = underlyingToCToken[_collateralAssets[i]];
             require(collateralCTokenEnabled[_setToken][cToken], "Collateral not enabled");
-            
+
             // Note: Will only exit market if cToken is not enabled as a borrow asset as well
             // If there is an existing borrow balance, will revert and market cannot be exited on Compound
             if (!borrowCTokenEnabled[_setToken][cToken]) {
@@ -611,7 +611,7 @@ contract CompoundLeverageModule is ModuleBase, ReentrancyGuard, Ownable {
         for(uint256 i = 0; i < _borrowAssets.length; i++) {
             ICErc20 cToken = underlyingToCToken[_borrowAssets[i]];
             require(borrowCTokenEnabled[_setToken][cToken], "Borrow not enabled");
-            
+
             // Note: Will only exit market if cToken is not enabled as a collateral asset as well
             // If there is an existing borrow balance, will revert and market cannot be exited on Compound
             if (!collateralCTokenEnabled[_setToken][cToken]) {
@@ -649,7 +649,7 @@ contract CompoundLeverageModule is ModuleBase, ReentrancyGuard, Ownable {
     /**
      * GOVERNANCE ONLY: Add Compound market to module with stored underlying to cToken mapping in case of market additions to Compound.
      *
-     * IMPORTANT: Validations are skipped in order to get contract under bytecode limit 
+     * IMPORTANT: Validations are skipped in order to get contract under bytecode limit
      *
      * @param _cToken                   Address of cToken to add
      * @param _underlying               Address of underlying token that maps to cToken
@@ -662,7 +662,7 @@ contract CompoundLeverageModule is ModuleBase, ReentrancyGuard, Ownable {
     /**
      * GOVERNANCE ONLY: Remove Compound market on stored underlying to cToken mapping in case of market removals
      *
-     * IMPORTANT: Validations are skipped in order to get contract under bytecode limit 
+     * IMPORTANT: Validations are skipped in order to get contract under bytecode limit
      *
      * @param _underlying               Address of underlying token to remove
      */
@@ -744,7 +744,7 @@ contract CompoundLeverageModule is ModuleBase, ReentrancyGuard, Ownable {
     /* ============ Internal Functions ============ */
 
     /**
-     * Mints the specified cToken from the underlying of the specified notional quantity. If cEther, the WETH must be 
+     * Mints the specified cToken from the underlying of the specified notional quantity. If cEther, the WETH must be
      * unwrapped as it only accepts the underlying ETH.
      */
     function _mintCToken(ISetToken _setToken, ICErc20 _cToken, IERC20 _underlyingToken, uint256 _mintNotional) internal {
@@ -847,7 +847,7 @@ contract CompoundLeverageModule is ModuleBase, ReentrancyGuard, Ownable {
      */
     function _accrueProtocolFee(ISetToken _setToken, IERC20 _receiveToken, uint256 _exchangedQuantity) internal returns(uint256) {
         uint256 protocolFeeTotal = getModuleFee(PROTOCOL_TRADE_FEE_INDEX, _exchangedQuantity);
-        
+
         payProtocolFeeFromSetToken(_setToken, address(_receiveToken), protocolFeeTotal);
 
         return protocolFeeTotal;

--- a/contracts/protocol/modules/CustomOracleNAVIssuanceModule.sol
+++ b/contracts/protocol/modules/CustomOracleNAVIssuanceModule.sol
@@ -122,7 +122,7 @@ contract CustomOracleNavIssuanceModule is ModuleBase, ReentrancyGuard {
         uint256 premiumPercentage;                     // Premium percentage (0.01% = 1e14, 1% = 1e16). This premium is a buffer around oracle
                                                        // prices paid by user to the SetToken, which prevents arbitrage and oracle front running
         uint256 maxPremiumPercentage;                  // Maximum premium percentage manager is allowed to set (configured by manager)
-        uint256 minSetTokenSupply;                     // Minimum SetToken supply required for issuance and redemption 
+        uint256 minSetTokenSupply;                     // Minimum SetToken supply required for issuance and redemption
                                                        // to prevent dramatic inflationary changes to the SetToken's position multiplier
     }
 
@@ -148,7 +148,7 @@ contract CustomOracleNavIssuanceModule is ModuleBase, ReentrancyGuard {
 
     // Mapping of SetToken to NAV issuance settings struct
     mapping(ISetToken => NAVIssuanceSettings) public navIssuanceSettings;
-    
+
     // Mapping to efficiently check a SetToken's reserve asset validity
     // SetToken => reserveAsset => isReserveAsset
     mapping(ISetToken => mapping(address => bool)) public isReserveAsset;
@@ -184,7 +184,7 @@ contract CustomOracleNavIssuanceModule is ModuleBase, ReentrancyGuard {
     }
 
     /* ============ External Functions ============ */
-    
+
     /**
      * Deposits the allowed reserve asset into the SetToken and mints the appropriate % of Net Asset Value of the SetToken
      * to the specified _to address.
@@ -201,13 +201,13 @@ contract CustomOracleNavIssuanceModule is ModuleBase, ReentrancyGuard {
         uint256 _reserveAssetQuantity,
         uint256 _minSetTokenReceiveQuantity,
         address _to
-    ) 
+    )
         external
         nonReentrant
         onlyValidAndInitializedSet(_setToken)
     {
         _validateCommon(_setToken, _reserveAsset, _reserveAssetQuantity);
-        
+
         _callPreIssueHooks(_setToken, _reserveAsset, _reserveAssetQuantity, msg.sender, _to);
 
         ActionInfo memory issueInfo = _createIssuanceInfo(_setToken, _reserveAsset, _reserveAssetQuantity);
@@ -231,7 +231,7 @@ contract CustomOracleNavIssuanceModule is ModuleBase, ReentrancyGuard {
         ISetToken _setToken,
         uint256 _minSetTokenReceiveQuantity,
         address _to
-    ) 
+    )
         external
         payable
         nonReentrant
@@ -240,7 +240,7 @@ contract CustomOracleNavIssuanceModule is ModuleBase, ReentrancyGuard {
         weth.deposit{ value: msg.value }();
 
         _validateCommon(_setToken, address(weth), msg.value);
-        
+
         _callPreIssueHooks(_setToken, address(weth), msg.value, msg.sender, _to);
 
         ActionInfo memory issueInfo = _createIssuanceInfo(_setToken, address(weth), msg.value);
@@ -268,7 +268,7 @@ contract CustomOracleNavIssuanceModule is ModuleBase, ReentrancyGuard {
         uint256 _setTokenQuantity,
         uint256 _minReserveReceiveQuantity,
         address _to
-    ) 
+    )
         external
         nonReentrant
         onlyValidAndInitializedSet(_setToken)
@@ -279,7 +279,7 @@ contract CustomOracleNavIssuanceModule is ModuleBase, ReentrancyGuard {
 
         ActionInfo memory redeemInfo = _createRedemptionInfo(_setToken, _reserveAsset, _setTokenQuantity);
 
-        _validateRedemptionInfo(_setToken, _minReserveReceiveQuantity, _setTokenQuantity, redeemInfo);
+        _validateRedemptionInfo(_setToken, _minReserveReceiveQuantity, redeemInfo);
 
         _setToken.burn(msg.sender, _setTokenQuantity);
 
@@ -309,7 +309,7 @@ contract CustomOracleNavIssuanceModule is ModuleBase, ReentrancyGuard {
         uint256 _setTokenQuantity,
         uint256 _minReserveReceiveQuantity,
         address payable _to
-    ) 
+    )
         external
         nonReentrant
         onlyValidAndInitializedSet(_setToken)
@@ -320,7 +320,7 @@ contract CustomOracleNavIssuanceModule is ModuleBase, ReentrancyGuard {
 
         ActionInfo memory redeemInfo = _createRedemptionInfo(_setToken, address(weth), _setTokenQuantity);
 
-        _validateRedemptionInfo(_setToken, _minReserveReceiveQuantity, _setTokenQuantity, redeemInfo);
+        _validateRedemptionInfo(_setToken, _minReserveReceiveQuantity, redeemInfo);
 
         _setToken.burn(msg.sender, _setTokenQuantity);
 
@@ -332,7 +332,7 @@ contract CustomOracleNavIssuanceModule is ModuleBase, ReentrancyGuard {
         );
 
         weth.withdraw(redeemInfo.netFlowQuantity);
-        
+
         _to.transfer(redeemInfo.netFlowQuantity);
 
         _handleRedemptionFees(_setToken, address(weth), redeemInfo);
@@ -348,7 +348,7 @@ contract CustomOracleNavIssuanceModule is ModuleBase, ReentrancyGuard {
      */
     function addReserveAsset(ISetToken _setToken, address _reserveAsset) external onlyManagerAndValidSet(_setToken) {
         require(!isReserveAsset[_setToken][_reserveAsset], "Reserve asset already exists");
-        
+
         navIssuanceSettings[_setToken].reserveAssets.push(_reserveAsset);
         isReserveAsset[_setToken][_reserveAsset] = true;
 
@@ -378,7 +378,7 @@ contract CustomOracleNavIssuanceModule is ModuleBase, ReentrancyGuard {
      */
     function editPremium(ISetToken _setToken, uint256 _premiumPercentage) external onlyManagerAndValidSet(_setToken) {
         require(_premiumPercentage <= navIssuanceSettings[_setToken].maxPremiumPercentage, "Premium must be less than maximum allowed");
-        
+
         navIssuanceSettings[_setToken].premiumPercentage = _premiumPercentage;
 
         emit PremiumEdited(_setToken, _premiumPercentage);
@@ -400,7 +400,7 @@ contract CustomOracleNavIssuanceModule is ModuleBase, ReentrancyGuard {
         onlyManagerAndValidSet(_setToken)
     {
         require(_managerFeePercentage <= navIssuanceSettings[_setToken].maxManagerFee, "Manager fee must be less than maximum allowed");
-        
+
         navIssuanceSettings[_setToken].managerFees[_managerFeeIndex] = _managerFeePercentage;
 
         emit ManagerFeeEdited(_setToken, _managerFeePercentage, _managerFeeIndex);
@@ -414,7 +414,7 @@ contract CustomOracleNavIssuanceModule is ModuleBase, ReentrancyGuard {
      */
     function editFeeRecipient(ISetToken _setToken, address _managerFeeRecipient) external onlyManagerAndValidSet(_setToken) {
         require(_managerFeeRecipient != address(0), "Fee recipient must not be 0 address");
-        
+
         navIssuanceSettings[_setToken].feeRecipient = _managerFeeRecipient;
 
         emit FeeRecipientEdited(_setToken, _managerFeeRecipient);
@@ -465,7 +465,7 @@ contract CustomOracleNavIssuanceModule is ModuleBase, ReentrancyGuard {
         for (uint256 i = 0; i < navIssuanceSettings[setToken].reserveAssets.length; i++) {
             delete isReserveAsset[setToken][navIssuanceSettings[setToken].reserveAssets[i]];
         }
-        
+
         delete navIssuanceSettings[setToken];
     }
 
@@ -661,7 +661,6 @@ contract CustomOracleNavIssuanceModule is ModuleBase, ReentrancyGuard {
     function _validateRedemptionInfo(
         ISetToken _setToken,
         uint256 _minReserveReceiveQuantity,
-        uint256 _setTokenQuantity,
         ActionInfo memory _redeemInfo
     )
         internal
@@ -782,7 +781,7 @@ contract CustomOracleNavIssuanceModule is ModuleBase, ReentrancyGuard {
         address _reserveAsset,
         address _to,
         ActionInfo memory _issueInfo
-    ) 
+    )
         internal
     {
         _setToken.editPositionMultiplier(_issueInfo.newPositionMultiplier);
@@ -800,7 +799,7 @@ contract CustomOracleNavIssuanceModule is ModuleBase, ReentrancyGuard {
             _issueInfo.setTokenQuantity,
             _issueInfo.managerFee,
             _issueInfo.protocolFees
-        );        
+        );
     }
 
     function _handleRedeemStateUpdates(
@@ -808,7 +807,7 @@ contract CustomOracleNavIssuanceModule is ModuleBase, ReentrancyGuard {
         address _reserveAsset,
         address _to,
         ActionInfo memory _redeemInfo
-    ) 
+    )
         internal
     {
         _setToken.editPositionMultiplier(_redeemInfo.newPositionMultiplier);
@@ -824,7 +823,7 @@ contract CustomOracleNavIssuanceModule is ModuleBase, ReentrancyGuard {
             _redeemInfo.setTokenQuantity,
             _redeemInfo.managerFee,
             _redeemInfo.protocolFees
-        );      
+        );
     }
 
     function _handleRedemptionFees(ISetToken _setToken, address _reserveAsset, ActionInfo memory _redeemInfo) internal {
@@ -932,7 +931,7 @@ contract CustomOracleNavIssuanceModule is ModuleBase, ReentrancyGuard {
         uint256 protocolDirectFeePercent = controller.getModuleFee(address(this), _protocolDirectFeeIndex);
         uint256 protocolManagerShareFeePercent = controller.getModuleFee(address(this), _protocolManagerFeeIndex);
         uint256 managerFeePercent = navIssuanceSettings[_setToken].managerFees[_managerFeeIndex];
-        
+
         // Calculate revenue share split percentage
         uint256 protocolRevenueSharePercentage = protocolManagerShareFeePercent.preciseMul(managerFeePercent);
         uint256 managerRevenueSharePercentage = managerFeePercent.sub(protocolRevenueSharePercentage);
@@ -997,7 +996,7 @@ contract CustomOracleNavIssuanceModule is ModuleBase, ReentrancyGuard {
      * The new position multiplier is calculated as follows:
      * inflationPercentage = (newSupply - oldSupply) / newSupply
      * newMultiplier = (1 - inflationPercentage) * positionMultiplier
-     */    
+     */
     function _getIssuePositionMultiplier(
         ISetToken _setToken,
         ActionInfo memory _issueInfo
@@ -1017,11 +1016,11 @@ contract CustomOracleNavIssuanceModule is ModuleBase, ReentrancyGuard {
 
     /**
      * Calculate deflation and new position multiplier. Note: Round deflation down in order to round position multiplier down
-     * 
+     *
      * The new position multiplier is calculated as follows:
      * deflationPercentage = (oldSupply - newSupply) / newSupply
      * newMultiplier = (1 + deflationPercentage) * positionMultiplier
-     */ 
+     */
     function _getRedeemPositionMultiplier(
         ISetToken _setToken,
         uint256 _setTokenQuantity,
@@ -1043,7 +1042,7 @@ contract CustomOracleNavIssuanceModule is ModuleBase, ReentrancyGuard {
      * The new position reserve asset unit is calculated as follows:
      * totalReserve = (oldUnit * oldSetTokenSupply) + reserveQuantity
      * newUnit = totalReserve / newSetTokenSupply
-     */ 
+     */
     function _getIssuePositionUnit(
         ISetToken _setToken,
         address _reserveAsset,
@@ -1065,7 +1064,7 @@ contract CustomOracleNavIssuanceModule is ModuleBase, ReentrancyGuard {
      * The new position reserve asset unit is calculated as follows:
      * totalReserve = (oldUnit * oldSetTokenSupply) - reserveQuantityToSendOut
      * newUnit = totalReserve / newSetTokenSupply
-     */ 
+     */
     function _getRedeemPositionUnit(
         ISetToken _setToken,
         address _reserveAsset,

--- a/contracts/protocol/modules/NAVIssuanceModule.sol
+++ b/contracts/protocol/modules/NAVIssuanceModule.sol
@@ -121,7 +121,7 @@ contract NavIssuanceModule is ModuleBase, ReentrancyGuard {
         uint256 premiumPercentage;                     // Premium percentage (0.01% = 1e14, 1% = 1e16). This premium is a buffer around oracle
                                                        // prices paid by user to the SetToken, which prevents arbitrage and oracle front running
         uint256 maxPremiumPercentage;                  // Maximum premium percentage manager is allowed to set (configured by manager)
-        uint256 minSetTokenSupply;                     // Minimum SetToken supply required for issuance and redemption 
+        uint256 minSetTokenSupply;                     // Minimum SetToken supply required for issuance and redemption
                                                        // to prevent dramatic inflationary changes to the SetToken's position multiplier
     }
 
@@ -147,7 +147,7 @@ contract NavIssuanceModule is ModuleBase, ReentrancyGuard {
 
     // Mapping of SetToken to NAV issuance settings struct
     mapping(ISetToken => NAVIssuanceSettings) public navIssuanceSettings;
-    
+
     // Mapping to efficiently check a SetToken's reserve asset validity
     // SetToken => reserveAsset => isReserveAsset
     mapping(ISetToken => mapping(address => bool)) public isReserveAsset;
@@ -183,7 +183,7 @@ contract NavIssuanceModule is ModuleBase, ReentrancyGuard {
     }
 
     /* ============ External Functions ============ */
-    
+
     /**
      * Deposits the allowed reserve asset into the SetToken and mints the appropriate % of Net Asset Value of the SetToken
      * to the specified _to address.
@@ -200,13 +200,13 @@ contract NavIssuanceModule is ModuleBase, ReentrancyGuard {
         uint256 _reserveAssetQuantity,
         uint256 _minSetTokenReceiveQuantity,
         address _to
-    ) 
+    )
         external
         nonReentrant
         onlyValidAndInitializedSet(_setToken)
     {
         _validateCommon(_setToken, _reserveAsset, _reserveAssetQuantity);
-        
+
         _callPreIssueHooks(_setToken, _reserveAsset, _reserveAssetQuantity, msg.sender, _to);
 
         ActionInfo memory issueInfo = _createIssuanceInfo(_setToken, _reserveAsset, _reserveAssetQuantity);
@@ -230,7 +230,7 @@ contract NavIssuanceModule is ModuleBase, ReentrancyGuard {
         ISetToken _setToken,
         uint256 _minSetTokenReceiveQuantity,
         address _to
-    ) 
+    )
         external
         payable
         nonReentrant
@@ -239,7 +239,7 @@ contract NavIssuanceModule is ModuleBase, ReentrancyGuard {
         weth.deposit{ value: msg.value }();
 
         _validateCommon(_setToken, address(weth), msg.value);
-        
+
         _callPreIssueHooks(_setToken, address(weth), msg.value, msg.sender, _to);
 
         ActionInfo memory issueInfo = _createIssuanceInfo(_setToken, address(weth), msg.value);
@@ -267,7 +267,7 @@ contract NavIssuanceModule is ModuleBase, ReentrancyGuard {
         uint256 _setTokenQuantity,
         uint256 _minReserveReceiveQuantity,
         address _to
-    ) 
+    )
         external
         nonReentrant
         onlyValidAndInitializedSet(_setToken)
@@ -278,7 +278,7 @@ contract NavIssuanceModule is ModuleBase, ReentrancyGuard {
 
         ActionInfo memory redeemInfo = _createRedemptionInfo(_setToken, _reserveAsset, _setTokenQuantity);
 
-        _validateRedemptionInfo(_setToken, _minReserveReceiveQuantity, _setTokenQuantity, redeemInfo);
+        _validateRedemptionInfo(_setToken, _minReserveReceiveQuantity, redeemInfo);
 
         _setToken.burn(msg.sender, _setTokenQuantity);
 
@@ -308,7 +308,7 @@ contract NavIssuanceModule is ModuleBase, ReentrancyGuard {
         uint256 _setTokenQuantity,
         uint256 _minReserveReceiveQuantity,
         address payable _to
-    ) 
+    )
         external
         nonReentrant
         onlyValidAndInitializedSet(_setToken)
@@ -319,7 +319,7 @@ contract NavIssuanceModule is ModuleBase, ReentrancyGuard {
 
         ActionInfo memory redeemInfo = _createRedemptionInfo(_setToken, address(weth), _setTokenQuantity);
 
-        _validateRedemptionInfo(_setToken, _minReserveReceiveQuantity, _setTokenQuantity, redeemInfo);
+        _validateRedemptionInfo(_setToken, _minReserveReceiveQuantity, redeemInfo);
 
         _setToken.burn(msg.sender, _setTokenQuantity);
 
@@ -331,7 +331,7 @@ contract NavIssuanceModule is ModuleBase, ReentrancyGuard {
         );
 
         weth.withdraw(redeemInfo.netFlowQuantity);
-        
+
         _to.transfer(redeemInfo.netFlowQuantity);
 
         _handleRedemptionFees(_setToken, address(weth), redeemInfo);
@@ -347,7 +347,7 @@ contract NavIssuanceModule is ModuleBase, ReentrancyGuard {
      */
     function addReserveAsset(ISetToken _setToken, address _reserveAsset) external onlyManagerAndValidSet(_setToken) {
         require(!isReserveAsset[_setToken][_reserveAsset], "Reserve asset already exists");
-        
+
         navIssuanceSettings[_setToken].reserveAssets.push(_reserveAsset);
         isReserveAsset[_setToken][_reserveAsset] = true;
 
@@ -377,7 +377,7 @@ contract NavIssuanceModule is ModuleBase, ReentrancyGuard {
      */
     function editPremium(ISetToken _setToken, uint256 _premiumPercentage) external onlyManagerAndValidSet(_setToken) {
         require(_premiumPercentage <= navIssuanceSettings[_setToken].maxPremiumPercentage, "Premium must be less than maximum allowed");
-        
+
         navIssuanceSettings[_setToken].premiumPercentage = _premiumPercentage;
 
         emit PremiumEdited(_setToken, _premiumPercentage);
@@ -399,7 +399,7 @@ contract NavIssuanceModule is ModuleBase, ReentrancyGuard {
         onlyManagerAndValidSet(_setToken)
     {
         require(_managerFeePercentage <= navIssuanceSettings[_setToken].maxManagerFee, "Manager fee must be less than maximum allowed");
-        
+
         navIssuanceSettings[_setToken].managerFees[_managerFeeIndex] = _managerFeePercentage;
 
         emit ManagerFeeEdited(_setToken, _managerFeePercentage, _managerFeeIndex);
@@ -413,7 +413,7 @@ contract NavIssuanceModule is ModuleBase, ReentrancyGuard {
      */
     function editFeeRecipient(ISetToken _setToken, address _managerFeeRecipient) external onlyManagerAndValidSet(_setToken) {
         require(_managerFeeRecipient != address(0), "Fee recipient must not be 0 address");
-        
+
         navIssuanceSettings[_setToken].feeRecipient = _managerFeeRecipient;
 
         emit FeeRecipientEdited(_setToken, _managerFeeRecipient);
@@ -464,7 +464,7 @@ contract NavIssuanceModule is ModuleBase, ReentrancyGuard {
         for (uint256 i = 0; i < navIssuanceSettings[setToken].reserveAssets.length; i++) {
             delete isReserveAsset[setToken][navIssuanceSettings[setToken].reserveAssets[i]];
         }
-        
+
         delete navIssuanceSettings[setToken];
     }
 
@@ -660,7 +660,6 @@ contract NavIssuanceModule is ModuleBase, ReentrancyGuard {
     function _validateRedemptionInfo(
         ISetToken _setToken,
         uint256 _minReserveReceiveQuantity,
-        uint256 _setTokenQuantity,
         ActionInfo memory _redeemInfo
     )
         internal
@@ -781,7 +780,7 @@ contract NavIssuanceModule is ModuleBase, ReentrancyGuard {
         address _reserveAsset,
         address _to,
         ActionInfo memory _issueInfo
-    ) 
+    )
         internal
     {
         _setToken.editPositionMultiplier(_issueInfo.newPositionMultiplier);
@@ -799,7 +798,7 @@ contract NavIssuanceModule is ModuleBase, ReentrancyGuard {
             _issueInfo.setTokenQuantity,
             _issueInfo.managerFee,
             _issueInfo.protocolFees
-        );        
+        );
     }
 
     function _handleRedeemStateUpdates(
@@ -807,7 +806,7 @@ contract NavIssuanceModule is ModuleBase, ReentrancyGuard {
         address _reserveAsset,
         address _to,
         ActionInfo memory _redeemInfo
-    ) 
+    )
         internal
     {
         _setToken.editPositionMultiplier(_redeemInfo.newPositionMultiplier);
@@ -823,7 +822,7 @@ contract NavIssuanceModule is ModuleBase, ReentrancyGuard {
             _redeemInfo.setTokenQuantity,
             _redeemInfo.managerFee,
             _redeemInfo.protocolFees
-        );      
+        );
     }
 
     function _handleRedemptionFees(ISetToken _setToken, address _reserveAsset, ActionInfo memory _redeemInfo) internal {
@@ -931,7 +930,7 @@ contract NavIssuanceModule is ModuleBase, ReentrancyGuard {
         uint256 protocolDirectFeePercent = controller.getModuleFee(address(this), _protocolDirectFeeIndex);
         uint256 protocolManagerShareFeePercent = controller.getModuleFee(address(this), _protocolManagerFeeIndex);
         uint256 managerFeePercent = navIssuanceSettings[_setToken].managerFees[_managerFeeIndex];
-        
+
         // Calculate revenue share split percentage
         uint256 protocolRevenueSharePercentage = protocolManagerShareFeePercent.preciseMul(managerFeePercent);
         uint256 managerRevenueSharePercentage = managerFeePercent.sub(protocolRevenueSharePercentage);
@@ -995,7 +994,7 @@ contract NavIssuanceModule is ModuleBase, ReentrancyGuard {
      * The new position multiplier is calculated as follows:
      * inflationPercentage = (newSupply - oldSupply) / newSupply
      * newMultiplier = (1 - inflationPercentage) * positionMultiplier
-     */    
+     */
     function _getIssuePositionMultiplier(
         ISetToken _setToken,
         ActionInfo memory _issueInfo
@@ -1015,11 +1014,11 @@ contract NavIssuanceModule is ModuleBase, ReentrancyGuard {
 
     /**
      * Calculate deflation and new position multiplier. Note: Round deflation down in order to round position multiplier down
-     * 
+     *
      * The new position multiplier is calculated as follows:
      * deflationPercentage = (oldSupply - newSupply) / newSupply
      * newMultiplier = (1 + deflationPercentage) * positionMultiplier
-     */ 
+     */
     function _getRedeemPositionMultiplier(
         ISetToken _setToken,
         uint256 _setTokenQuantity,
@@ -1041,7 +1040,7 @@ contract NavIssuanceModule is ModuleBase, ReentrancyGuard {
      * The new position reserve asset unit is calculated as follows:
      * totalReserve = (oldUnit * oldSetTokenSupply) + reserveQuantity
      * newUnit = totalReserve / newSetTokenSupply
-     */ 
+     */
     function _getIssuePositionUnit(
         ISetToken _setToken,
         address _reserveAsset,
@@ -1063,7 +1062,7 @@ contract NavIssuanceModule is ModuleBase, ReentrancyGuard {
      * The new position reserve asset unit is calculated as follows:
      * totalReserve = (oldUnit * oldSetTokenSupply) - reserveQuantityToSendOut
      * newUnit = totalReserve / newSetTokenSupply
-     */ 
+     */
     function _getRedeemPositionUnit(
         ISetToken _setToken,
         address _reserveAsset,

--- a/external/contracts/uniswap/v2/lib/UniswapV2Library.sol
+++ b/external/contracts/uniswap/v2/lib/UniswapV2Library.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache License, Version 2.0
 pragma solidity 0.6.10;
 
 import "../../../../../contracts/interfaces/external/IUniswapV2Pair.sol";

--- a/external/contracts/yearn/BaseStrategy.sol
+++ b/external/contracts/yearn/BaseStrategy.sol
@@ -217,6 +217,9 @@ abstract contract BaseStrategy {
      *  Locked (TVL) calculation across it's ecosystem.
      */
     function delegatedAssets() external virtual view returns (uint256) {
+        // silence state mutability warning without generating bytecode
+        // see https://github.com/ethereum/solidity/issues/2691
+        this;
         return 0;
     }
 
@@ -579,7 +582,7 @@ abstract contract BaseStrategy {
      *  time.
      * @return `true` if `tend()` should be called, `false` otherwise.
      */
-    function tendTrigger(uint256 /* callCost */) public virtual view returns (bool) {
+    function tendTrigger(uint256 /* callCost */) public virtual pure returns (bool) {
         // We usually don't need tend, but if there are positions that need
         // active maintainence, overriding this function is how you would
         // signal for that.

--- a/external/contracts/yearn/BaseStrategy.sol
+++ b/external/contracts/yearn/BaseStrategy.sol
@@ -577,10 +577,9 @@ abstract contract BaseStrategy {
      *
      *  This call and `harvestTrigger()` should never return `true` at the same
      *  time.
-     * @param callCost The keeper's estimated cast cost to call `tend()`.
      * @return `true` if `tend()` should be called, `false` otherwise.
      */
-    function tendTrigger(uint256 callCost) public virtual view returns (bool) {
+    function tendTrigger(uint256 /* callCost */) public virtual view returns (bool) {
         // We usually don't need tend, but if there are positions that need
         // active maintainence, overriding this function is how you would
         // signal for that.


### PR DESCRIPTION
Preliminary step for upgrading Solidity at some point in the future. It's common for warnings to become errors at the solc version increases. 

Removes a few dozen warnings, in 3 categories. 

+ Missing SPDX license id 
+ state mutability can be restricted to pure or view (mostly in mocks and adapters)
+ unused parameters

Only changes that touch logic are in 
+ 788d040 where a `NavIssuance` module internal method has an unused parameter
+ 34e6e76 where an unused local variable assignment is made in `CompoundLeverageModule`

(Also removed a lot of trailing whitespace here ... there's a bit of noise in the diff unfortunately)
