### PR TITLE
Replace Telegram link with Discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ npm install @setprotocol/set-protocol-v2
 [23]: https://www.npmjs.com/package/typechain
 
 ## Contributing
-We highly encourage participation from the community to help shape the development of Set. If you are interested in developing on top of Set Protocol or have any questions, please ping us on [Telegram](https://t.me/joinchat/Fx8D6wyprLUlM1jMVnaRdg).
+We highly encourage participation from the community to help shape the development of Set. If you are interested in developing on top of Set Protocol or have any questions, please ping us on [Discord](discord.gg/ZWY66aR).
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ npm install @setprotocol/set-protocol-v2
 [23]: https://www.npmjs.com/package/typechain
 
 ## Contributing
-We highly encourage participation from the community to help shape the development of Set. If you are interested in developing on top of Set Protocol or have any questions, please ping us on [Discord](discord.gg/ZWY66aR).
+We highly encourage participation from the community to help shape the development of Set. If you are interested in developing on top of Set Protocol or have any questions, please ping us on [Discord](https://discord.gg/ZWY66aR).
 
 ## Security
 


### PR DESCRIPTION
According to the pinned message in the Telegram group, Telegram is deprecated in favor of Discord

<img width="1123" alt="Screen Shot 2021-09-06 at 11 06 29 PM" src="https://user-images.githubusercontent.com/3699047/132278103-993a1a51-d51c-4a28-be2c-ec9503a04756.png">
