### PR TITLE
Publish 0.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@setprotocol/set-protocol-v2",
-  "version": "0.0.54",
+  "version": "0.1.0",
   "description": "",
   "main": "dist",
   "types": "dist/types",


### PR DESCRIPTION
Updating version a full (minor) step because this release has breaking changes for anyone consuming the typechain artifacts. 

They're now generated using `@typechain/hardhat` and support the latest ethers (5.4.6)

To import ambient type definitions (.d.ts) from this package you must now pull directly from the typechain folder external to `dist`, e.g
```ts
import { Controller } from "@setprotocol/set-protocol-v2/typechain"
```

Factories are still transpiled to JS in the `dist` though. 
