### PR TITLE
Replace @ethersproject imports with ethers

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,12 +49,6 @@
   "author": "felix2feng",
   "license": "MIT",
   "homepage": "https://github.com/SetProtocol",
-  "resolutions": {
-    "@ethersproject/abi": "5.4.1",
-    "@ethersproject/bignumber": "5.4.1",
-    "@ethersproject/contracts": "5.4.1",
-    "@ethersproject/providers": "5.4.5"
-  },
   "devDependencies": {
     "@0x/utils": "^6.4.3",
     "@nomiclabs/hardhat-ethers": "^2.0.2",

--- a/test/fixtures/aaveV2.spec.ts
+++ b/test/fixtures/aaveV2.spec.ts
@@ -8,7 +8,7 @@ import {
   getAaveV2Fixture
 } from "@utils/test/index";
 import { SystemFixture, AaveV2Fixture } from "@utils/fixtures";
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 import { ether } from "@utils/common";
 
 const expect = getWaffleExpect();

--- a/test/fixtures/curve.spec.ts
+++ b/test/fixtures/curve.spec.ts
@@ -16,7 +16,7 @@ import {
 import { CurveFixture } from "@utils/fixtures";
 import { StandardTokenMock } from "../../typechain/StandardTokenMock";
 import { ZERO } from "@utils/constants";
-import { BigNumber, BigNumberish } from "@ethersproject/bignumber";
+import { BigNumber, BigNumberish } from "ethers";
 import { LiquidityGauge } from "@typechain/LiquidityGauge";
 
 const expect = getWaffleExpect();

--- a/test/fixtures/kyberV3DMM.spec.ts
+++ b/test/fixtures/kyberV3DMM.spec.ts
@@ -13,7 +13,7 @@ import {
 } from "@utils/test/index";
 import { SystemFixture, KyberV3DMMFixture } from "@utils/fixtures";
 import { ZERO, MAX_UINT_256 } from "@utils/constants";
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 import { Address } from "@utils/types";
 import { DMMPool } from "../../typechain/DMMPool";
 

--- a/test/fixtures/uniswap.spec.ts
+++ b/test/fixtures/uniswap.spec.ts
@@ -13,7 +13,7 @@ import {
 } from "@utils/test/index";
 import { SystemFixture, UniswapFixture } from "@utils/fixtures";
 import { ZERO, MAX_UINT_256 } from "@utils/constants";
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 
 const expect = getWaffleExpect();
 

--- a/test/integration/aaveGovernanceModule.spec.ts
+++ b/test/integration/aaveGovernanceModule.spec.ts
@@ -1,7 +1,5 @@
 import "module-alias/register";
-import { BigNumber } from "ethers";
-import { keccak256 } from "ethers/lib/utils";
-import { utils.defaultAbiCoder } from "ethers/lib/utils";
+import { utils, BigNumber } from "ethers";
 
 import { Address, Bytes } from "@utils/types";
 import { Account } from "@utils/test/types";
@@ -104,8 +102,8 @@ describe("AaveGovernanceModule", () => {
 
       beforeEach(async () => {
         await aaveSetup.aaveProtoGovernance.newProposal(
-          keccak256(new Buffer("ProposalOne")),
-          keccak256(new Buffer("RandomIPFSHash")),
+          utils.keccak256(new Buffer("ProposalOne")),
+          utils.keccak256(new Buffer("RandomIPFSHash")),
           ether(13000000),
           await getRandomAddress(),
           1660,

--- a/test/integration/aaveGovernanceModule.spec.ts
+++ b/test/integration/aaveGovernanceModule.spec.ts
@@ -1,7 +1,7 @@
 import "module-alias/register";
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 import { keccak256 } from "ethers/lib/utils";
-import { defaultAbiCoder } from "ethers/lib/utils";
+import { utils.defaultAbiCoder } from "ethers/lib/utils";
 
 import { Address, Bytes } from "@utils/types";
 import { Account } from "@utils/test/types";
@@ -145,7 +145,7 @@ describe("AaveGovernanceModule", () => {
 
       describe("when voting with another supported token", () => {
         beforeEach(async () => {
-          subjectData = defaultAbiCoder.encode(
+          subjectData = utils.defaultAbiCoder.encode(
             ["address"],
             [aaveSetup.lendToken.address]
           );

--- a/test/integration/aaveGovernanceV2Module.spec.ts
+++ b/test/integration/aaveGovernanceV2Module.spec.ts
@@ -1,6 +1,6 @@
 import "module-alias/register";
 import { BigNumber } from "ethers";
-import { utils.defaultAbiCoder } from "ethers/lib/utils";
+import { utils } from "ethers";
 
 import { Address, Bytes } from "@utils/types";
 import { Account } from "@utils/test/types";

--- a/test/integration/aaveGovernanceV2Module.spec.ts
+++ b/test/integration/aaveGovernanceV2Module.spec.ts
@@ -1,6 +1,6 @@
 import "module-alias/register";
-import { BigNumber } from "@ethersproject/bignumber";
-import { defaultAbiCoder } from "ethers/lib/utils";
+import { BigNumber } from "ethers";
+import { utils.defaultAbiCoder } from "ethers/lib/utils";
 
 import { Address, Bytes } from "@utils/types";
 import { Account } from "@utils/test/types";
@@ -184,7 +184,7 @@ describe("AaveGovernanceV2Module", () => {
         subjectCaller = owner;
         subjectSetToken = setToken;
         subjectGovernanceIntegrationName = aaveGovernanceV2AdapterIntegrationName;
-        subjectProposalData = defaultAbiCoder.encode(
+        subjectProposalData = utils.defaultAbiCoder.encode(
           ["address", "address[]", "uint256[]", "string[]", "bytes[]", "bool[]", "bytes32"],
           [aaveSetup.executor.address, targets, values, signatures, calldatas, withDelegateCall, ipfsHash]
         );

--- a/test/integration/aaveMigrationWrapModule.spec.ts
+++ b/test/integration/aaveMigrationWrapModule.spec.ts
@@ -1,5 +1,5 @@
 import "module-alias/register";
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 
 import { Address } from "@utils/types";
 import { Account } from "@utils/test/types";

--- a/test/integration/aaveUniswapLeverageDebtIssuance.spec.ts
+++ b/test/integration/aaveUniswapLeverageDebtIssuance.spec.ts
@@ -32,7 +32,7 @@ import {
   getUniswapFixture
 } from "@utils/test/index";
 import { AaveV2Fixture, SystemFixture, UniswapFixture } from "@utils/fixtures";
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 import { ADDRESS_ZERO, ZERO, EMPTY_BYTES, MAX_UINT_256 } from "@utils/constants";
 
 const expect = getWaffleExpect();

--- a/test/integration/aaveWrapModule.spec.ts
+++ b/test/integration/aaveWrapModule.spec.ts
@@ -1,5 +1,5 @@
 import "module-alias/register";
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 
 import { Address } from "@utils/types";
 import { Account } from "@utils/test/types";

--- a/test/integration/agiMigrationWrapModule.spec.ts
+++ b/test/integration/agiMigrationWrapModule.spec.ts
@@ -1,5 +1,5 @@
 import "module-alias/register";
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 
 import { Address } from "@utils/types";
 import { Account } from "@utils/test/types";

--- a/test/integration/ammSplitterGeneralIndexModule.spec.ts
+++ b/test/integration/ammSplitterGeneralIndexModule.spec.ts
@@ -1,5 +1,5 @@
 import "module-alias/register";
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 
 import { Address } from "@utils/types";
 import { Account } from "@utils/test/types";

--- a/test/integration/ammSplitterTradeModule.spec.ts
+++ b/test/integration/ammSplitterTradeModule.spec.ts
@@ -1,6 +1,6 @@
 import "module-alias/register";
-import { BigNumber } from "@ethersproject/bignumber";
-import { defaultAbiCoder } from "ethers/lib/utils";
+import { BigNumber } from "ethers";
+import { utils.defaultAbiCoder } from "ethers/lib/utils";
 import { ethers } from "hardhat";
 
 import { Address, Bytes } from "@utils/types";
@@ -286,7 +286,7 @@ describe("AMMSplitterTradeModule", () => {
 
             subjectDestinationToken = setup.dai.address;
             const tradePath = [subjectSourceToken, setup.weth.address, subjectDestinationToken];
-            subjectData = defaultAbiCoder.encode(
+            subjectData = utils.defaultAbiCoder.encode(
               ["address[]"],
               [tradePath]
             );

--- a/test/integration/ammSplitterTradeModule.spec.ts
+++ b/test/integration/ammSplitterTradeModule.spec.ts
@@ -1,6 +1,5 @@
 import "module-alias/register";
-import { BigNumber } from "ethers";
-import { utils.defaultAbiCoder } from "ethers/lib/utils";
+import { BigNumber, utils } from "ethers";
 import { ethers } from "hardhat";
 
 import { Address, Bytes } from "@utils/types";

--- a/test/integration/claim/compClaimAdapter.spec.ts
+++ b/test/integration/claim/compClaimAdapter.spec.ts
@@ -1,6 +1,7 @@
 import "module-alias/register";
 import { waffle } from "hardhat";
 import { Contract, BigNumber } from "ethers";
+import { MockContract } from "@ethereum-waffle/mock-contract";
 import { Address } from "@utils/types";
 import { Account } from "@utils/test/types";
 import { ADDRESS_ZERO } from "@utils/constants";
@@ -29,6 +30,7 @@ describe("CompClaimAdapter", function() {
   let compoundAdmin: Account;
   let deployer: DeployHelper;
   let comptroller: Contract;
+  let mockComptroller: MockContract;
   let compClaimAdapter: CompClaimAdapter;
 
   before(async function() {
@@ -43,7 +45,7 @@ describe("CompClaimAdapter", function() {
   context("unit tests", async function() {
 
     before(async function() {
-      comptroller = await deployMockContract(owner.wallet, ComptrollerArtifact.abi);
+      mockComptroller = await deployMockContract(owner.wallet, ComptrollerArtifact.abi);
       compClaimAdapter = await deployer.adapters.deployCompClaimAdapter(comptroller.address);
     });
 
@@ -51,7 +53,7 @@ describe("CompClaimAdapter", function() {
       let claimCallData: string;
 
       before(function() {
-        claimCallData = comptroller.interface.encodeFunctionData("claimComp(address)", [ADDRESS_ZERO]);
+        claimCallData = mockComptroller.interface.encodeFunctionData("claimComp(address)", [ADDRESS_ZERO]);
       });
 
       function subject(): Promise<[Address, BigNumber, string]> {
@@ -71,7 +73,7 @@ describe("CompClaimAdapter", function() {
       const rewards: BigNumber = ether(1);
 
       before(async function() {
-        await comptroller.mock.compAccrued.returns(rewards);
+        await mockComptroller.mock.compAccrued.returns(rewards);
       });
 
       function subject(): Promise<BigNumber> {
@@ -85,7 +87,7 @@ describe("CompClaimAdapter", function() {
 
     describe("#getTokenAddress", async function() {
       before(async function() {
-        await comptroller.mock.getCompAddress.returns(ADDRESS_ZERO);
+        await mockComptroller.mock.getCompAddress.returns(ADDRESS_ZERO);
       });
 
       function subject(): Promise<Address> {

--- a/test/integration/claim/compClaimAdapter.spec.ts
+++ b/test/integration/claim/compClaimAdapter.spec.ts
@@ -46,7 +46,7 @@ describe("CompClaimAdapter", function() {
 
     before(async function() {
       mockComptroller = await deployMockContract(owner.wallet, ComptrollerArtifact.abi);
-      compClaimAdapter = await deployer.adapters.deployCompClaimAdapter(comptroller.address);
+      compClaimAdapter = await deployer.adapters.deployCompClaimAdapter(mockComptroller.address);
     });
 
     describe("#getClaimCallData", async function() {
@@ -63,7 +63,7 @@ describe("CompClaimAdapter", function() {
       it("should return claim callData", async function() {
         const callData = await subject();
 
-        expect(callData[0]).to.eq(comptroller.address);
+        expect(callData[0]).to.eq(mockComptroller.address);
         expect(callData[1]).to.eq(ether(0));
         expect(callData[2]).to.eq(claimCallData);
       });
@@ -178,7 +178,14 @@ describe("CompClaimAdapter", function() {
       });
 
       it("should claim accrued amount", async function() {
-        await expect(subject).to.changeTokenBalance(comp, setToken, amount);
+        const initialCompBalance = await comp.balanceOf(setToken.address);
+
+        await subject();
+
+        const finalCompBalance = await comp.balanceOf(setToken.address);
+        const expectedBalance = initialCompBalance.add(amount);
+
+        expect(finalCompBalance).to.equal(expectedBalance);
       });
     });
   });

--- a/test/integration/compoundBravoGovernanceModule.spec.ts
+++ b/test/integration/compoundBravoGovernanceModule.spec.ts
@@ -1,6 +1,6 @@
 import "module-alias/register";
-import { BigNumber } from "@ethersproject/bignumber";
-import { defaultAbiCoder } from "ethers/lib/utils";
+import { BigNumber } from "ethers";
+import { utils.defaultAbiCoder } from "ethers/lib/utils";
 
 import { Address, Bytes } from "@utils/types";
 import { Account } from "@utils/test/types";
@@ -120,7 +120,7 @@ describe("CompoundBravoGovernanceModule", () => {
 
         subjectSetToken = setToken.address;
         subjectIntegrationName = compoundBravoGovernanceAdapterIntegrationName;
-        subjectProposalData = defaultAbiCoder.encode(
+        subjectProposalData = utils.defaultAbiCoder.encode(
           ["address[]", "uint256[]", "string[]", "bytes[]", "string"],
           [targets, values, signatures, calldatas, description]
         );
@@ -165,7 +165,7 @@ describe("CompoundBravoGovernanceModule", () => {
           "0x00000000000000000000000000000000000000000000000002c68af0bb140000",
         ];
         const description = "Create A Proposal";
-        const proposalData = defaultAbiCoder.encode(
+        const proposalData = utils.defaultAbiCoder.encode(
           ["address[]", "uint256[]", "string[]", "bytes[]", "string"],
           [targets, values, signatures, calldatas, description]
         );

--- a/test/integration/compoundBravoGovernanceModule.spec.ts
+++ b/test/integration/compoundBravoGovernanceModule.spec.ts
@@ -1,6 +1,5 @@
 import "module-alias/register";
-import { BigNumber } from "ethers";
-import { utils.defaultAbiCoder } from "ethers/lib/utils";
+import { BigNumber, utils } from "ethers";
 
 import { Address, Bytes } from "@utils/types";
 import { Account } from "@utils/test/types";

--- a/test/integration/compoundGovernanceModule.spec.ts
+++ b/test/integration/compoundGovernanceModule.spec.ts
@@ -1,6 +1,5 @@
 import "module-alias/register";
-import { BigNumber } from "ethers";
-import { utils.defaultAbiCoder } from "ethers/lib/utils";
+import { BigNumber, utils } from "ethers";
 
 import { Address, Bytes } from "@utils/types";
 import { Account } from "@utils/test/types";

--- a/test/integration/compoundGovernanceModule.spec.ts
+++ b/test/integration/compoundGovernanceModule.spec.ts
@@ -1,6 +1,6 @@
 import "module-alias/register";
-import { BigNumber } from "@ethersproject/bignumber";
-import { defaultAbiCoder } from "ethers/lib/utils";
+import { BigNumber } from "ethers";
+import { utils.defaultAbiCoder } from "ethers/lib/utils";
 
 import { Address, Bytes } from "@utils/types";
 import { Account } from "@utils/test/types";
@@ -119,7 +119,7 @@ describe("CompoundGovernanceModule", () => {
 
         subjectSetToken = setToken.address;
         subjectIntegrationName = compoundLikeGovernanceAdapterIntegrationName;
-        subjectProposalData = defaultAbiCoder.encode(
+        subjectProposalData = utils.defaultAbiCoder.encode(
           ["address[]", "uint256[]", "string[]", "bytes[]", "string"],
           [targets, values, signatures, calldatas, description]
         );
@@ -162,7 +162,7 @@ describe("CompoundGovernanceModule", () => {
           "0x00000000000000000000000000000000000000000000000002c68af0bb140000",
         ];
         const description = "Create A Proposal";
-        const proposalData = defaultAbiCoder.encode(
+        const proposalData = utils.defaultAbiCoder.encode(
           ["address[]", "uint256[]", "string[]", "bytes[]", "string"],
           [targets, values, signatures, calldatas, description]
         );

--- a/test/integration/compoundUniswapLeverageDebtIssuance.spec.ts
+++ b/test/integration/compoundUniswapLeverageDebtIssuance.spec.ts
@@ -29,7 +29,7 @@ import {
   getUniswapFixture,
 } from "@utils/test/index";
 import { CompoundFixture, SystemFixture, UniswapFixture } from "@utils/fixtures";
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 import { ADDRESS_ZERO, ZERO, EMPTY_BYTES, MAX_UINT_256 } from "@utils/constants";
 
 const expect = getWaffleExpect();

--- a/test/integration/compoundWrapModule.spec.ts
+++ b/test/integration/compoundWrapModule.spec.ts
@@ -1,5 +1,5 @@
 import "module-alias/register";
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 
 import { Address } from "@utils/types";
 import { Account } from "@utils/test/types";

--- a/test/integration/curveStakingModule.spec.ts
+++ b/test/integration/curveStakingModule.spec.ts
@@ -1,5 +1,5 @@
 import "module-alias/register";
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 
 import { Address } from "@utils/types";
 import { Account } from "@utils/test/types";

--- a/test/integration/oracles/cTokenOracle.spec.ts
+++ b/test/integration/oracles/cTokenOracle.spec.ts
@@ -1,5 +1,5 @@
 import "module-alias/register";
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 
 import { Address } from "@utils/types";
 import { Account } from "@utils/test/types";

--- a/test/integration/oracles/yearnVaultOracle.spec.ts
+++ b/test/integration/oracles/yearnVaultOracle.spec.ts
@@ -1,5 +1,5 @@
 import "module-alias/register";
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 
 import { Address } from "@utils/types";
 import { Account } from "@utils/test/types";

--- a/test/integration/sushiswapExchangeTradeModule.spec.ts
+++ b/test/integration/sushiswapExchangeTradeModule.spec.ts
@@ -1,6 +1,6 @@
 import "module-alias/register";
 
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 import { ethers } from "hardhat";
 
 import { Address, Bytes } from "@utils/types";

--- a/test/integration/uniswapGovernanceModule.spec.ts
+++ b/test/integration/uniswapGovernanceModule.spec.ts
@@ -1,6 +1,5 @@
 import "module-alias/register";
-import { BigNumber } from "ethers";
-import { utils.defaultAbiCoder } from "ethers/lib/utils";
+import { BigNumber, utils } from "ethers";
 
 import { Address, Bytes } from "@utils/types";
 import { Account } from "@utils/test/types";

--- a/test/integration/uniswapGovernanceModule.spec.ts
+++ b/test/integration/uniswapGovernanceModule.spec.ts
@@ -1,6 +1,6 @@
 import "module-alias/register";
-import { BigNumber } from "@ethersproject/bignumber";
-import { defaultAbiCoder } from "ethers/lib/utils";
+import { BigNumber } from "ethers";
+import { utils.defaultAbiCoder } from "ethers/lib/utils";
 
 import { Address, Bytes } from "@utils/types";
 import { Account } from "@utils/test/types";
@@ -119,7 +119,7 @@ describe("UniswapGovernanceModule", () => {
 
         subjectSetToken = setToken.address;
         subjectIntegrationName = compoundLikeGovernanceAdapterIntegrationName;
-        subjectProposalData = defaultAbiCoder.encode(
+        subjectProposalData = utils.defaultAbiCoder.encode(
           ["address[]", "uint256[]", "string[]", "bytes[]", "string"],
           [targets, values, signatures, calldatas, description]
         );
@@ -162,7 +162,7 @@ describe("UniswapGovernanceModule", () => {
           "0x00000000000000000000000000000000000000000000000002c68af0bb140000",
         ];
         const description = "Create A Proposal";
-        const proposalData = defaultAbiCoder.encode(
+        const proposalData = utils.defaultAbiCoder.encode(
           ["address[]", "uint256[]", "string[]", "bytes[]", "string"],
           [targets, values, signatures, calldatas, description]
         );

--- a/test/integration/uniswapV2ExchangeGeneralIndexModule.spec.ts
+++ b/test/integration/uniswapV2ExchangeGeneralIndexModule.spec.ts
@@ -1,5 +1,5 @@
 import "module-alias/register";
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 
 import { Address } from "@utils/types";
 import { Account } from "@utils/test/types";

--- a/test/integration/uniswapV2ExchangeTradeModule.spec.ts
+++ b/test/integration/uniswapV2ExchangeTradeModule.spec.ts
@@ -1,6 +1,6 @@
 import "module-alias/register";
 
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 import { ethers } from "hardhat";
 
 import { Address, Bytes } from "@utils/types";

--- a/test/integration/wrap-v2/aaveV2WrapModuleV2.spec.ts
+++ b/test/integration/wrap-v2/aaveV2WrapModuleV2.spec.ts
@@ -1,5 +1,5 @@
 import "module-alias/register";
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 
 import { Address } from "@utils/types";
 import { Account } from "@utils/test/types";

--- a/test/integration/wrap-v2/compoundWrapModuleV2.spec.ts
+++ b/test/integration/wrap-v2/compoundWrapModuleV2.spec.ts
@@ -1,5 +1,5 @@
 import "module-alias/register";
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 
 import { Address } from "@utils/types";
 import { Account } from "@utils/test/types";

--- a/test/integration/wrap-v2/yearnWrapModuleV2.spec.ts
+++ b/test/integration/wrap-v2/yearnWrapModuleV2.spec.ts
@@ -1,5 +1,5 @@
 import "module-alias/register";
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 
 import { Address } from "@utils/types";
 import { Account } from "@utils/test/types";

--- a/test/integration/yearnWrapModule.spec.ts
+++ b/test/integration/yearnWrapModule.spec.ts
@@ -1,5 +1,5 @@
 import "module-alias/register";
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 
 import { Address } from "@utils/types";
 import { Account } from "@utils/test/types";

--- a/test/lib/addressArrayUtils.spec.ts
+++ b/test/lib/addressArrayUtils.spec.ts
@@ -1,5 +1,5 @@
 import "module-alias/register";
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 
 import { Address } from "@utils/types";
 import { Account } from "@utils/test/types";

--- a/test/lib/explicitERC20Mock.spec.ts
+++ b/test/lib/explicitERC20Mock.spec.ts
@@ -1,6 +1,6 @@
 import "module-alias/register";
 
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 
 import { Address } from "@utils/types";
 import { Account } from "@utils/test/types";

--- a/test/lib/preciseUnitMath.spec.ts
+++ b/test/lib/preciseUnitMath.spec.ts
@@ -1,4 +1,4 @@
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 
 import { Account } from "../../utils/test/types";
 import { PRECISE_UNIT, MIN_INT_256, MAX_INT_256, ZERO } from "../../utils/constants";

--- a/test/lib/uint256ArrayUtils.spec.ts
+++ b/test/lib/uint256ArrayUtils.spec.ts
@@ -1,5 +1,5 @@
 import "module-alias/register";
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 
 import { Account } from "@utils/test/types";
 import { ONE, TWO, THREE, MAX_UINT_256 } from "@utils/constants";

--- a/test/product/assetLimitHook.spec.ts
+++ b/test/product/assetLimitHook.spec.ts
@@ -1,6 +1,6 @@
 import "module-alias/register";
 
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 
 import { Address, NAVIssuanceSettings } from "@utils/types";
 import { Account } from "@utils/test/types";

--- a/test/product/uniswapYieldHook.spec.ts
+++ b/test/product/uniswapYieldHook.spec.ts
@@ -1,6 +1,6 @@
 import "module-alias/register";
 
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 
 import { Address, NAVIssuanceSettings } from "@utils/types";
 import { Account } from "@utils/test/types";

--- a/test/protocol-viewers/protocolViewer.spec.ts
+++ b/test/protocol-viewers/protocolViewer.spec.ts
@@ -1,5 +1,5 @@
 import "module-alias/register";
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 
 import { Address, StreamingFeeState } from "@utils/types";
 import { Account } from "@utils/test/types";

--- a/test/protocol/controller.spec.ts
+++ b/test/protocol/controller.spec.ts
@@ -1,6 +1,6 @@
 import "module-alias/register";
 
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 
 import { Address } from "@utils/types";
 import { Account } from "@utils/test/types";

--- a/test/protocol/integration/amm/UniswapV2AmmAdapter.spec.ts
+++ b/test/protocol/integration/amm/UniswapV2AmmAdapter.spec.ts
@@ -1,6 +1,6 @@
 import "module-alias/register";
 
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 
 import { Address } from "@utils/types";
 import { Account } from "@utils/test/types";

--- a/test/protocol/integration/exchange/kyberExchangeAdapter.spec.ts
+++ b/test/protocol/integration/exchange/kyberExchangeAdapter.spec.ts
@@ -1,7 +1,7 @@
 import "module-alias/register";
 
 import { ethers } from "hardhat";
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 
 import { Address, Bytes } from "@utils/types";
 import { Account } from "@utils/test/types";

--- a/test/protocol/integration/exchange/oneInchExchangeAdapter.spec.ts
+++ b/test/protocol/integration/exchange/oneInchExchangeAdapter.spec.ts
@@ -1,7 +1,7 @@
 import "module-alias/register";
 import Web3 from "web3";
 
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 
 import { Address, Bytes } from "@utils/types";
 import { Account } from "@utils/test/types";

--- a/test/protocol/integration/exchange/synthetixExchangeAdapter.spec.ts
+++ b/test/protocol/integration/exchange/synthetixExchangeAdapter.spec.ts
@@ -1,6 +1,6 @@
 import "module-alias/register";
 
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 
 import { Address, Bytes } from "@utils/types";
 import { Account } from "@utils/test/types";

--- a/test/protocol/integration/exchange/uniswapV2ExchangeAdapter.spec.ts
+++ b/test/protocol/integration/exchange/uniswapV2ExchangeAdapter.spec.ts
@@ -1,7 +1,7 @@
 import "module-alias/register";
 
-import { BigNumber } from "@ethersproject/bignumber";
-import { defaultAbiCoder } from "ethers/lib/utils";
+import { BigNumber } from "ethers";
+import { utils.defaultAbiCoder } from "ethers/lib/utils";
 
 import { Address, Bytes } from "@utils/types";
 import { Account } from "@utils/test/types";
@@ -144,7 +144,7 @@ describe("UniswapV2ExchangeAdapter", () => {
     describe("when passed in custom path to trade data", async () => {
       beforeEach(async () => {
         const path = [sourceAddress, setup.weth.address, destinationAddress];
-        subjectData = defaultAbiCoder.encode(
+        subjectData = utils.defaultAbiCoder.encode(
           ["address[]"],
           [path]
         );

--- a/test/protocol/integration/exchange/uniswapV2ExchangeAdapter.spec.ts
+++ b/test/protocol/integration/exchange/uniswapV2ExchangeAdapter.spec.ts
@@ -1,7 +1,7 @@
 import "module-alias/register";
 
 import { BigNumber } from "ethers";
-import { utils.defaultAbiCoder } from "ethers/lib/utils";
+import { utils } from "ethers";
 
 import { Address, Bytes } from "@utils/types";
 import { Account } from "@utils/test/types";

--- a/test/protocol/integration/exchange/uniswapV2ExchangeAdapterV2.spec.ts
+++ b/test/protocol/integration/exchange/uniswapV2ExchangeAdapterV2.spec.ts
@@ -1,7 +1,7 @@
 import "module-alias/register";
 
 import { BigNumber } from "ethers";
-import { utils.defaultAbiCoder } from "ethers/lib/utils";
+import { utils } from "ethers";
 
 import { Address, Bytes } from "@utils/types";
 import { Account } from "@utils/test/types";

--- a/test/protocol/integration/exchange/uniswapV2ExchangeAdapterV2.spec.ts
+++ b/test/protocol/integration/exchange/uniswapV2ExchangeAdapterV2.spec.ts
@@ -1,7 +1,7 @@
 import "module-alias/register";
 
-import { BigNumber } from "@ethersproject/bignumber";
-import { defaultAbiCoder } from "ethers/lib/utils";
+import { BigNumber } from "ethers";
+import { utils.defaultAbiCoder } from "ethers/lib/utils";
 
 import { Address, Bytes } from "@utils/types";
 import { Account } from "@utils/test/types";
@@ -105,7 +105,7 @@ describe("UniswapV2ExchangeAdapterV2", () => {
 
     it("should return the correct data", async () => {
       const uniswapData = await subject();
-      const expectedData = defaultAbiCoder.encode(
+      const expectedData = utils.defaultAbiCoder.encode(
         ["address[]", "bool"],
         [subjectPath, subjectShouldTradeExactTokensForTokens]
       );
@@ -148,7 +148,7 @@ describe("UniswapV2ExchangeAdapterV2", () => {
         const dataParam = await subject();
 
         const path = [sourceToken, destinationToken];
-        const expectedDataParam = defaultAbiCoder.encode(
+        const expectedDataParam = utils.defaultAbiCoder.encode(
           ["address[]", "bool"],
           [path, subjectFixIn]
         );
@@ -165,7 +165,7 @@ describe("UniswapV2ExchangeAdapterV2", () => {
         const dataParam = await subject();
 
         const path = [sourceToken, destinationToken];
-        const expectedDataParam = defaultAbiCoder.encode(
+        const expectedDataParam = utils.defaultAbiCoder.encode(
           ["address[]", "bool"],
           [path, subjectFixIn]
         );
@@ -216,7 +216,7 @@ describe("UniswapV2ExchangeAdapterV2", () => {
       beforeEach(async () => {
         const path = [sourceToken, setup.weth.address, destinationToken];
         const shouldTradeExactTokensForTokens = true;
-        subjectData = defaultAbiCoder.encode(
+        subjectData = utils.defaultAbiCoder.encode(
           ["address[]", "bool"],
           [path, shouldTradeExactTokensForTokens]
         );
@@ -240,7 +240,7 @@ describe("UniswapV2ExchangeAdapterV2", () => {
       beforeEach(async () => {
         const path = [sourceToken, setup.weth.address, destinationToken];
         const shouldTradeExactTokensForTokens = false;
-        subjectData = defaultAbiCoder.encode(
+        subjectData = utils.defaultAbiCoder.encode(
           ["address[]", "bool"],
           [path, shouldTradeExactTokensForTokens]
         );

--- a/test/protocol/integration/exchange/uniswapV3ExchangeAdapter.spec.ts
+++ b/test/protocol/integration/exchange/uniswapV3ExchangeAdapter.spec.ts
@@ -1,6 +1,6 @@
 import "module-alias/register";
 
-import { BigNumber, BigNumberish } from "@ethersproject/bignumber";
+import { BigNumber, BigNumberish } from "ethers";
 import { solidityPack } from "ethers/lib/utils";
 
 import { Address, Bytes } from "@utils/types";

--- a/test/protocol/integration/governance/aaveGovernanceAdapter.spec.ts
+++ b/test/protocol/integration/governance/aaveGovernanceAdapter.spec.ts
@@ -1,6 +1,5 @@
 import "module-alias/register";
-import { BigNumber } from "@ethersproject/bignumber";
-import { defaultAbiCoder } from "@ethersproject/abi";
+import { utils, BigNumber } from "ethers";
 import { Address, Bytes } from "@utils/types";
 import { Account } from "@utils/test/types";
 import { EMPTY_BYTES, ONE, TWO, ZERO } from "@utils/constants";
@@ -161,7 +160,7 @@ describe("AaveGovernanceAdapter", () => {
 
     describe("when voting with another token", () => {
       beforeEach(async () => {
-        subjectData = defaultAbiCoder.encode(
+        subjectData = utils.defaultAbiCoder.encode(
           ["address"],
           [aaveSetup.lendToken.address]
         );

--- a/test/protocol/integration/governance/aaveGovernanceV2Adapter.spec.ts
+++ b/test/protocol/integration/governance/aaveGovernanceV2Adapter.spec.ts
@@ -1,6 +1,5 @@
 import "module-alias/register";
-import { BigNumber } from "@ethersproject/bignumber";
-import { defaultAbiCoder } from "@ethersproject/abi";
+import { utils, BigNumber } from "ethers";
 import { Address, Bytes } from "@utils/types";
 import { Account } from "@utils/test/types";
 import { EMPTY_BYTES, ZERO } from "@utils/constants";
@@ -91,7 +90,7 @@ describe("AaveGovernanceAdapter", () => {
     const ipfsHash = "0x384dd57abcd23aae459877625228062db4082485a0ac1fc45eb54524f5836507";
 
     beforeEach(async () => {
-      subjectProposalData = defaultAbiCoder.encode(
+      subjectProposalData = utils.defaultAbiCoder.encode(
         ["address", "address[]", "uint256[]", "string[]", "bytes[]", "bool[]", "bytes32"],
         [aaveSetup.executor.address, targets, values, signatures, calldatas, withDelegateCall, ipfsHash]
       );

--- a/test/protocol/integration/governance/compoundBravoGovernanceAdapter.spec.ts
+++ b/test/protocol/integration/governance/compoundBravoGovernanceAdapter.spec.ts
@@ -1,6 +1,5 @@
 import "module-alias/register";
-import { BigNumber } from "@ethersproject/bignumber";
-import { defaultAbiCoder } from "@ethersproject/abi";
+import { utils, BigNumber } from "ethers";
 import { Address, Bytes } from "@utils/types";
 import { Account } from "@utils/test/types";
 import { ADDRESS_ZERO, EMPTY_BYTES, ZERO } from "@utils/constants";
@@ -101,7 +100,7 @@ describe("CompoundBravoGovernanceAdapter", () => {
         "0x00000000000000000000000000000000000000000000000002c68af0bb140000",
       ];
       description = "Create A Proposal";
-      subjectProposalData = defaultAbiCoder.encode(
+      subjectProposalData = utils.defaultAbiCoder.encode(
         ["address[]", "uint256[]", "string[]", "bytes[]", "string"],
         [targets, values, signatures, calldatas, description]
       );

--- a/test/protocol/integration/governance/compoundLikeGovernanceAdapter.spec.ts
+++ b/test/protocol/integration/governance/compoundLikeGovernanceAdapter.spec.ts
@@ -1,6 +1,5 @@
 import "module-alias/register";
-import { BigNumber } from "@ethersproject/bignumber";
-import { defaultAbiCoder } from "@ethersproject/abi";
+import { utils, BigNumber } from "ethers";
 import { Address, Bytes } from "@utils/types";
 import { Account } from "@utils/test/types";
 import { ADDRESS_ZERO, EMPTY_BYTES, ZERO } from "@utils/constants";
@@ -100,7 +99,7 @@ describe("CompoundLikeGovernanceAdapter", () => {
         "0x00000000000000000000000000000000000000000000000002c68af0bb140000",
       ];
       description = "Create A Proposal";
-      subjectProposalData = defaultAbiCoder.encode(
+      subjectProposalData = utils.defaultAbiCoder.encode(
         ["address[]", "uint256[]", "string[]", "bytes[]", "string"],
         [targets, values, signatures, calldatas, description]
       );

--- a/test/protocol/integration/index-exchange/balancerV1IndexExchangeAdapter.spec.ts
+++ b/test/protocol/integration/index-exchange/balancerV1IndexExchangeAdapter.spec.ts
@@ -1,6 +1,6 @@
 import "module-alias/register";
 
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 
 import { Address, Bytes } from "@utils/types";
 import { Account } from "@utils/test/types";

--- a/test/protocol/integration/index-exchange/kyberV3IndexExchangeAdapter.spec.ts
+++ b/test/protocol/integration/index-exchange/kyberV3IndexExchangeAdapter.spec.ts
@@ -1,6 +1,6 @@
 import "module-alias/register";
 
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 
 import { Address, Bytes } from "@utils/types";
 import { Account } from "@utils/test/types";

--- a/test/protocol/integration/index-exchange/uniswapV2IndexExchangeAdapter.spec.ts
+++ b/test/protocol/integration/index-exchange/uniswapV2IndexExchangeAdapter.spec.ts
@@ -1,6 +1,6 @@
 import "module-alias/register";
 
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 
 import { Address, Bytes } from "@utils/types";
 import { Account } from "@utils/test/types";

--- a/test/protocol/integration/index-exchange/uniswapV3IndexExchangeAdapter.spec.ts
+++ b/test/protocol/integration/index-exchange/uniswapV3IndexExchangeAdapter.spec.ts
@@ -1,7 +1,7 @@
 import "module-alias/register";
 
 import { hexlify, hexZeroPad } from "ethers/lib/utils";
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 import { Address, Bytes } from "@utils/types";
 import { Account } from "@utils/test/types";
 import {

--- a/test/protocol/integration/lib/aaveV2.spec.ts
+++ b/test/protocol/integration/lib/aaveV2.spec.ts
@@ -1,5 +1,5 @@
 import "module-alias/register";
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 
 import { Address } from "@utils/types";
 import { Account } from "@utils/test/types";

--- a/test/protocol/integration/lib/compound.spec.ts
+++ b/test/protocol/integration/lib/compound.spec.ts
@@ -1,5 +1,5 @@
 import "module-alias/register";
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 
 import { Address } from "@utils/types";
 import { Account } from "@utils/test/types";

--- a/test/protocol/integration/oracles/uniswapPairPriceAdapter.spec.ts
+++ b/test/protocol/integration/oracles/uniswapPairPriceAdapter.spec.ts
@@ -1,5 +1,5 @@
 import "module-alias/register";
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 
 import { Address } from "@utils/types";
 import { Account } from "@utils/test/types";

--- a/test/protocol/integration/staking/curveStakingAdapter.spec.ts
+++ b/test/protocol/integration/staking/curveStakingAdapter.spec.ts
@@ -1,5 +1,5 @@
 import "module-alias/register";
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 
 import { Address } from "@utils/types";
 import { Account } from "@utils/test/types";

--- a/test/protocol/integration/uniswapV2TransferFeeExchangeAdapter.spec.ts
+++ b/test/protocol/integration/uniswapV2TransferFeeExchangeAdapter.spec.ts
@@ -1,7 +1,7 @@
 import "module-alias/register";
 
 import { BigNumber } from "ethers";
-import { utils.defaultAbiCoder } from "ethers/lib/utils";
+import { utils } from "ethers";
 
 import { Address, Bytes } from "@utils/types";
 import { Account } from "@utils/test/types";

--- a/test/protocol/integration/uniswapV2TransferFeeExchangeAdapter.spec.ts
+++ b/test/protocol/integration/uniswapV2TransferFeeExchangeAdapter.spec.ts
@@ -1,7 +1,7 @@
 import "module-alias/register";
 
-import { BigNumber } from "@ethersproject/bignumber";
-import { defaultAbiCoder } from "ethers/lib/utils";
+import { BigNumber } from "ethers";
+import { utils.defaultAbiCoder } from "ethers/lib/utils";
 
 import { Address, Bytes } from "@utils/types";
 import { Account } from "@utils/test/types";
@@ -144,7 +144,7 @@ describe("UniswapV2TransferFeeExchangeAdapter", () => {
     describe("when passed in custom path to trade data", async () => {
       beforeEach(async () => {
         const path = [sourceAddress, setup.weth.address, destinationAddress];
-        subjectData = defaultAbiCoder.encode(
+        subjectData = utils.defaultAbiCoder.encode(
           ["address[]"],
           [path]
         );

--- a/test/protocol/integration/wrap-v2/aaveV2WrapV2Adapter.spec.ts
+++ b/test/protocol/integration/wrap-v2/aaveV2WrapV2Adapter.spec.ts
@@ -1,5 +1,5 @@
 import "module-alias/register";
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 
 import { Address } from "@utils/types";
 import { Account } from "@utils/test/types";

--- a/test/protocol/integration/wrap-v2/compoundWrapV2Adapter.spec.ts
+++ b/test/protocol/integration/wrap-v2/compoundWrapV2Adapter.spec.ts
@@ -1,5 +1,5 @@
 import "module-alias/register";
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 
 import { Address } from "@utils/types";
 import { Account } from "@utils/test/types";

--- a/test/protocol/integration/wrap-v2/yearnWrapV2Adapter.spec.ts
+++ b/test/protocol/integration/wrap-v2/yearnWrapV2Adapter.spec.ts
@@ -1,5 +1,5 @@
 import "module-alias/register";
-import { BigNumber } from "@ethersproject/bignumber";
+import { utils, BigNumber } from "ethers";
 
 import { Address } from "@utils/types";
 import { Account } from "@utils/test/types";
@@ -17,7 +17,6 @@ import {
   getWaffleExpect,
   getYearnFixture,
 } from "@utils/test/index";
-import { defaultAbiCoder } from "@ethersproject/abi";
 import { solidityKeccak256 } from "ethers/lib/utils";
 
 const expect = getWaffleExpect();
@@ -85,7 +84,7 @@ describe("YearnWrapV2Adapter", () => {
       const [targetAddress, ethValue, callData] = await subject();
 
       const selector = solidityKeccak256(["string"], ["deposit(uint256)"]).slice(0, 10);
-      const data = defaultAbiCoder.encode(["uint256"], [subjectQuantity]).slice(2);
+      const data = utils.defaultAbiCoder.encode(["uint256"], [subjectQuantity]).slice(2);
       const expectedCalldata = selector + data;
 
       expect(targetAddress).to.eq(subjectYToken);
@@ -117,7 +116,7 @@ describe("YearnWrapV2Adapter", () => {
       const [targetAddress, ethValue, callData] = await subject();
 
       const selector = solidityKeccak256(["string"], ["withdraw(uint256)"]).slice(0, 10);
-      const data = defaultAbiCoder.encode(["uint256"], [subjectQuantity]).slice(2);
+      const data = utils.defaultAbiCoder.encode(["uint256"], [subjectQuantity]).slice(2);
       const expectedCalldata = selector + data;
 
       expect(targetAddress).to.eq(subjectYToken);

--- a/test/protocol/integration/wrap/aaveMigrationWrapAdapter.spec.ts
+++ b/test/protocol/integration/wrap/aaveMigrationWrapAdapter.spec.ts
@@ -1,5 +1,5 @@
 import "module-alias/register";
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 
 import { Address } from "@utils/types";
 import { Account } from "@utils/test/types";

--- a/test/protocol/integration/wrap/aaveWrapAdapter.spec.ts
+++ b/test/protocol/integration/wrap/aaveWrapAdapter.spec.ts
@@ -1,5 +1,5 @@
 import "module-alias/register";
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 
 import { Address } from "@utils/types";
 import { Account } from "@utils/test/types";

--- a/test/protocol/integration/wrap/agiMigrationWrapAdapter.spec.ts
+++ b/test/protocol/integration/wrap/agiMigrationWrapAdapter.spec.ts
@@ -1,5 +1,5 @@
 import "module-alias/register";
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 
 import { Address } from "@utils/types";
 import { Account } from "@utils/test/types";

--- a/test/protocol/integration/wrap/axieInfinityMigrationWrapAdapter.spec.ts
+++ b/test/protocol/integration/wrap/axieInfinityMigrationWrapAdapter.spec.ts
@@ -1,5 +1,5 @@
 import "module-alias/register";
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 
 import { Address } from "@utils/types";
 import { Account } from "@utils/test/types";

--- a/test/protocol/integration/wrap/compoundWrapAdapter.spec.ts
+++ b/test/protocol/integration/wrap/compoundWrapAdapter.spec.ts
@@ -1,5 +1,5 @@
 import "module-alias/register";
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 
 import { Address } from "@utils/types";
 import { Account } from "@utils/test/types";

--- a/test/protocol/integration/wrap/kyberMigrationWrapAdapter.spec.ts
+++ b/test/protocol/integration/wrap/kyberMigrationWrapAdapter.spec.ts
@@ -1,5 +1,5 @@
 import "module-alias/register";
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 
 import { Address } from "@utils/types";
 import { Account } from "@utils/test/types";

--- a/test/protocol/lib/invoke.spec.ts
+++ b/test/protocol/lib/invoke.spec.ts
@@ -1,5 +1,5 @@
 import "module-alias/register";
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 
 import { Address } from "@utils/types";
 import { Account } from "@utils/test/types";

--- a/test/protocol/lib/moduleBase.spec.ts
+++ b/test/protocol/lib/moduleBase.spec.ts
@@ -1,6 +1,6 @@
 import "module-alias/register";
 
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 import { Address } from "@utils/types";
 import { Account } from "@utils/test/types";
 import { ModuleBaseMock, SetToken, StandardTokenMock, StandardTokenWithFeeMock } from "@utils/contracts";

--- a/test/protocol/lib/position.spec.ts
+++ b/test/protocol/lib/position.spec.ts
@@ -1,5 +1,5 @@
 import "module-alias/register";
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 import { PositionMock, SetToken, StandardTokenMock } from "@utils/contracts";
 import DeployHelper from "@utils/deploys";
 import {

--- a/test/protocol/modules/aaveLeverageModule.spec.ts
+++ b/test/protocol/modules/aaveLeverageModule.spec.ts
@@ -32,10 +32,9 @@ import {
   getUniswapFixture
 } from "@utils/test/index";
 import { AaveV2Fixture, SystemFixture, UniswapFixture } from "@utils/fixtures";
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber, ContractTransaction } from "ethers";
 import { ADDRESS_ZERO, ZERO, EMPTY_BYTES, MAX_UINT_256 } from "@utils/constants";
 import { ReserveTokens } from "@utils/fixtures/aaveV2Fixture";
-import { ContractTransaction } from "@ethersproject/contracts";
 
 const expect = getWaffleExpect();
 const web3 = new Web3();

--- a/test/protocol/modules/airdropModule.spec.ts
+++ b/test/protocol/modules/airdropModule.spec.ts
@@ -1,5 +1,5 @@
 import "module-alias/register";
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 
 import { Address, ContractTransaction } from "@utils/types";
 import { Account } from "@utils/test/types";

--- a/test/protocol/modules/ammModule.spec.ts
+++ b/test/protocol/modules/ammModule.spec.ts
@@ -1,5 +1,5 @@
 import "module-alias/register";
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 
 import { Address } from "@utils/types";
 import { Account } from "@utils/test/types";

--- a/test/protocol/modules/basicIssuanceModule.spec.ts
+++ b/test/protocol/modules/basicIssuanceModule.spec.ts
@@ -1,5 +1,5 @@
 import "module-alias/register";
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 
 import { Address } from "@utils/types";
 import { Account } from "@utils/test/types";

--- a/test/protocol/modules/claimModule.spec.ts
+++ b/test/protocol/modules/claimModule.spec.ts
@@ -16,7 +16,7 @@ import {
   getRandomAddress,
 } from "@utils/test/index";
 import { SystemFixture } from "@utils/fixtures";
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 import { ZERO } from "@utils/constants";
 
 const expect = getWaffleExpect();

--- a/test/protocol/modules/compoundLeverageModule.spec.ts
+++ b/test/protocol/modules/compoundLeverageModule.spec.ts
@@ -27,7 +27,7 @@ import {
   getRandomAddress
 } from "@utils/test/index";
 import { CompoundFixture, SystemFixture } from "@utils/fixtures";
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 import { ADDRESS_ZERO, ZERO, EMPTY_BYTES } from "@utils/constants";
 
 const expect = getWaffleExpect();

--- a/test/protocol/modules/compoundLeverageModule2.spec.ts
+++ b/test/protocol/modules/compoundLeverageModule2.spec.ts
@@ -24,7 +24,7 @@ import {
   getRandomAddress
 } from "@utils/test/index";
 import { CompoundFixture, SystemFixture } from "@utils/fixtures";
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 import { ADDRESS_ZERO, ZERO, EMPTY_BYTES } from "@utils/constants";
 
 const expect = getWaffleExpect();

--- a/test/protocol/modules/customOracleNAVIssuanceModule.spec.ts
+++ b/test/protocol/modules/customOracleNAVIssuanceModule.spec.ts
@@ -1,6 +1,6 @@
 import "module-alias/register";
 
-import { BigNumber, BigNumberish } from "@ethersproject/bignumber";
+import { BigNumber, BigNumberish } from "ethers";
 
 import { Address, CustomOracleNAVIssuanceSettings } from "@utils/types";
 import { Account } from "@utils/test/types";

--- a/test/protocol/modules/debtIssuanceModule.spec.ts
+++ b/test/protocol/modules/debtIssuanceModule.spec.ts
@@ -1,6 +1,6 @@
 import "module-alias/register";
 
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 
 import { Address } from "@utils/types";
 import { Account } from "@utils/test/types";

--- a/test/protocol/modules/debtIssuanceModuleV2.spec.ts
+++ b/test/protocol/modules/debtIssuanceModuleV2.spec.ts
@@ -1,6 +1,6 @@
 import "module-alias/register";
 
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 
 import { Address } from "@utils/types";
 import { Account } from "@utils/test/types";

--- a/test/protocol/modules/generalIndexModule.spec.ts
+++ b/test/protocol/modules/generalIndexModule.spec.ts
@@ -1,5 +1,5 @@
 import "module-alias/register";
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 
 import { hexlify, hexZeroPad } from "ethers/lib/utils";
 import { Address, StreamingFeeState } from "@utils/types";

--- a/test/protocol/modules/governanceModule.spec.ts
+++ b/test/protocol/modules/governanceModule.spec.ts
@@ -17,7 +17,7 @@ import {
   getRandomAddress,
 } from "@utils/test/index";
 import { SystemFixture } from "@utils/fixtures";
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 import { ADDRESS_ZERO, ONE, TWO, ZERO, EMPTY_BYTES } from "@utils/constants";
 
 const expect = getWaffleExpect();

--- a/test/protocol/modules/issuanceModule.spec.ts
+++ b/test/protocol/modules/issuanceModule.spec.ts
@@ -1,5 +1,5 @@
 import "module-alias/register";
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 
 import { Address } from "@utils/types";
 import { Account } from "@utils/test/types";

--- a/test/protocol/modules/navIssuanceModule.spec.ts
+++ b/test/protocol/modules/navIssuanceModule.spec.ts
@@ -1,6 +1,6 @@
 import "module-alias/register";
 
-import { BigNumber, BigNumberish } from "@ethersproject/bignumber";
+import { BigNumber, BigNumberish } from "ethers";
 
 import { Address, NAVIssuanceSettings } from "@utils/types";
 import { Account } from "@utils/test/types";

--- a/test/protocol/modules/singleIndexModule.spec.ts
+++ b/test/protocol/modules/singleIndexModule.spec.ts
@@ -1,5 +1,5 @@
 import "module-alias/register";
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 
 import { Address, StreamingFeeState } from "@utils/types";
 import { Account } from "@utils/test/types";

--- a/test/protocol/modules/stakingModule.spec.ts
+++ b/test/protocol/modules/stakingModule.spec.ts
@@ -1,5 +1,5 @@
 import "module-alias/register";
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 
 import { Address } from "@utils/types";
 import { Account } from "@utils/test/types";
@@ -20,7 +20,7 @@ import {
 } from "@utils/test/index";
 import { SystemFixture } from "@utils/fixtures";
 import { ContractTransaction } from "ethers";
-import { HashZero } from "@ethersproject/constants";
+import { constants } from "ethers";
 
 const expect = getWaffleExpect();
 
@@ -488,7 +488,7 @@ describe("StakingModule", () => {
       await subject();
 
       const position: any = await stakingModule.getStakingPosition(subjectSetToken, subjectComponent, subjectStakeContract);
-      expect(position.adapterHash).to.eq(HashZero);
+      expect(position.adapterHash).to.eq(constants.HashZero);
       expect(position.componentPositionUnits).to.eq(ZERO);
     });
 

--- a/test/protocol/modules/streamingFeeModule.spec.ts
+++ b/test/protocol/modules/streamingFeeModule.spec.ts
@@ -1,6 +1,6 @@
 import "module-alias/register";
 
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 
 import { Address, ContractTransaction, StreamingFeeState } from "@utils/types";
 import { Account } from "@utils/test/types";

--- a/test/protocol/modules/tradeModule.spec.ts
+++ b/test/protocol/modules/tradeModule.spec.ts
@@ -1,7 +1,7 @@
 import "module-alias/register";
 import Web3 from "web3";
 import { BigNumber } from "ethers";
-import { utils.defaultAbiCoder } from "ethers/lib/utils";
+import { utils } from "ethers";
 import { ethers } from "hardhat";
 
 import { Address, Bytes } from "@utils/types";

--- a/test/protocol/modules/tradeModule.spec.ts
+++ b/test/protocol/modules/tradeModule.spec.ts
@@ -1,7 +1,7 @@
 import "module-alias/register";
 import Web3 from "web3";
-import { BigNumber } from "@ethersproject/bignumber";
-import { defaultAbiCoder } from "ethers/lib/utils";
+import { BigNumber } from "ethers";
+import { utils.defaultAbiCoder } from "ethers/lib/utils";
 import { ethers } from "hardhat";
 
 import { Address, Bytes } from "@utils/types";
@@ -820,7 +820,7 @@ describe("TradeModule", () => {
 
             subjectDestinationToken = setup.dai.address;
             const tradePath = [subjectSourceToken, setup.weth.address, subjectDestinationToken];
-            subjectData = defaultAbiCoder.encode(
+            subjectData = utils.defaultAbiCoder.encode(
               ["address[]"],
               [tradePath]
             );
@@ -980,7 +980,7 @@ describe("TradeModule", () => {
 
             subjectDestinationToken = setup.dai.address;
             const tradePath = [subjectSourceToken, setup.wbtc.address, subjectDestinationToken];
-            subjectData = defaultAbiCoder.encode(
+            subjectData = utils.defaultAbiCoder.encode(
               ["address[]"],
               [tradePath]
             );

--- a/test/protocol/modules/wrapModule.spec.ts
+++ b/test/protocol/modules/wrapModule.spec.ts
@@ -1,5 +1,5 @@
 import "module-alias/register";
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 
 import { Address } from "@utils/types";
 import { Account } from "@utils/test/types";

--- a/test/protocol/modules/wrapModuleV2.spec.ts
+++ b/test/protocol/modules/wrapModuleV2.spec.ts
@@ -1,5 +1,5 @@
 import "module-alias/register";
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 
 import { Address } from "@utils/types";
 import { Account } from "@utils/test/types";

--- a/test/protocol/priceOracle.spec.ts
+++ b/test/protocol/priceOracle.spec.ts
@@ -1,6 +1,6 @@
 import "module-alias/register";
 import { ethers } from "hardhat";
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 import { ContractTransaction } from "ethers";
 
 import { Address } from "@utils/types";

--- a/test/protocol/setToken.spec.ts
+++ b/test/protocol/setToken.spec.ts
@@ -1,7 +1,7 @@
 import "module-alias/register";
 
 import Web3 from "web3";
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 
 import { Address, Position } from "@utils/types";
 import { Account } from "@utils/test/types";

--- a/test/protocol/setTokenCreator.spec.ts
+++ b/test/protocol/setTokenCreator.spec.ts
@@ -1,5 +1,5 @@
 import "module-alias/register";
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 
 import { Address } from "@utils/types";
 import { Account } from "@utils/test/types";

--- a/test/protocol/setValuer.spec.ts
+++ b/test/protocol/setValuer.spec.ts
@@ -1,5 +1,5 @@
 import "module-alias/register";
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 import { SetToken, SetValuer } from "@utils/contracts";
 import DeployHelper from "@utils/deploys";
 import {

--- a/utils/common/adapterUtils.ts
+++ b/utils/common/adapterUtils.ts
@@ -1,5 +1,5 @@
 import { keccak256 } from "ethers/lib/utils";
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 
 export const addressToData = (address: String) => address.replace("0x", "000000000000000000000000");
 export const bigNumberToData = (number: BigNumber) => number.toHexString().replace("0x", "").padStart(64, "0");

--- a/utils/common/blockchainUtils.ts
+++ b/utils/common/blockchainUtils.ts
@@ -1,10 +1,10 @@
-import { JsonRpcProvider, Web3Provider } from "@ethersproject/providers";
+import { providers } from "ethers";
 
 export class Blockchain {
-  public _provider: Web3Provider | JsonRpcProvider;
+  public _provider: providers.Web3Provider | providers.JsonRpcProvider;
   private _snapshotId: number;
 
-  constructor(_provider: Web3Provider | JsonRpcProvider) {
+  constructor(_provider: providers.Web3Provider | providers.JsonRpcProvider) {
     this._provider = _provider;
 
     this._snapshotId = 0;

--- a/utils/common/feeModuleUtils.ts
+++ b/utils/common/feeModuleUtils.ts
@@ -1,4 +1,4 @@
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 
 import { preciseMul, preciseMulCeilInt } from "./mathUtils";
 import { ONE_YEAR_IN_SECONDS, PRECISE_UNIT } from "../constants";

--- a/utils/common/mathUtils.ts
+++ b/utils/common/mathUtils.ts
@@ -1,4 +1,4 @@
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 
 import { PRECISE_UNIT, ZERO } from "../constants";
 

--- a/utils/common/navIssuanceModuleUtils.ts
+++ b/utils/common/navIssuanceModuleUtils.ts
@@ -1,4 +1,4 @@
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 import { Address } from "../types";
 import { preciseMul, preciseMulCeil, preciseDiv, preciseDivCeil } from "./mathUtils";
 import { PRECISE_UNIT } from "../constants";

--- a/utils/common/protocolUtils.ts
+++ b/utils/common/protocolUtils.ts
@@ -1,7 +1,4 @@
-import { JsonRpcProvider, Web3Provider } from "@ethersproject/providers";
-
-import { BigNumber } from "@ethersproject/bignumber";
-import { ethers, constants } from "ethers";
+import { BigNumber, constants, ethers, providers } from "ethers";
 
 import { EMPTY_BYTES } from "../constants";
 import { Address, Position } from "../types";
@@ -9,9 +6,9 @@ import { Address, Position } from "../types";
 const { AddressZero } = constants;
 
 export class ProtocolUtils {
-  public _provider: Web3Provider | JsonRpcProvider;
+  public _provider: providers.Web3Provider | providers.JsonRpcProvider;
 
-  constructor(_provider: Web3Provider | JsonRpcProvider) {
+  constructor(_provider: providers.Web3Provider | providers.JsonRpcProvider) {
     this._provider = _provider;
   }
 

--- a/utils/common/uniswapUtils.ts
+++ b/utils/common/uniswapUtils.ts
@@ -1,4 +1,4 @@
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 import { UniswapV2Pair, SetToken, StakingRewards, StandardTokenMock, WETH9, UniswapV2Router02 } from "../contracts";
 import { ZERO } from "../constants";
 import { ether, preciseMul } from "../index";

--- a/utils/common/unitsUtils.ts
+++ b/utils/common/unitsUtils.ts
@@ -1,5 +1,5 @@
 import { ethers } from "ethers";
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 
 export const ether = (amount: number | string): BigNumber => {
   const weiString = ethers.utils.parseEther(amount.toString());

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -1,5 +1,5 @@
 import { constants } from "ethers";
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 
 const { AddressZero, MaxUint256, One, Two, Zero } = constants;
 

--- a/utils/deploys/deployCoreContracts.ts
+++ b/utils/deploys/deployCoreContracts.ts
@@ -1,5 +1,4 @@
-import { Signer } from "ethers";
-import { BigNumberish } from "@ethersproject/bignumber";
+import { BigNumberish, Signer } from "ethers";
 
 import {
   Controller,

--- a/utils/deploys/deployExternal.ts
+++ b/utils/deploys/deployExternal.ts
@@ -1,5 +1,4 @@
-import { Signer } from "ethers";
-import { BigNumberish, BigNumber } from "@ethersproject/bignumber";
+import { BigNumberish, BigNumber, Signer } from "ethers";
 import { ether } from "../common";
 
 import {

--- a/utils/deploys/deployMocks.ts
+++ b/utils/deploys/deployMocks.ts
@@ -1,6 +1,5 @@
 import { Address, Bytes } from "../types";
-import { Signer } from "ethers";
-import { BigNumberish, BigNumber } from "@ethersproject/bignumber";
+import { BigNumberish, BigNumber, Signer } from "ethers";
 
 import {
   AaveLendingPoolCoreMock,

--- a/utils/deploys/deployOracles.ts
+++ b/utils/deploys/deployOracles.ts
@@ -1,6 +1,6 @@
 import { Signer } from "ethers";
 import { Address } from "../types";
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 
 import { CTokenOracle, YearnVaultOracle } from "../contracts";
 

--- a/utils/deploys/deployProduct.ts
+++ b/utils/deploys/deployProduct.ts
@@ -1,5 +1,5 @@
 import { Signer } from "ethers";
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 
 import {
   UniswapYieldHook,

--- a/utils/fixtures/aaveFixture.ts
+++ b/utils/fixtures/aaveFixture.ts
@@ -1,8 +1,7 @@
 import DeployHelper from "../deploys";
 import { Signer } from "ethers";
-import { JsonRpcProvider, Web3Provider } from "@ethersproject/providers";
+import { providers, BigNumber, BigNumberish } from "ethers";
 import { Address } from "../types";
-import { BigNumber, BigNumberish } from "@ethersproject/bignumber";
 
 import {
   AavePropositionPower,
@@ -50,7 +49,7 @@ export class AaveFixture {
   public assetVotingWeightPower: AssetVotingWeightProvider;
   public governanceParamsProvider: GovernanceParamsProvider;
 
-  constructor(provider: Web3Provider | JsonRpcProvider, ownerAddress: Address) {
+  constructor(provider: providers.Web3Provider | providers.JsonRpcProvider, ownerAddress: Address) {
     this._ownerSigner = provider.getSigner(ownerAddress);
     this._deployer = new DeployHelper(this._ownerSigner);
   }

--- a/utils/fixtures/aaveV2Fixture.ts
+++ b/utils/fixtures/aaveV2Fixture.ts
@@ -1,8 +1,7 @@
 import DeployHelper from "../deploys";
 import { Signer } from "ethers";
-import { JsonRpcProvider, Web3Provider } from "@ethersproject/providers";
 import { Address } from "../types";
-import { BigNumber, BigNumberish } from "@ethersproject/bignumber";
+import { providers, BigNumber, BigNumberish } from "ethers";
 
 import {
   AaveGovernanceV2,
@@ -65,7 +64,7 @@ export class AaveV2Fixture {
   public executor: Executor;
   public governanceStrategy: GovernanceStrategy;
 
-  constructor(provider: Web3Provider | JsonRpcProvider, ownerAddress: Address) {
+  constructor(provider: providers.Web3Provider | providers.JsonRpcProvider, ownerAddress: Address) {
     this._ownerSigner = provider.getSigner(ownerAddress);
     this._deployer = new DeployHelper(this._ownerSigner);
   }

--- a/utils/fixtures/balancerFixture.ts
+++ b/utils/fixtures/balancerFixture.ts
@@ -1,9 +1,7 @@
 import DeployHelper from "../deploys";
-import { Signer, ContractTransaction } from "ethers";
-import { JsonRpcProvider, Web3Provider } from "@ethersproject/providers";
+import { BigNumber, Signer, ContractTransaction, providers } from "ethers";
 import { Address } from "../types";
 import { Account } from "@utils/test/types";
-import { BigNumber } from "@ethersproject/bignumber";
 
 import {
   BFactory,
@@ -30,7 +28,7 @@ export class BalancerFixture {
   public wethWbtcPool: BPool;
   public wbtcDaiPool: BPool;
 
-  constructor(provider: Web3Provider | JsonRpcProvider, ownerAddress: Address) {
+  constructor(provider: providers.Web3Provider | providers.JsonRpcProvider, ownerAddress: Address) {
     this._ownerSigner = provider.getSigner(ownerAddress);
     this._deployer = new DeployHelper(this._ownerSigner);
   }

--- a/utils/fixtures/compoundFixture.ts
+++ b/utils/fixtures/compoundFixture.ts
@@ -1,6 +1,4 @@
-import { JsonRpcProvider, Web3Provider } from "@ethersproject/providers";
-import { BigNumberish, BigNumber } from "@ethersproject/bignumber";
-import { Signer } from "ethers";
+import { BigNumberish, BigNumber, providers, Signer } from "ethers";
 
 import {
   CERc20,
@@ -48,7 +46,7 @@ export class CompoundFixture {
   public priceOracle: CompoundPriceOracleMock;
   public priceOracleProxy: PriceOracleProxy;
 
-  constructor(provider: Web3Provider | JsonRpcProvider, ownerAddress: Address) {
+  constructor(provider: providers.Web3Provider | providers.JsonRpcProvider, ownerAddress: Address) {
     this._ownerAddress = ownerAddress;
     this._ownerSigner = provider.getSigner(ownerAddress);
     this._deployer = new DeployHelper(this._ownerSigner);

--- a/utils/fixtures/curveFixture.ts
+++ b/utils/fixtures/curveFixture.ts
@@ -1,4 +1,4 @@
-import { JsonRpcProvider, Web3Provider } from "@ethersproject/providers";
+import { providers } from "ethers";
 import { Address } from "../types";
 import DeployHelper from "../deploys";
 import { Signer } from "ethers";
@@ -24,7 +24,7 @@ export class CurveFixture {
   public gaugeController: GaugeController;
   public minter: Minter;
 
-  constructor(provider: Web3Provider | JsonRpcProvider, ownerAddress: Address) {
+  constructor(provider: providers.Web3Provider | providers.JsonRpcProvider, ownerAddress: Address) {
     this._ownerSigner = provider.getSigner(ownerAddress);
     this._deployer = new DeployHelper(this._ownerSigner);
   }

--- a/utils/fixtures/kyberV3DMMFixture.ts
+++ b/utils/fixtures/kyberV3DMMFixture.ts
@@ -1,9 +1,7 @@
 import DeployHelper from "../deploys";
-import { Signer } from "ethers";
-import { JsonRpcProvider, Web3Provider } from "@ethersproject/providers";
+import { providers, Signer, BigNumber } from "ethers";
 import { Address } from "../types";
 import { Account } from "../test/types";
-import { BigNumber } from "@ethersproject/bignumber";
 
 import { StandardTokenMock } from "../contracts";
 import {
@@ -28,7 +26,7 @@ export class KyberV3DMMFixture {
   public wethDaiPool: DMMPool;
   public wethWbtcPool: DMMPool;
 
-  constructor(provider: Web3Provider | JsonRpcProvider, ownerAddress: Address) {
+  constructor(provider: providers.Web3Provider | providers.JsonRpcProvider, ownerAddress: Address) {
     this._ownerSigner = provider.getSigner(ownerAddress);
     this._deployer = new DeployHelper(this._ownerSigner);
   }

--- a/utils/fixtures/systemFixture.ts
+++ b/utils/fixtures/systemFixture.ts
@@ -1,6 +1,6 @@
-import { JsonRpcProvider, Web3Provider } from "@ethersproject/providers";
+import { providers } from "ethers";
 import { ContractTransaction, Signer } from "ethers";
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 
 import {
   BasicIssuanceModule,
@@ -31,7 +31,7 @@ import {
 import { SetToken__factory } from "../../typechain/factories/SetToken__factory";
 
 export class SystemFixture {
-  private _provider: Web3Provider | JsonRpcProvider;
+  private _provider: providers.Web3Provider | providers.JsonRpcProvider;
   private _ownerAddress: Address;
   private _ownerSigner: Signer;
   private _deployer: DeployHelper;
@@ -63,7 +63,7 @@ export class SystemFixture {
   public component3Price: BigNumber;
   public component4Price: BigNumber;
 
-  constructor(provider: Web3Provider | JsonRpcProvider, ownerAddress: Address) {
+  constructor(provider: providers.Web3Provider | providers.JsonRpcProvider, ownerAddress: Address) {
     this._provider = provider;
     this._ownerAddress = ownerAddress;
     this._ownerSigner = provider.getSigner(ownerAddress);

--- a/utils/fixtures/uniswapFixture.ts
+++ b/utils/fixtures/uniswapFixture.ts
@@ -1,9 +1,7 @@
 import DeployHelper from "../deploys";
-import { Signer } from "ethers";
-import { JsonRpcProvider, Web3Provider } from "@ethersproject/providers";
+import { Signer, providers, BigNumber } from "ethers";
 import { Address } from "../types";
 import { Account } from "../test/types";
-import { BigNumber } from "@ethersproject/bignumber";
 
 import {
   StakingRewards,
@@ -21,7 +19,7 @@ import { ONE_DAY_IN_SECONDS } from "../constants";
 
 export class UniswapFixture {
   private _deployer: DeployHelper;
-  private _provider: Web3Provider | JsonRpcProvider;
+  private _provider: providers.Web3Provider | providers.JsonRpcProvider;
   private _ownerSigner: Signer;
 
   public owner: Account;
@@ -38,7 +36,7 @@ export class UniswapFixture {
   public wethWbtcStakingRewards: StakingRewards;
   public uniWethPool: UniswapV2Pair;
 
-  constructor(provider: Web3Provider | JsonRpcProvider, ownerAddress: Address) {
+  constructor(provider: providers.Web3Provider | providers.JsonRpcProvider, ownerAddress: Address) {
     this._ownerSigner = provider.getSigner(ownerAddress);
     this._provider = provider;
     this._deployer = new DeployHelper(this._ownerSigner);

--- a/utils/fixtures/uniswapV3Fixture.ts
+++ b/utils/fixtures/uniswapV3Fixture.ts
@@ -1,7 +1,6 @@
 import DeployHelper from "../deploys";
 import { MAX_UINT_256 } from "../constants";
-import { JsonRpcProvider, Web3Provider } from "@ethersproject/providers";
-import { BigNumber, BigNumberish, Signer } from "ethers";
+import { BigNumber, BigNumberish, Signer, providers } from "ethers";
 import { Address } from "../types";
 import { Account } from "../test/types";
 
@@ -42,7 +41,7 @@ export class UniswapV3Fixture {
    * @param provider      the ethers web3 provider to use
    * @param ownerAddress  the address of the owner
    */
-  constructor(provider: Web3Provider | JsonRpcProvider, ownerAddress: Address) {
+  constructor(provider: providers.Web3Provider | providers.JsonRpcProvider, ownerAddress: Address) {
     this._ownerSigner = provider.getSigner(ownerAddress);
     this._deployer = new DeployHelper(this._ownerSigner);
   }

--- a/utils/fixtures/yearnFixture.ts
+++ b/utils/fixtures/yearnFixture.ts
@@ -1,6 +1,4 @@
-import { JsonRpcProvider, Web3Provider } from "@ethersproject/providers";
-import { BigNumber } from "@ethersproject/bignumber";
-import { Signer } from "ethers";
+import { providers, BigNumber, Signer } from "ethers";
 
 import {
   Vault,
@@ -16,7 +14,7 @@ export class YearnFixture {
 
   public registry: Registry;
 
-  constructor(provider: Web3Provider | JsonRpcProvider, ownerAddress: Address) {
+  constructor(provider: providers.Web3Provider | providers.JsonRpcProvider, ownerAddress: Address) {
     this._ownerAddress = ownerAddress;
     this._ownerSigner = provider.getSigner(ownerAddress);
     this._deployer = new DeployHelper(this._ownerSigner);

--- a/utils/test/accountUtils.ts
+++ b/utils/test/accountUtils.ts
@@ -1,5 +1,5 @@
 import { ethers, network } from "hardhat";
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 import { Address } from "../types";
 import { Account, ForkedTokens } from "./types";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
@@ -86,4 +86,3 @@ export const initializeForkedTokens = async (deployer: DeployHelper): Promise<vo
     await funder.fund(whale, {value: ether(100)}); // Gas money
   }
 };
-

--- a/utils/test/testingUtils.ts
+++ b/utils/test/testingUtils.ts
@@ -5,15 +5,14 @@ chai.use(solidity);
 
 // Use HARDHAT version of providers
 import { ethers } from "hardhat";
-import { BigNumber } from "@ethersproject/bignumber";
-import { JsonRpcProvider } from "@ethersproject/providers";
+import { BigNumber, providers } from "ethers";
 import { Blockchain } from "../common";
 
 const provider = ethers.provider;
 // const blockchain = new Blockchain(provider);
 
 // HARDHAT-SPECIFIC Provider
-export const getProvider = (): JsonRpcProvider => {
+export const getProvider = (): providers.JsonRpcProvider => {
   return ethers.provider;
 };
 

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -1,4 +1,4 @@
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 import {
   ContractTransaction as ContractTransactionType,
   Wallet as WalletType

--- a/yarn.lock
+++ b/yarn.lock
@@ -203,7 +203,52 @@
     rustbn.js "~0.2.0"
     util.promisify "^1.0.1"
 
-"@ethersproject/abi@5.0.0-beta.153", "@ethersproject/abi@5.0.7", "@ethersproject/abi@5.0.9", "@ethersproject/abi@5.4.1", "@ethersproject/abi@^5.0.1", "@ethersproject/abi@^5.1.2", "@ethersproject/abi@^5.4.0":
+"@ethersproject/abi@5.0.0-beta.153":
+  version "5.0.0-beta.153"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abi/-/abi-5.0.0-beta.153.tgz#43a37172b33794e4562999f6e2d555b7599a8eee"
+  integrity sha512-aXweZ1Z7vMNzJdLpR1CZUAIgnwjrZeUSvN9syCwlBaEBUFJmFY+HHnfuTI5vIhVs/mRkfJVrbEyl51JZQqyjAg==
+  dependencies:
+    "@ethersproject/address" ">=5.0.0-beta.128"
+    "@ethersproject/bignumber" ">=5.0.0-beta.130"
+    "@ethersproject/bytes" ">=5.0.0-beta.129"
+    "@ethersproject/constants" ">=5.0.0-beta.128"
+    "@ethersproject/hash" ">=5.0.0-beta.128"
+    "@ethersproject/keccak256" ">=5.0.0-beta.127"
+    "@ethersproject/logger" ">=5.0.0-beta.129"
+    "@ethersproject/properties" ">=5.0.0-beta.131"
+    "@ethersproject/strings" ">=5.0.0-beta.130"
+
+"@ethersproject/abi@5.0.7":
+  version "5.0.7"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abi/-/abi-5.0.7.tgz#79e52452bd3ca2956d0e1c964207a58ad1a0ee7b"
+  integrity sha512-Cqktk+hSIckwP/W8O47Eef60VwmoSC/L3lY0+dIBhQPCNn9E4V7rwmm2aFrNRRDJfFlGuZ1khkQUOc3oBX+niw==
+  dependencies:
+    "@ethersproject/address" "^5.0.4"
+    "@ethersproject/bignumber" "^5.0.7"
+    "@ethersproject/bytes" "^5.0.4"
+    "@ethersproject/constants" "^5.0.4"
+    "@ethersproject/hash" "^5.0.4"
+    "@ethersproject/keccak256" "^5.0.3"
+    "@ethersproject/logger" "^5.0.5"
+    "@ethersproject/properties" "^5.0.3"
+    "@ethersproject/strings" "^5.0.4"
+
+"@ethersproject/abi@5.0.9":
+  version "5.0.9"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abi/-/abi-5.0.9.tgz#738c1c557e56d8f395a5a27caef9b0449bc85a10"
+  integrity sha512-ily2OufA2DTrxkiHQw5GqbkMSnNKuwZBqKsajtT0ERhZy1r9w2CpW1bmtRMIGzaqQxCdn/GEoFogexk72cBBZQ==
+  dependencies:
+    "@ethersproject/address" "^5.0.4"
+    "@ethersproject/bignumber" "^5.0.7"
+    "@ethersproject/bytes" "^5.0.4"
+    "@ethersproject/constants" "^5.0.4"
+    "@ethersproject/hash" "^5.0.4"
+    "@ethersproject/keccak256" "^5.0.3"
+    "@ethersproject/logger" "^5.0.5"
+    "@ethersproject/properties" "^5.0.3"
+    "@ethersproject/strings" "^5.0.4"
+
+"@ethersproject/abi@5.4.1", "@ethersproject/abi@^5.0.1", "@ethersproject/abi@^5.0.5", "@ethersproject/abi@^5.1.2", "@ethersproject/abi@^5.4.0":
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/@ethersproject/abi/-/abi-5.4.1.tgz#6ac28fafc9ef6f5a7a37e30356a2eb31fa05d39b"
   integrity sha512-9mhbjUk76BiSluiiW4BaYyI58KSbDMMQpCLdsAR+RsT2GyATiNYxVv+pGWRrekmsIdY3I+hOqsYQSTkc8L/mcg==
@@ -290,7 +335,7 @@
     "@ethersproject/logger" "^5.0.5"
     "@ethersproject/rlp" "^5.0.3"
 
-"@ethersproject/address@5.4.0", "@ethersproject/address@^5.4.0":
+"@ethersproject/address@5.4.0", "@ethersproject/address@>=5.0.0-beta.128", "@ethersproject/address@^5.4.0":
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/address/-/address-5.4.0.tgz#ba2d00a0f8c4c0854933b963b9a3a9f6eb4a37a3"
   integrity sha512-SD0VgOEkcACEG/C6xavlU1Hy3m5DGSXW3CUHkaaEHbAPPsgi0coP5oNPsxau8eTlZOk/bpa/hKeCNoK5IzVI2Q==
@@ -331,7 +376,16 @@
     "@ethersproject/bytes" "^5.4.0"
     "@ethersproject/properties" "^5.4.0"
 
-"@ethersproject/bignumber@5.0.12", "@ethersproject/bignumber@5.4.1", "@ethersproject/bignumber@^5.0.10", "@ethersproject/bignumber@^5.0.7", "@ethersproject/bignumber@^5.0.8", "@ethersproject/bignumber@^5.4.0":
+"@ethersproject/bignumber@5.0.12":
+  version "5.0.12"
+  resolved "https://registry.yarnpkg.com/@ethersproject/bignumber/-/bignumber-5.0.12.tgz#fe4a78667d7cb01790f75131147e82d6ea7e7cba"
+  integrity sha512-mbFZjwthx6vFlHG9owXP/C5QkNvsA+xHpDCkPPPdG2n1dS9AmZAL5DI0InNLid60rQWL3MXpEl19tFmtL7Q9jw==
+  dependencies:
+    "@ethersproject/bytes" "^5.0.8"
+    "@ethersproject/logger" "^5.0.5"
+    bn.js "^4.4.0"
+
+"@ethersproject/bignumber@5.4.1", "@ethersproject/bignumber@>=5.0.0-beta.130", "@ethersproject/bignumber@^5.0.10", "@ethersproject/bignumber@^5.0.7", "@ethersproject/bignumber@^5.0.8", "@ethersproject/bignumber@^5.4.0":
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/@ethersproject/bignumber/-/bignumber-5.4.1.tgz#64399d3b9ae80aa83d483e550ba57ea062c1042d"
   integrity sha512-fJhdxqoQNuDOk6epfM7yD6J8Pol4NUCy1vkaGAkuujZm0+lNow//MKu1hLhRiYV4BsOHyBv5/lsTjF+7hWwhJg==
@@ -347,7 +401,7 @@
   dependencies:
     "@ethersproject/logger" "^5.0.5"
 
-"@ethersproject/bytes@5.4.0", "@ethersproject/bytes@^5.4.0":
+"@ethersproject/bytes@5.4.0", "@ethersproject/bytes@>=5.0.0-beta.129", "@ethersproject/bytes@^5.0.8", "@ethersproject/bytes@^5.4.0":
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.4.0.tgz#56fa32ce3bf67153756dbaefda921d1d4774404e"
   integrity sha512-H60ceqgTHbhzOj4uRc/83SCN9d+BSUnOkrr2intevqdtEMO1JFVZ1XL84OEZV+QjV36OaZYxtnt4lGmxcGsPfA==
@@ -361,14 +415,29 @@
   dependencies:
     "@ethersproject/bignumber" "^5.0.7"
 
-"@ethersproject/constants@5.4.0", "@ethersproject/constants@^5.4.0":
+"@ethersproject/constants@5.4.0", "@ethersproject/constants@>=5.0.0-beta.128", "@ethersproject/constants@^5.4.0":
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/constants/-/constants-5.4.0.tgz#ee0bdcb30bf1b532d2353c977bf2ef1ee117958a"
   integrity sha512-tzjn6S7sj9+DIIeKTJLjK9WGN2Tj0P++Z8ONEIlZjyoTkBuODN+0VfhAyYksKi43l1Sx9tX2VlFfzjfmr5Wl3Q==
   dependencies:
     "@ethersproject/bignumber" "^5.4.0"
 
-"@ethersproject/contracts@5.0.8", "@ethersproject/contracts@5.4.1":
+"@ethersproject/contracts@5.0.8":
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/@ethersproject/contracts/-/contracts-5.0.8.tgz#71d3ba16853a1555be2e161a6741df186f81c73b"
+  integrity sha512-PecBL4vnsrpuks2lzzkRsOts8csJy338HNDKDIivbFmx92BVzh3ohOOv3XsoYPSXIHQvobF959W+aSk3RCZL/g==
+  dependencies:
+    "@ethersproject/abi" "^5.0.5"
+    "@ethersproject/abstract-provider" "^5.0.4"
+    "@ethersproject/abstract-signer" "^5.0.4"
+    "@ethersproject/address" "^5.0.4"
+    "@ethersproject/bignumber" "^5.0.7"
+    "@ethersproject/bytes" "^5.0.4"
+    "@ethersproject/constants" "^5.0.4"
+    "@ethersproject/logger" "^5.0.5"
+    "@ethersproject/properties" "^5.0.3"
+
+"@ethersproject/contracts@5.4.1":
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/@ethersproject/contracts/-/contracts-5.4.1.tgz#3eb4f35b7fe60a962a75804ada2746494df3e470"
   integrity sha512-m+z2ZgPy4pyR15Je//dUaymRUZq5MtDajF6GwFbGAVmKz/RF+DNIPwF0k5qEcL3wPGVqUjFg2/krlCRVTU4T5w==
@@ -398,7 +467,7 @@
     "@ethersproject/properties" "^5.0.4"
     "@ethersproject/strings" "^5.0.4"
 
-"@ethersproject/hash@5.4.0", "@ethersproject/hash@^5.4.0":
+"@ethersproject/hash@5.4.0", "@ethersproject/hash@>=5.0.0-beta.128", "@ethersproject/hash@^5.4.0":
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/hash/-/hash-5.4.0.tgz#d18a8e927e828e22860a011f39e429d388344ae0"
   integrity sha512-xymAM9tmikKgbktOCjW60Z5sdouiIIurkZUr9oW5NOex5uwxrbsYG09kb5bMcNjlVeJD3yPivTNzViIs1GCbqA==
@@ -494,7 +563,7 @@
     "@ethersproject/bytes" "^5.0.4"
     js-sha3 "0.5.7"
 
-"@ethersproject/keccak256@5.4.0", "@ethersproject/keccak256@^5.4.0":
+"@ethersproject/keccak256@5.4.0", "@ethersproject/keccak256@>=5.0.0-beta.127", "@ethersproject/keccak256@^5.4.0":
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/keccak256/-/keccak256-5.4.0.tgz#7143b8eea4976080241d2bd92e3b1f1bf7025318"
   integrity sha512-FBI1plWet+dPUvAzPAeHzRKiPpETQzqSUWR1wXJGHVWi4i8bOSrpC3NwpkPjgeXG7MnugVc1B42VbfnQikyC/A==
@@ -507,7 +576,7 @@
   resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.0.8.tgz#135c1903d35c878265f3cbf2b287042c4c20d5d4"
   integrity sha512-SkJCTaVTnaZ3/ieLF5pVftxGEFX56pTH+f2Slrpv7cU0TNpUZNib84QQdukd++sWUp/S7j5t5NW+WegbXd4U/A==
 
-"@ethersproject/logger@5.4.1":
+"@ethersproject/logger@5.4.1", "@ethersproject/logger@>=5.0.0-beta.129":
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.4.1.tgz#503bd33683538b923c578c07d1c2c0dd18672054"
   integrity sha512-DZ+bRinnYLPw1yAC64oRl0QyVZj43QeHIhVKfD/+YwSz4wsv1pfwb5SOFjz+r710YEWzU6LrhuSjpSO+6PeE4A==
@@ -554,7 +623,7 @@
   dependencies:
     "@ethersproject/logger" "^5.0.5"
 
-"@ethersproject/properties@5.4.1":
+"@ethersproject/properties@5.4.1", "@ethersproject/properties@>=5.0.0-beta.131":
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/@ethersproject/properties/-/properties-5.4.1.tgz#9f051f976ce790142c6261ccb7b826eaae1f2f36"
   integrity sha512-cyCGlF8wWlIZyizsj2PpbJ9I7rIlUAfnHYwy/T90pdkSn/NFTa5YWZx2wTJBe9V7dD65dcrrEMisCRUJiq6n3w==
@@ -568,7 +637,32 @@
   dependencies:
     "@ethersproject/logger" "^5.4.0"
 
-"@ethersproject/providers@5.0.17", "@ethersproject/providers@5.4.5":
+"@ethersproject/providers@5.0.17":
+  version "5.0.17"
+  resolved "https://registry.yarnpkg.com/@ethersproject/providers/-/providers-5.0.17.tgz#f380e7831149e24e7a1c6c9b5fb1d6dfc729d024"
+  integrity sha512-bJnvs5X7ttU5x2ekGJYG7R3Z+spZawLFfR0IDsbaMDLiCwZOyrgk+VTBU7amSFLT0WUhWFv8WwSUB+AryCQG1Q==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.0.4"
+    "@ethersproject/abstract-signer" "^5.0.4"
+    "@ethersproject/address" "^5.0.4"
+    "@ethersproject/basex" "^5.0.3"
+    "@ethersproject/bignumber" "^5.0.7"
+    "@ethersproject/bytes" "^5.0.4"
+    "@ethersproject/constants" "^5.0.4"
+    "@ethersproject/hash" "^5.0.4"
+    "@ethersproject/logger" "^5.0.5"
+    "@ethersproject/networks" "^5.0.3"
+    "@ethersproject/properties" "^5.0.3"
+    "@ethersproject/random" "^5.0.3"
+    "@ethersproject/rlp" "^5.0.3"
+    "@ethersproject/sha2" "^5.0.3"
+    "@ethersproject/strings" "^5.0.4"
+    "@ethersproject/transactions" "^5.0.5"
+    "@ethersproject/web" "^5.0.6"
+    bech32 "1.1.4"
+    ws "7.2.3"
+
+"@ethersproject/providers@5.4.5":
   version "5.4.5"
   resolved "https://registry.yarnpkg.com/@ethersproject/providers/-/providers-5.4.5.tgz#eb2ea2a743a8115f79604a8157233a3a2c832928"
   integrity sha512-1GkrvkiAw3Fj28cwi1Sqm8ED1RtERtpdXmRfwIBGmqBSN5MoeRUHuwHPppMtbPayPgpFcvD7/Gdc9doO5fGYgw==
@@ -696,7 +790,7 @@
     "@ethersproject/constants" "^5.0.4"
     "@ethersproject/logger" "^5.0.5"
 
-"@ethersproject/strings@5.4.0", "@ethersproject/strings@^5.4.0":
+"@ethersproject/strings@5.4.0", "@ethersproject/strings@>=5.0.0-beta.130", "@ethersproject/strings@^5.4.0":
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/strings/-/strings-5.4.0.tgz#fb12270132dd84b02906a8d895ae7e7fa3d07d9a"
   integrity sha512-k/9DkH5UGDhv7aReXLluFG5ExurwtIpUfnDNhQA29w896Dw3i4uDTz01Quaptbks1Uj9kI8wo9tmW73wcIEaWA==
@@ -10361,6 +10455,11 @@ write@1.0.3:
   integrity sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==
   dependencies:
     mkdirp "^0.5.1"
+
+ws@7.2.3:
+  version "7.2.3"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.2.3.tgz#a5411e1fb04d5ed0efee76d26d5c46d830c39b46"
+  integrity sha512-HTDl9G9hbkNDk98naoR/cHDws7+EyYMOdL1BmjsZXRUjf7d+MficC4B7HLUPlSiho0vg+CWKrGIt/VJBd1xunQ==
 
 ws@7.4.6:
   version "7.4.6"


### PR DESCRIPTION
Motivation in [this comment](https://github.com/SetProtocol/set-protocol-v2/pull/131#discussion_r705766240). I expect we'll encounter fewer dependency mismatches for ethers subpackages if we import from the umbrella package. Also the [ethers docs](https://github.com/ethers-io/ethers.js/tree/master/packages/bignumber) say:

> Most users will prefer to use the umbrella package, but for those with more specific needs, individual components can be imported.

### Testing
`yarn build` succeeds