### PR TITLE
Update getRequiredComponentIssuanceUnits to use token balances to cal…

### DIFF
--- a/contracts/protocol/modules/DebtIssuanceModule.sol
+++ b/contracts/protocol/modules/DebtIssuanceModule.sol
@@ -390,6 +390,7 @@ contract DebtIssuanceModule is ModuleBase, ReentrancyGuard {
     )
         external
         view
+        virtual
         returns (address[] memory, uint256[] memory, uint256[] memory)
     {
         (

--- a/contracts/protocol/modules/DebtIssuanceModuleV2.sol
+++ b/contracts/protocol/modules/DebtIssuanceModuleV2.sol
@@ -27,6 +27,7 @@ import { IController } from "../../interfaces/IController.sol";
 import { Invoke } from "../lib/Invoke.sol";
 import { ISetToken } from "../../interfaces/ISetToken.sol";
 import { IssuanceValidationUtils } from "../lib/IssuanceValidationUtils.sol";
+import { Position } from "../lib/Position.sol";
 
 /**
  * @title DebtIssuanceModuleV2
@@ -45,8 +46,12 @@ import { IssuanceValidationUtils } from "../lib/IssuanceValidationUtils.sol";
  * For example, this module can be used to issue/redeem SetTokens which has one or more aTokens as its components.
  * The new checks do NOT apply to any transfers that are part of an external position. A token that has rounding issues may lead to 
  * reverts if it is included as an external position unless explicitly allowed in a module hook.
+ *
+ * The getRequiredComponentIssuanceUnits function on this module assumes that Default token balances will be synced on every issuance
+ * and redemption. If token balances are not being synced it will over-estimate the amount of tokens required to issue a Set.
  */
 contract DebtIssuanceModuleV2 is DebtIssuanceModule {
+    using Position for uint256;
     
     /* ============ Constructor ============ */
     
@@ -184,6 +189,57 @@ contract DebtIssuanceModuleV2 is DebtIssuanceModule {
         );
     }
 
+    /* ============ External View Functions ============ */
+
+    /**
+     * Calculates the amount of each component needed to collateralize passed issue quantity plus fees of Sets as well as amount of debt
+     * that will be returned to caller. Default equity alues are calculated based on token balances and not position units in order to more
+     * closely track any accrued tokens that will be synced during issuance. External equity and debt positions will use the stored position
+     * units. IF TOKEN VALUES ARE NOT BEING SYNCED DURING ISSUANCE THIS FUNCTION WILL OVER ESTIMATE THE AMOUNT OF REQUIRED TOKENS.
+     *
+     * @param _setToken         Instance of the SetToken to issue
+     * @param _quantity         Amount of Sets to be issued
+     *
+     * @return address[]        Array of component addresses making up the Set
+     * @return uint256[]        Array of equity notional amounts of each component, respectively, represented as uint256
+     * @return uint256[]        Array of debt notional amounts of each component, respectively, represented as uint256
+     */
+    function getRequiredComponentIssuanceUnits(
+        ISetToken _setToken,
+        uint256 _quantity
+    )
+        external
+        view
+        override
+        returns (address[] memory, uint256[] memory, uint256[] memory)
+    {
+        (
+            uint256 totalQuantity,,
+        ) = calculateTotalFees(_setToken, _quantity, true);
+
+        if(_setToken.totalSupply() == 0) {
+            return _calculateRequiredComponentIssuanceUnits(_setToken, totalQuantity, true);
+        } else {
+            (
+                address[] memory components,
+                uint256[] memory equityUnits,
+                uint256[] memory debtUnits
+            ) = _getTotalIssuanceUnitsFromBalances(_setToken);
+
+            uint256 componentsLength = components.length;
+            uint256[] memory totalEquityUnits = new uint256[](componentsLength);
+            uint256[] memory totalDebtUnits = new uint256[](componentsLength);
+            for (uint256 i = 0; i < components.length; i++) {
+                // Use preciseMulCeil to round up to ensure overcollateration of equity when small issue quantities are provided
+                // and use preciseMul to round debt calculations down to make sure we don't return too much debt to issuer
+                totalEquityUnits[i] = equityUnits[i].preciseMulCeil(totalQuantity);
+                totalDebtUnits[i] = debtUnits[i].preciseMul(totalQuantity);
+            }
+
+            return (components, totalEquityUnits, totalDebtUnits);
+        }
+    }
+
     /* ============ Internal Functions ============ */
     
     /**
@@ -274,5 +330,58 @@ contract DebtIssuanceModuleV2 is DebtIssuanceModule {
                 }
             }
         }
+    }
+    /**
+     * Reimplementation of _getTotalIssuanceUnits but instead derives Default equity positions from token balances on Set instead of from
+     * position units. This function is ONLY to be used in getRequiredComponentIssuanceUnits in order to return more accurate required
+     * token amounts to issuers when positions are being synced on issuance.
+     *
+     * @param _setToken         Instance of the SetToken to issue
+     *
+     * @return address[]        Array of component addresses making up the Set
+     * @return uint256[]        Array of equity unit amounts of each component, respectively, represented as uint256
+     * @return uint256[]        Array of debt unit amounts of each component, respectively, represented as uint256
+     */
+    function _getTotalIssuanceUnitsFromBalances(
+        ISetToken _setToken
+    )
+        internal
+        view
+        returns (address[] memory, uint256[] memory, uint256[] memory)
+    {
+        address[] memory components = _setToken.getComponents();
+        uint256 componentsLength = components.length;
+
+        uint256[] memory equityUnits = new uint256[](componentsLength);
+        uint256[] memory debtUnits = new uint256[](componentsLength);
+
+        uint256 totalSupply = _setToken.totalSupply();
+
+        for (uint256 i = 0; i < components.length; i++) {
+            address component = components[i];
+            int256 cumulativeEquity = totalSupply
+                                        .getDefaultPositionUnit(IERC20(component).balanceOf(address(_setToken)))
+                                        .toInt256();
+            int256 cumulativeDebt = 0;
+            address[] memory externalPositions = _setToken.getExternalPositionModules(component);
+
+            if (externalPositions.length > 0) {
+                for (uint256 j = 0; j < externalPositions.length; j++) { 
+                    int256 externalPositionUnit = _setToken.getExternalPositionRealUnit(component, externalPositions[j]);
+
+                    // If positionUnit <= 0 it will be "added" to debt position
+                    if (externalPositionUnit > 0) {
+                        cumulativeEquity = cumulativeEquity.add(externalPositionUnit);
+                    } else {
+                        cumulativeDebt = cumulativeDebt.add(externalPositionUnit);
+                    }
+                }
+            }
+
+            equityUnits[i] = cumulativeEquity.toUint256();
+            debtUnits[i] = cumulativeDebt.mul(-1).toUint256();
+        }
+
+        return (components, equityUnits, debtUnits);
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@setprotocol/set-protocol-v2",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "",
   "main": "dist",
   "types": "dist/types",


### PR DESCRIPTION
…culate default position issue amounts instead of position units.

This PR changes the `getRequiredComponentIssuanceUnits` getter to use the current component *balances* when calculating the amount of tokens required to issue a `Default` position instead of the `Default positionUnit`. We do this in order to provide better estimates for AAVE tokens which accrue tokens every block and are synced on every issuance and redemption for our FLI products.

We are treating this as a more one-off solution for dealing with AAVE. This module is now very specific to Sets that sync their balances on every issuance and redemption. `getRequiredComponentIssuanceUnits` will over estimate any Default positions that DO NOT sync every issuance and redemption AND have extra accrued tokens. If syncing is done through the Airdrop module and the manager has enabled an Airdrop fee then this will over-estimate the amount of tokens needed for issuance.

# Code Review Processes
## New Feature Review
Before submitting a pull request for new review, make sure the following is done:
* Design doc is created and posted here: **Not used here**
* Code cleanliness and completeness is addressed via [guidelines](https://app.gitbook.com/@setprotocol-1/s/set/smart-contract-engineering/sc-code-review-process)

README Checks
- [x] README has proper context for the reviewer to understand what the code includes, any important design considerations, and areas to pay more attention to

Code Checks
- [x] Add explanatory comments. If there is complex code that requires specific context or understanding, note that in a comment
- [x] Remove unncessary comments. Any comments that do not add additional context, information, etc. should be removed
- [x] Add javadocs. 
- [x] Scrub through the code for inconsistencies (e.g. removing extra spaces)
- [x] Ensure there are not any .onlys in spec files


Broader Considerations
- [x] Ensure variable, function and event naming is clear, consistent, and reflective for the scope of the code.
- [x] Consider if certain pieces of logic should be placed in a different library, module
