### PR TITLE
Brian/slippage iss review changes

### DIFF
--- a/contracts/interfaces/IModuleIssuanceHookV2.sol
+++ b/contracts/interfaces/IModuleIssuanceHookV2.sol
@@ -1,5 +1,5 @@
 /*
-    Copyright 2020 Set Labs Inc.
+    Copyright 2021 Set Labs Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/contracts/interfaces/IModuleIssuanceHookV2.sol
+++ b/contracts/interfaces/IModuleIssuanceHookV2.sol
@@ -50,16 +50,9 @@ interface IModuleIssuanceHookV2 {
 
     /**
      * Adjustments should return the NET CHANGE in POSITION UNITS for each component in the SetToken's
-     * components array. Each entry in the returned arrays should index to the same component in the
-     * SetToken's components array (called using getComponents()). Directional adjustments should be made
-     * according to the following table (i.e. returning a negative debt number means debt is reduced during
-     * issue/redeem):
-     * | ------------------------------------|
-     * | Type    |  Positive |  Negative     |
-     * | -----   |---------- | --------------|
-     * | Equity  | Add Equity| Equity Reduced|
-     * | Debt    | Add Debt  | Debt Reduced  |
-     * | ------------------------------------|
+     * components array (i.e. if debt is greater than current debt position unit return negative number).
+     * Each entry in the returned arrays should index to the same component in the SetToken's components
+     * array (called using getComponents()).
      */
     function getIssuanceAdjustments(
         ISetToken _setToken,

--- a/contracts/protocol/modules/SlippageIssuanceModule.sol
+++ b/contracts/protocol/modules/SlippageIssuanceModule.sol
@@ -316,7 +316,7 @@ contract SlippageIssuanceModule is DebtIssuanceModule {
                 adjustedEquityUnits.preciseMul(_quantity);
 
             // NOTE: If debtAdjustment is negative and exceeds debtUnits in absolute value this will revert
-            uint256 adjustedDebtUnits = debtUnits[i].toInt256().add(_debtAdjustments[i]).toUint256();
+            uint256 adjustedDebtUnits = debtUnits[i].toInt256().sub(_debtAdjustments[i]).toUint256();
 
             // Use preciseMulCeil to round up to ensure overcollateration when small redeem quantities are provided
             // and preciseMul to round down to ensure overcollateration when small issue quantities are provided

--- a/contracts/protocol/modules/SlippageIssuanceModule.sol
+++ b/contracts/protocol/modules/SlippageIssuanceModule.sol
@@ -190,6 +190,8 @@ contract SlippageIssuanceModule is DebtIssuanceModule {
         );
     }
 
+    /* ============ External View Functions ============ */
+
     /**
      * Calculates the amount of each component needed to collateralize passed issue quantity plus fees of Sets as well as amount of debt
      * that will be returned to caller. Overrides inherited function to take into account position updates from pre action module hooks.
@@ -270,6 +272,8 @@ contract SlippageIssuanceModule is DebtIssuanceModule {
             debtRedemptionAdjustments
         );
     }
+
+    /* ============ Internal Functions ============ */
 
     /**
      * Similar to _calculateRequiredComponentIssuanceUnits but adjustments for positions that will be updated DURING the issue

--- a/contracts/protocol/modules/SlippageIssuanceModule.sol
+++ b/contracts/protocol/modules/SlippageIssuanceModule.sol
@@ -34,7 +34,7 @@ import { Position } from "../lib/Position.sol";
  * @title SlippageIssuanceModule
  * @author Set Protocol
  *
- * The SlippageIssuanceModule is a module that enables users to issue and redeem SetTokens that requires a transaction that incurs slippage.
+ * The SlippageIssuanceModule is a module that enables users to issue and redeem SetTokens that requires a transaction that incurs slippage
  * in order to replicate the Set. Like the DebtIssuanceModule, module hooks are added to allow for syncing of positions, and component
  * level hooks are added to ensure positions are replicated correctly. The manager can define arbitrary issuance logic in the manager hook,
  * as well as specify issue and redeem fees. The getRequiredComponentIssuanceUnits and it's redemption counterpart now also include any
@@ -306,7 +306,7 @@ contract SlippageIssuanceModule is DebtIssuanceModule {
         uint256[] memory totalEquityUnits = new uint256[](components.length);
         uint256[] memory totalDebtUnits = new uint256[](components.length);
         for (uint256 i = 0; i < components.length; i++) {
-            // NOTE: If equityAdjustment is negative and exceeds debtUnits in absolute value this will revert
+            // NOTE: If equityAdjustment is negative and exceeds equityUnits in absolute value this will revert
             uint256 adjustedEquityUnits = equityUnits[i].toInt256().add(_equityAdjustments[i]).toUint256();
 
             // Use preciseMulCeil to round up to ensure overcollateration when small issue quantities are provided

--- a/test/protocol/modules/slippageIssuanceModule.spec.ts
+++ b/test/protocol/modules/slippageIssuanceModule.spec.ts
@@ -25,7 +25,7 @@ import { ContractTransaction } from "ethers";
 
 const expect = getWaffleExpect();
 
-describe.only("SlippageIssuanceModule", () => {
+describe("SlippageIssuanceModule", () => {
   let owner: Account;
   let manager: Account;
   let feeRecipient: Account;

--- a/test/protocol/modules/slippageIssuanceModule.spec.ts
+++ b/test/protocol/modules/slippageIssuanceModule.spec.ts
@@ -27,7 +27,7 @@ import { ContractTransaction } from "ethers";
 
 const expect = getWaffleExpect();
 
-describe("SlippageIssuanceModule", () => {
+describe.only("SlippageIssuanceModule", () => {
   let owner: Account;
   let manager: Account;
   let feeRecipient: Account;
@@ -486,7 +486,7 @@ describe("SlippageIssuanceModule", () => {
               const [components, equityFlows, debtFlows] = await subject();
 
               const mintQuantity = preciseMul(subjectQuantity, ether(1).add(issueFee));
-              const daiFlows = preciseMulCeil(mintQuantity, debtUnits.add(daiDebtAdjustment));
+              const daiFlows = preciseMulCeil(mintQuantity, debtUnits.sub(daiDebtAdjustment));
               const wethFlows = preciseMul(mintQuantity, ether(1).add(ethIssuanceAdjustment));
 
               const expectedComponents = await setToken.getComponents();
@@ -514,7 +514,7 @@ describe("SlippageIssuanceModule", () => {
               const [components, equityFlows, debtFlows] = await subject();
 
               const mintQuantity = preciseMul(subjectQuantity, ether(1).add(issueFee));
-              const daiFlows = preciseMulCeil(mintQuantity, debtUnits.add(daiDebtAdjustment));
+              const daiFlows = preciseMulCeil(mintQuantity, debtUnits.sub(daiDebtAdjustment));
               const wethFlows = preciseMul(mintQuantity, ether(1).add(ethIssuanceAdjustment));
 
               const expectedComponents = await setToken.getComponents();
@@ -544,7 +544,7 @@ describe("SlippageIssuanceModule", () => {
 
           describe("when debt positional adjustments lead to negative results", async () => {
             before(async () => {
-              daiDebtAdjustment = ether(101).mul(-1);
+              daiDebtAdjustment = ether(101);
             });
 
             after(async () => {
@@ -664,7 +664,7 @@ describe("SlippageIssuanceModule", () => {
               const [components, equityFlows, debtFlows] = await subject();
 
               const mintQuantity = preciseMul(subjectQuantity, ether(1).sub(issueFee));
-              const daiFlows = preciseMulCeil(mintQuantity, debtUnits.add(daiDebtAdjustment));
+              const daiFlows = preciseMulCeil(mintQuantity, debtUnits.sub(daiDebtAdjustment));
               const wethFlows = preciseMul(mintQuantity, ether(1).add(ethIssuanceAdjustment));
 
               const expectedComponents = await setToken.getComponents();
@@ -687,7 +687,7 @@ describe("SlippageIssuanceModule", () => {
               const [components, equityFlows, debtFlows] = await subject();
 
               const mintQuantity = preciseMul(subjectQuantity, ether(1).sub(issueFee));
-              const daiFlows = preciseMulCeil(mintQuantity, debtUnits.add(daiDebtAdjustment));
+              const daiFlows = preciseMulCeil(mintQuantity, debtUnits.sub(daiDebtAdjustment));
               const wethFlows = preciseMul(mintQuantity, ether(1).add(ethIssuanceAdjustment));
 
               const expectedComponents = await setToken.getComponents();
@@ -717,7 +717,7 @@ describe("SlippageIssuanceModule", () => {
 
           describe("when debt positional adjustments lead to negative results", async () => {
             before(async () => {
-              daiDebtAdjustment = ether(101).mul(-1);
+              daiDebtAdjustment = ether(101);
             });
 
             after(async () => {

--- a/test/protocol/modules/slippageIssuanceModule.spec.ts
+++ b/test/protocol/modules/slippageIssuanceModule.spec.ts
@@ -17,8 +17,6 @@ import {
 import {
   addSnapshotBeforeRestoreAfterEach,
   getAccounts,
-  getRandomAccount,
-  getRandomAddress,
   getSystemFixture,
   getWaffleExpect,
 } from "@utils/test/index";
@@ -41,6 +39,12 @@ describe.only("SlippageIssuanceModule", () => {
   let slippageIssuance: SlippageIssuanceModule;
   let issuanceHook: ManagerIssuanceHookMock;
   let setToken: SetToken;
+
+  let preIssueHook: Address;
+  let initialize: boolean;
+  let maxFee: BigNumber;
+  let issueFee: BigNumber;
+  let redeemFee: BigNumber;
 
   before(async () => {
     [
@@ -75,135 +79,17 @@ describe.only("SlippageIssuanceModule", () => {
     );
 
     await externalPositionModule.initialize(setToken.address);
+
+    preIssueHook = ADDRESS_ZERO;
+    initialize = true;
+    maxFee = ether(0.02);
+    issueFee = ether(0.005);
+    redeemFee = ether(0.005);
   });
 
   addSnapshotBeforeRestoreAfterEach();
 
-  describe("#initialize", async () => {
-    let subjectSetToken: Address;
-    let subjectMaxManagerFee: BigNumber;
-    let subjectManagerIssueFee: BigNumber;
-    let subjectManagerRedeemFee: BigNumber;
-    let subjectFeeRecipient: Address;
-    let subjectManagerIssuanceHook: Address;
-    let subjectCaller: Account;
-
-    beforeEach(async () => {
-      subjectSetToken = setToken.address;
-      subjectMaxManagerFee = ether(0.02);
-      subjectManagerIssueFee = ether(0.005);
-      subjectManagerRedeemFee = ether(0.004);
-      subjectFeeRecipient = feeRecipient.address;
-      subjectManagerIssuanceHook = owner.address;
-      subjectCaller = manager;
-    });
-
-    async function subject(): Promise<ContractTransaction> {
-      return slippageIssuance.connect(subjectCaller.wallet).initialize(
-        subjectSetToken,
-        subjectMaxManagerFee,
-        subjectManagerIssueFee,
-        subjectManagerRedeemFee,
-        subjectFeeRecipient,
-        subjectManagerIssuanceHook
-      );
-    }
-
-    it("should set the correct state", async () => {
-      await subject();
-
-      const settings: any = await slippageIssuance.issuanceSettings(subjectSetToken);
-
-      expect(settings.maxManagerFee).to.eq(subjectMaxManagerFee);
-      expect(settings.managerIssueFee).to.eq(subjectManagerIssueFee);
-      expect(settings.managerRedeemFee).to.eq(subjectManagerRedeemFee);
-      expect(settings.feeRecipient).to.eq(subjectFeeRecipient);
-      expect(settings.managerIssuanceHook).to.eq(subjectManagerIssuanceHook);
-    });
-
-    describe("when the issue fee is greater than the maximum fee", async () => {
-      beforeEach(async () => {
-        subjectManagerIssueFee = ether(0.03);
-      });
-
-      it("should revert", async () => {
-        await expect(subject()).to.be.revertedWith("Issue fee can't exceed maximum fee");
-      });
-    });
-
-    describe("when the redeem fee is greater than the maximum fee", async () => {
-      beforeEach(async () => {
-        subjectManagerRedeemFee = ether(0.03);
-      });
-
-      it("should revert", async () => {
-        await expect(subject()).to.be.revertedWith("Redeem fee can't exceed maximum fee");
-      });
-    });
-
-    describe("when the caller is not the SetToken manager", async () => {
-      beforeEach(async () => {
-        subjectCaller = await getRandomAccount();
-      });
-
-      it("should revert", async () => {
-        await expect(subject()).to.be.revertedWith("Must be the SetToken manager");
-      });
-    });
-
-    describe("when SetToken is not in pending state", async () => {
-      beforeEach(async () => {
-        const newModule = await getRandomAddress();
-        await setup.controller.addModule(newModule);
-
-        const issuanceModuleNotPendingSetToken = await setup.createSetToken(
-          [setup.weth.address],
-          [ether(1)],
-          [newModule],
-          manager.address
-        );
-
-        subjectSetToken = issuanceModuleNotPendingSetToken.address;
-      });
-
-      it("should revert", async () => {
-        await expect(subject()).to.be.revertedWith("Must be pending initialization");
-      });
-    });
-
-    describe("when the SetToken is not enabled on the controller", async () => {
-      beforeEach(async () => {
-        const nonEnabledSetToken = await setup.createNonControllerEnabledSetToken(
-          [setup.weth.address],
-          [ether(1)],
-          [slippageIssuance.address],
-          manager.address
-        );
-
-        subjectSetToken = nonEnabledSetToken.address;
-      });
-
-      it("should revert", async () => {
-        await expect(subject()).to.be.revertedWith("Must be controller-enabled SetToken");
-      });
-    });
-  });
-
-  context("SlippageIssuanceModule has been initialized", async () => {
-    let preIssueHook: Address;
-    let initialize: boolean;
-    let maxFee: BigNumber;
-    let issueFee: BigNumber;
-    let redeemFee: BigNumber;
-
-    before(async () => {
-      preIssueHook = ADDRESS_ZERO;
-      initialize = true;
-      maxFee = ether(0.02);
-      issueFee = ether(0.005);
-      redeemFee = ether(0.005);
-    });
-
+  context("External debt module has been registered with SlippageIssuanceModule", async () => {
     beforeEach(async () => {
       if (initialize) {
         await slippageIssuance.connect(manager.wallet).initialize(
@@ -215,187 +101,76 @@ describe.only("SlippageIssuanceModule", () => {
           preIssueHook
         );
       }
+
+      await debtModule.connect(manager.wallet).initialize(setToken.address);
     });
 
-    describe("#removeModule", async () => {
-      let subjectModule: Address;
-
-      beforeEach(async () => {
-        subjectModule = slippageIssuance.address;
-      });
-
-      async function subject(): Promise<ContractTransaction> {
-        return setToken.connect(manager.wallet).removeModule(subjectModule);
-      }
-
-      it("should set the correct state", async () => {
-        await subject();
-
-        const settings: any = await slippageIssuance.issuanceSettings(setToken.address);
-
-        expect(settings.managerIssueFee).to.eq(ZERO);
-        expect(settings.managerRedeemFee).to.eq(ZERO);
-        expect(settings.feeRecipient).to.eq(ADDRESS_ZERO);
-        expect(settings.managerIssuanceHook).to.eq(ADDRESS_ZERO);
-      });
-
-      describe("when a module is still registered with the SlippageIssuanceModule", async () => {
-        beforeEach(async () => {
-          await setup.controller.addModule(dummyModule.address);
-          await setToken.connect(manager.wallet).addModule(dummyModule.address);
-          await setToken.connect(dummyModule.wallet).initializeModule();
-
-          await slippageIssuance.connect(dummyModule.wallet).registerToIssuanceModule(setToken.address);
-        });
-
-        it("should revert", async () => {
-          await expect(subject()).to.be.revertedWith("Registered modules must be removed.");
-        });
-      });
-    });
-
-    describe("#registerToIssuanceModule", async () => {
+    describe("#getRequiredComponentIssuanceUnits", async () => {
       let subjectSetToken: Address;
-      let subjectCaller: Account;
+      let subjectQuantity: BigNumber;
+
+      const debtUnits: BigNumber = ether(100);
 
       beforeEach(async () => {
-        await setup.controller.addModule(dummyModule.address);
-        await setToken.connect(manager.wallet).addModule(dummyModule.address);
-        await setToken.connect(dummyModule.wallet).initializeModule();
+        await debtModule.addDebt(setToken.address, setup.dai.address, debtUnits);
 
         subjectSetToken = setToken.address;
-        subjectCaller = dummyModule;
+        subjectQuantity = ether(1);
       });
 
-      async function subject(): Promise<ContractTransaction> {
-        return slippageIssuance.connect(subjectCaller.wallet).registerToIssuanceModule(
-          subjectSetToken
+      async function subject(): Promise<any> {
+        return slippageIssuance.getRequiredComponentIssuanceUnits(
+          subjectSetToken,
+          subjectQuantity
         );
       }
 
-      it("should add dummyModule to moduleIssuanceHooks", async () => {
-        await subject();
+      it("should return the correct issue token amounts", async () => {
+        const [components, equityFlows, debtFlows] = await subject();
 
-        const moduleHooks = await slippageIssuance.getModuleIssuanceHooks(subjectSetToken);
-        expect(moduleHooks).to.contain(subjectCaller.address);
+        const mintQuantity = preciseMul(subjectQuantity, ether(1).add(issueFee));
+        const daiFlows = preciseMulCeil( mintQuantity, debtUnits);
+        const wethFlows = preciseMul(mintQuantity, ether(1));
+
+        const expectedComponents = await setToken.getComponents();
+        const expectedEquityFlows = [wethFlows, ZERO];
+        const expectedDebtFlows = [ZERO, daiFlows];
+
+        expect(JSON.stringify(expectedComponents)).to.eq(JSON.stringify(components));
+        expect(JSON.stringify(expectedEquityFlows)).to.eq(JSON.stringify(equityFlows));
+        expect(JSON.stringify(expectedDebtFlows)).to.eq(JSON.stringify(debtFlows));
       });
 
-      it("should mark dummyModule as a valid module issuance hook", async () => {
-        await subject();
-
-        const isModuleHook = await slippageIssuance.isModuleIssuanceHook(subjectSetToken, dummyModule.address);
-        expect(isModuleHook).to.be.true;
-      });
-
-      describe("when SlippageIssuanceModule is not initialized", async () => {
-        before(async () => {
-          initialize = false;
-        });
-
-        after(async () => {
-          initialize = true;
-        });
-
-        it("should revert", async () => {
-          await expect(subject()).to.be.revertedWith("Must be a valid and initialized SetToken");
-        });
-      });
-
-      describe("when module is already registered", async () => {
-        beforeEach(async () => {
-          await subject();
-        });
-
-        it("should revert", async () => {
-          await expect(subject()).to.be.revertedWith("Module already registered.");
-        });
-      });
-    });
-
-    describe("#unregisterFromIssuanceModule", async () => {
-      let subjectSetToken: Address;
-      let subjectCaller: Account;
-      let register: boolean;
-
-      before(async () => {
-        register = true;
-      });
-
-      beforeEach(async () => {
-        await setup.controller.addModule(dummyModule.address);
-        await setToken.connect(manager.wallet).addModule(dummyModule.address);
-        await setToken.connect(dummyModule.wallet).initializeModule();
-
-        if (register) {
-          await slippageIssuance.connect(dummyModule.wallet).registerToIssuanceModule(setToken.address);
-        }
-
-        subjectSetToken = setToken.address;
-        subjectCaller = dummyModule;
-      });
-
-      async function subject(): Promise<ContractTransaction> {
-        return slippageIssuance.connect(subjectCaller.wallet).unregisterFromIssuanceModule(
-          subjectSetToken
-        );
-      }
-
-      it("should remove dummyModule from issuanceSettings", async () => {
-        const preModuleHooks = await slippageIssuance.getModuleIssuanceHooks(subjectSetToken);
-        expect(preModuleHooks).to.contain(subjectCaller.address);
-
-        await subject();
-
-        const postModuleHooks = await slippageIssuance.getModuleIssuanceHooks(subjectSetToken);
-        expect(postModuleHooks).to.not.contain(subjectCaller.address);
-      });
-
-      it("should not mark dummyModule as a valid module issuance hook", async () => {
-        await subject();
-
-        const isModuleHook = await slippageIssuance.isModuleIssuanceHook(subjectSetToken, dummyModule.address);
-        expect(isModuleHook).to.be.false;
-      });
-
-      describe("when calling module isn't registered", async () => {
-        before(async () => {
-          register = false;
-        });
-
-        after(async () => {
-          register = true;
-        });
-
-        it("should revert", async () => {
-          await expect(subject()).to.be.revertedWith("Module not registered.");
-        });
-      });
-    });
-
-    context("External debt module has been registered with SlippageIssuanceModule", async () => {
-      beforeEach(async () => {
-        await debtModule.connect(manager.wallet).initialize(setToken.address);
-      });
-
-      describe("#getRequiredComponentIssuanceUnits", async () => {
-        let subjectSetToken: Address;
-        let subjectQuantity: BigNumber;
-
-        const debtUnits: BigNumber = ether(100);
+      describe("when an additive external equity position is in place", async () => {
+        const externalUnits: BigNumber = ether(1);
 
         beforeEach(async () => {
-          await debtModule.addDebt(setToken.address, setup.dai.address, debtUnits);
-
-          subjectSetToken = setToken.address;
-          subjectQuantity = ether(1);
+          await externalPositionModule.addExternalPosition(setToken.address, setup.weth.address, externalUnits);
         });
 
-        async function subject(): Promise<any> {
-          return slippageIssuance.getRequiredComponentIssuanceUnits(
-            subjectSetToken,
-            subjectQuantity
-          );
-        }
+        it("should return the correct issue token amounts", async () => {
+          const [components, equityFlows, debtFlows] = await subject();
+
+          const mintQuantity = preciseMul(subjectQuantity, ether(1).add(issueFee));
+          const daiFlows = preciseMulCeil( mintQuantity, debtUnits);
+          const wethFlows = preciseMul(mintQuantity, ether(1).add(externalUnits));
+
+          const expectedComponents = await setToken.getComponents();
+          const expectedEquityFlows = [wethFlows, ZERO];
+          const expectedDebtFlows = [ZERO, daiFlows];
+
+          expect(JSON.stringify(expectedComponents)).to.eq(JSON.stringify(components));
+          expect(JSON.stringify(expectedEquityFlows)).to.eq(JSON.stringify(equityFlows));
+          expect(JSON.stringify(expectedDebtFlows)).to.eq(JSON.stringify(debtFlows));
+        });
+      });
+
+      describe("when a non-additive external equity position is in place", async () => {
+        const externalUnits: BigNumber = bitcoin(.5);
+
+        beforeEach(async () => {
+          await externalPositionModule.addExternalPosition(setToken.address, setup.wbtc.address, externalUnits);
+        });
 
         it("should return the correct issue token amounts", async () => {
           const [components, equityFlows, debtFlows] = await subject();
@@ -403,29 +178,44 @@ describe.only("SlippageIssuanceModule", () => {
           const mintQuantity = preciseMul(subjectQuantity, ether(1).add(issueFee));
           const daiFlows = preciseMulCeil( mintQuantity, debtUnits);
           const wethFlows = preciseMul(mintQuantity, ether(1));
+          const btcFlows = preciseMul(mintQuantity, externalUnits);
 
           const expectedComponents = await setToken.getComponents();
-          const expectedEquityFlows = [wethFlows, ZERO];
-          const expectedDebtFlows = [ZERO, daiFlows];
+          const expectedEquityFlows = [wethFlows, ZERO, btcFlows];
+          const expectedDebtFlows = [ZERO, daiFlows, ZERO];
 
           expect(JSON.stringify(expectedComponents)).to.eq(JSON.stringify(components));
           expect(JSON.stringify(expectedEquityFlows)).to.eq(JSON.stringify(equityFlows));
           expect(JSON.stringify(expectedDebtFlows)).to.eq(JSON.stringify(debtFlows));
         });
+      });
 
-        describe("when an additive external equity position is in place", async () => {
-          const externalUnits: BigNumber = ether(1);
+      describe("when positional adjustments are needed to account for positions changed during issuance", async () => {
+        let ethIssuanceAdjustment: BigNumber;
+        let daiDebtAdjustment: BigNumber;
 
-          beforeEach(async () => {
-            await externalPositionModule.addExternalPosition(setToken.address, setup.weth.address, externalUnits);
+        beforeEach(async () => {
+          await debtModule.addEquityIssuanceAdjustment(setup.weth.address, ethIssuanceAdjustment);
+          await debtModule.addDebtIssuanceAdjustment(setup.dai.address, daiDebtAdjustment);
+        });
+
+        describe("when positional adjustments are positive numbers", async () => {
+          before(async () => {
+            ethIssuanceAdjustment = ether(0.01);
+            daiDebtAdjustment = ether(1.5);
+          });
+
+          after(async () => {
+            ethIssuanceAdjustment = ZERO;
+            daiDebtAdjustment = ZERO;
           });
 
           it("should return the correct issue token amounts", async () => {
             const [components, equityFlows, debtFlows] = await subject();
 
             const mintQuantity = preciseMul(subjectQuantity, ether(1).add(issueFee));
-            const daiFlows = preciseMulCeil( mintQuantity, debtUnits);
-            const wethFlows = preciseMul(mintQuantity, ether(1).add(externalUnits));
+            const daiFlows = preciseMulCeil(mintQuantity, debtUnits.sub(daiDebtAdjustment));
+            const wethFlows = preciseMul(mintQuantity, ether(1).add(ethIssuanceAdjustment));
 
             const expectedComponents = await setToken.getComponents();
             const expectedEquityFlows = [wethFlows, ZERO];
@@ -437,24 +227,27 @@ describe.only("SlippageIssuanceModule", () => {
           });
         });
 
-        describe("when a non-additive external equity position is in place", async () => {
-          const externalUnits: BigNumber = bitcoin(.5);
+        describe("when positional adjustments are negative numbers", async () => {
+          before(async () => {
+            ethIssuanceAdjustment = ether(0.01).mul(-1);
+            daiDebtAdjustment = ether(1.5).mul(-1);
+          });
 
-          beforeEach(async () => {
-            await externalPositionModule.addExternalPosition(setToken.address, setup.wbtc.address, externalUnits);
+          after(async () => {
+            ethIssuanceAdjustment = ZERO;
+            daiDebtAdjustment = ZERO;
           });
 
           it("should return the correct issue token amounts", async () => {
             const [components, equityFlows, debtFlows] = await subject();
 
             const mintQuantity = preciseMul(subjectQuantity, ether(1).add(issueFee));
-            const daiFlows = preciseMulCeil( mintQuantity, debtUnits);
-            const wethFlows = preciseMul(mintQuantity, ether(1));
-            const btcFlows = preciseMul(mintQuantity, externalUnits);
+            const daiFlows = preciseMulCeil(mintQuantity, debtUnits.sub(daiDebtAdjustment));
+            const wethFlows = preciseMul(mintQuantity, ether(1).add(ethIssuanceAdjustment));
 
             const expectedComponents = await setToken.getComponents();
-            const expectedEquityFlows = [wethFlows, ZERO, btcFlows];
-            const expectedDebtFlows = [ZERO, daiFlows, ZERO];
+            const expectedEquityFlows = [wethFlows, ZERO];
+            const expectedDebtFlows = [ZERO, daiFlows];
 
             expect(JSON.stringify(expectedComponents)).to.eq(JSON.stringify(components));
             expect(JSON.stringify(expectedEquityFlows)).to.eq(JSON.stringify(equityFlows));
@@ -462,129 +255,88 @@ describe.only("SlippageIssuanceModule", () => {
           });
         });
 
-        describe("when positional adjustments are needed to account for positions changed during issuance", async () => {
-          let ethIssuanceAdjustment: BigNumber;
-          let daiDebtAdjustment: BigNumber;
-
-          beforeEach(async () => {
-            await debtModule.addEquityIssuanceAdjustment(setup.weth.address, ethIssuanceAdjustment);
-            await debtModule.addDebtIssuanceAdjustment(setup.dai.address, daiDebtAdjustment);
+        describe("when equity positional adjustments lead to negative results", async () => {
+          before(async () => {
+            ethIssuanceAdjustment = ether(1.1).mul(-1);
           });
 
-          describe("when positional adjustments are positive numbers", async () => {
-            before(async () => {
-              ethIssuanceAdjustment = ether(0.01);
-              daiDebtAdjustment = ether(1.5);
-            });
-
-            after(async () => {
-              ethIssuanceAdjustment = ZERO;
-              daiDebtAdjustment = ZERO;
-            });
-
-            it("should return the correct issue token amounts", async () => {
-              const [components, equityFlows, debtFlows] = await subject();
-
-              const mintQuantity = preciseMul(subjectQuantity, ether(1).add(issueFee));
-              const daiFlows = preciseMulCeil(mintQuantity, debtUnits.sub(daiDebtAdjustment));
-              const wethFlows = preciseMul(mintQuantity, ether(1).add(ethIssuanceAdjustment));
-
-              const expectedComponents = await setToken.getComponents();
-              const expectedEquityFlows = [wethFlows, ZERO];
-              const expectedDebtFlows = [ZERO, daiFlows];
-
-              expect(JSON.stringify(expectedComponents)).to.eq(JSON.stringify(components));
-              expect(JSON.stringify(expectedEquityFlows)).to.eq(JSON.stringify(equityFlows));
-              expect(JSON.stringify(expectedDebtFlows)).to.eq(JSON.stringify(debtFlows));
-            });
+          after(async () => {
+            ethIssuanceAdjustment = ZERO;
+            daiDebtAdjustment = ZERO;
           });
 
-          describe("when positional adjustments are negative numbers", async () => {
-            before(async () => {
-              ethIssuanceAdjustment = ether(0.01).mul(-1);
-              daiDebtAdjustment = ether(1.5).mul(-1);
-            });
+          it("should revert", async () => {
+            await expect(subject()).to.be.revertedWith("SafeCast: value must be positive");
+          });
+        });
 
-            after(async () => {
-              ethIssuanceAdjustment = ZERO;
-              daiDebtAdjustment = ZERO;
-            });
-
-            it("should return the correct issue token amounts", async () => {
-              const [components, equityFlows, debtFlows] = await subject();
-
-              const mintQuantity = preciseMul(subjectQuantity, ether(1).add(issueFee));
-              const daiFlows = preciseMulCeil(mintQuantity, debtUnits.sub(daiDebtAdjustment));
-              const wethFlows = preciseMul(mintQuantity, ether(1).add(ethIssuanceAdjustment));
-
-              const expectedComponents = await setToken.getComponents();
-              const expectedEquityFlows = [wethFlows, ZERO];
-              const expectedDebtFlows = [ZERO, daiFlows];
-
-              expect(JSON.stringify(expectedComponents)).to.eq(JSON.stringify(components));
-              expect(JSON.stringify(expectedEquityFlows)).to.eq(JSON.stringify(equityFlows));
-              expect(JSON.stringify(expectedDebtFlows)).to.eq(JSON.stringify(debtFlows));
-            });
+        describe("when debt positional adjustments lead to negative results", async () => {
+          before(async () => {
+            daiDebtAdjustment = ether(101);
           });
 
-          describe("when equity positional adjustments lead to negative results", async () => {
-            before(async () => {
-              ethIssuanceAdjustment = ether(1.1).mul(-1);
-            });
-
-            after(async () => {
-              ethIssuanceAdjustment = ZERO;
-              daiDebtAdjustment = ZERO;
-            });
-
-            it("should revert", async () => {
-              await expect(subject()).to.be.revertedWith("SafeCast: value must be positive");
-            });
+          after(async () => {
+            ethIssuanceAdjustment = ZERO;
+            daiDebtAdjustment = ZERO;
           });
 
-          describe("when debt positional adjustments lead to negative results", async () => {
-            before(async () => {
-              daiDebtAdjustment = ether(101);
-            });
-
-            after(async () => {
-              ethIssuanceAdjustment = ZERO;
-              daiDebtAdjustment = ZERO;
-            });
-
-            it("should revert", async () => {
-              await expect(subject()).to.be.revertedWith("SafeCast: value must be positive");
-            });
+          it("should revert", async () => {
+            await expect(subject()).to.be.revertedWith("SafeCast: value must be positive");
           });
         });
       });
+    });
 
-      describe("#getRequiredComponentRedemptionUnits", async () => {
-        let subjectSetToken: Address;
-        let subjectQuantity: BigNumber;
+    describe("#getRequiredComponentRedemptionUnits", async () => {
+      let subjectSetToken: Address;
+      let subjectQuantity: BigNumber;
 
-        const debtUnits: BigNumber = ether(100);
+      const debtUnits: BigNumber = ether(100);
+
+      beforeEach(async () => {
+        await debtModule.addDebt(setToken.address, setup.dai.address, debtUnits);
+
+        subjectSetToken = setToken.address;
+        subjectQuantity = ether(1);
+      });
+
+      async function subject(): Promise<any> {
+        return slippageIssuance.getRequiredComponentRedemptionUnits(
+          subjectSetToken,
+          subjectQuantity
+        );
+      }
+
+      it("should return the correct redeem token amounts", async () => {
+        const [components, equityFlows, debtFlows] = await subject();
+
+        const mintQuantity = preciseMul(subjectQuantity, ether(1).sub(issueFee));
+        const daiFlows = preciseMulCeil( mintQuantity, debtUnits);
+        const wethFlows = preciseMul(mintQuantity, ether(1));
+
+        const expectedComponents = await setToken.getComponents();
+        const expectedEquityFlows = [wethFlows, ZERO];
+        const expectedDebtFlows = [ZERO, daiFlows];
+
+        expect(JSON.stringify(expectedComponents)).to.eq(JSON.stringify(components));
+        expect(JSON.stringify(expectedEquityFlows)).to.eq(JSON.stringify(equityFlows));
+        expect(JSON.stringify(expectedDebtFlows)).to.eq(JSON.stringify(debtFlows));
+      });
+
+
+      describe("when an additive external equity position is in place", async () => {
+        const externalUnits: BigNumber = ether(1);
 
         beforeEach(async () => {
-          await debtModule.addDebt(setToken.address, setup.dai.address, debtUnits);
-
-          subjectSetToken = setToken.address;
-          subjectQuantity = ether(1);
+          await externalPositionModule.addExternalPosition(setToken.address, setup.weth.address, externalUnits);
         });
-
-        async function subject(): Promise<any> {
-          return slippageIssuance.getRequiredComponentRedemptionUnits(
-            subjectSetToken,
-            subjectQuantity
-          );
-        }
 
         it("should return the correct redeem token amounts", async () => {
           const [components, equityFlows, debtFlows] = await subject();
 
           const mintQuantity = preciseMul(subjectQuantity, ether(1).sub(issueFee));
-          const daiFlows = preciseMulCeil( mintQuantity, debtUnits);
-          const wethFlows = preciseMul(mintQuantity, ether(1));
+          const daiFlows = preciseMulCeil(mintQuantity, debtUnits);
+          const wethFlows = preciseMul(mintQuantity, ether(1).add(externalUnits));
 
           const expectedComponents = await setToken.getComponents();
           const expectedEquityFlows = [wethFlows, ZERO];
@@ -594,21 +346,54 @@ describe.only("SlippageIssuanceModule", () => {
           expect(JSON.stringify(expectedEquityFlows)).to.eq(JSON.stringify(equityFlows));
           expect(JSON.stringify(expectedDebtFlows)).to.eq(JSON.stringify(debtFlows));
         });
+      });
 
+      describe("when a non-additive external equity position is in place", async () => {
+        const externalUnits: BigNumber = bitcoin(0.5);
 
-        describe("when an additive external equity position is in place", async () => {
-          const externalUnits: BigNumber = ether(1);
+        beforeEach(async () => {
+          await externalPositionModule.addExternalPosition(setToken.address, setup.wbtc.address, externalUnits);
+        });
 
-          beforeEach(async () => {
-            await externalPositionModule.addExternalPosition(setToken.address, setup.weth.address, externalUnits);
+        it("should return the correct redeem token amounts", async () => {
+          const [components, equityFlows, debtFlows] = await subject();
+
+          const mintQuantity = preciseMul(subjectQuantity, ether(1).sub(issueFee));
+          const daiFlows = preciseMulCeil(mintQuantity, debtUnits);
+          const wethFlows = preciseMul(mintQuantity, ether(1));
+          const wbtcFlows = preciseMul(mintQuantity, externalUnits);
+
+          const expectedComponents = await setToken.getComponents();
+          const expectedEquityFlows = [wethFlows, ZERO, wbtcFlows];
+          const expectedDebtFlows = [ZERO, daiFlows, ZERO];
+
+          expect(JSON.stringify(expectedComponents)).to.eq(JSON.stringify(components));
+          expect(JSON.stringify(expectedEquityFlows)).to.eq(JSON.stringify(equityFlows));
+          expect(JSON.stringify(expectedDebtFlows)).to.eq(JSON.stringify(debtFlows));
+        });
+      });
+
+      describe("when positional adjustments are needed to account for positions changed during redemption", async () => {
+        let ethIssuanceAdjustment: BigNumber;
+        let daiDebtAdjustment: BigNumber;
+
+        beforeEach(async () => {
+          await debtModule.addEquityIssuanceAdjustment(setup.weth.address, ethIssuanceAdjustment);
+          await debtModule.addDebtIssuanceAdjustment(setup.dai.address, daiDebtAdjustment);
+        });
+
+        describe("when positional adjustments are positive numbers", async () => {
+          before(async () => {
+            ethIssuanceAdjustment = ether(0.01);
+            daiDebtAdjustment = ether(1.5);
           });
 
-          it("should return the correct redeem token amounts", async () => {
+          it("should return the correct issue token amounts", async () => {
             const [components, equityFlows, debtFlows] = await subject();
 
             const mintQuantity = preciseMul(subjectQuantity, ether(1).sub(issueFee));
-            const daiFlows = preciseMulCeil(mintQuantity, debtUnits);
-            const wethFlows = preciseMul(mintQuantity, ether(1).add(externalUnits));
+            const daiFlows = preciseMulCeil(mintQuantity, debtUnits.sub(daiDebtAdjustment));
+            const wethFlows = preciseMul(mintQuantity, ether(1).add(ethIssuanceAdjustment));
 
             const expectedComponents = await setToken.getComponents();
             const expectedEquityFlows = [wethFlows, ZERO];
@@ -620,24 +405,22 @@ describe.only("SlippageIssuanceModule", () => {
           });
         });
 
-        describe("when a non-additive external equity position is in place", async () => {
-          const externalUnits: BigNumber = bitcoin(0.5);
-
-          beforeEach(async () => {
-            await externalPositionModule.addExternalPosition(setToken.address, setup.wbtc.address, externalUnits);
+        describe("when positional adjustments are negative numbers", async () => {
+          before(async () => {
+            ethIssuanceAdjustment = ether(0.01).mul(-1);
+            daiDebtAdjustment = ether(1.5).mul(-1);
           });
 
-          it("should return the correct redeem token amounts", async () => {
+          it("should return the correct issue token amounts", async () => {
             const [components, equityFlows, debtFlows] = await subject();
 
             const mintQuantity = preciseMul(subjectQuantity, ether(1).sub(issueFee));
-            const daiFlows = preciseMulCeil(mintQuantity, debtUnits);
-            const wethFlows = preciseMul(mintQuantity, ether(1));
-            const wbtcFlows = preciseMul(mintQuantity, externalUnits);
+            const daiFlows = preciseMulCeil(mintQuantity, debtUnits.sub(daiDebtAdjustment));
+            const wethFlows = preciseMul(mintQuantity, ether(1).add(ethIssuanceAdjustment));
 
             const expectedComponents = await setToken.getComponents();
-            const expectedEquityFlows = [wethFlows, ZERO, wbtcFlows];
-            const expectedDebtFlows = [ZERO, daiFlows, ZERO];
+            const expectedEquityFlows = [wethFlows, ZERO];
+            const expectedDebtFlows = [ZERO, daiFlows];
 
             expect(JSON.stringify(expectedComponents)).to.eq(JSON.stringify(components));
             expect(JSON.stringify(expectedEquityFlows)).to.eq(JSON.stringify(equityFlows));
@@ -645,127 +428,267 @@ describe.only("SlippageIssuanceModule", () => {
           });
         });
 
-        describe("when positional adjustments are needed to account for positions changed during redemption", async () => {
-          let ethIssuanceAdjustment: BigNumber;
-          let daiDebtAdjustment: BigNumber;
-
-          beforeEach(async () => {
-            await debtModule.addEquityIssuanceAdjustment(setup.weth.address, ethIssuanceAdjustment);
-            await debtModule.addDebtIssuanceAdjustment(setup.dai.address, daiDebtAdjustment);
+        describe("when equity positional adjustments lead to negative results", async () => {
+          before(async () => {
+            ethIssuanceAdjustment = ether(1.1).mul(-1);
           });
 
-          describe("when positional adjustments are positive numbers", async () => {
-            before(async () => {
-              ethIssuanceAdjustment = ether(0.01);
-              daiDebtAdjustment = ether(1.5);
-            });
-
-            it("should return the correct issue token amounts", async () => {
-              const [components, equityFlows, debtFlows] = await subject();
-
-              const mintQuantity = preciseMul(subjectQuantity, ether(1).sub(issueFee));
-              const daiFlows = preciseMulCeil(mintQuantity, debtUnits.sub(daiDebtAdjustment));
-              const wethFlows = preciseMul(mintQuantity, ether(1).add(ethIssuanceAdjustment));
-
-              const expectedComponents = await setToken.getComponents();
-              const expectedEquityFlows = [wethFlows, ZERO];
-              const expectedDebtFlows = [ZERO, daiFlows];
-
-              expect(JSON.stringify(expectedComponents)).to.eq(JSON.stringify(components));
-              expect(JSON.stringify(expectedEquityFlows)).to.eq(JSON.stringify(equityFlows));
-              expect(JSON.stringify(expectedDebtFlows)).to.eq(JSON.stringify(debtFlows));
-            });
+          after(async () => {
+            ethIssuanceAdjustment = ZERO;
+            daiDebtAdjustment = ZERO;
           });
 
-          describe("when positional adjustments are negative numbers", async () => {
-            before(async () => {
-              ethIssuanceAdjustment = ether(0.01).mul(-1);
-              daiDebtAdjustment = ether(1.5).mul(-1);
-            });
+          it("should revert", async () => {
+            await expect(subject()).to.be.revertedWith("SafeCast: value must be positive");
+          });
+        });
 
-            it("should return the correct issue token amounts", async () => {
-              const [components, equityFlows, debtFlows] = await subject();
-
-              const mintQuantity = preciseMul(subjectQuantity, ether(1).sub(issueFee));
-              const daiFlows = preciseMulCeil(mintQuantity, debtUnits.sub(daiDebtAdjustment));
-              const wethFlows = preciseMul(mintQuantity, ether(1).add(ethIssuanceAdjustment));
-
-              const expectedComponents = await setToken.getComponents();
-              const expectedEquityFlows = [wethFlows, ZERO];
-              const expectedDebtFlows = [ZERO, daiFlows];
-
-              expect(JSON.stringify(expectedComponents)).to.eq(JSON.stringify(components));
-              expect(JSON.stringify(expectedEquityFlows)).to.eq(JSON.stringify(equityFlows));
-              expect(JSON.stringify(expectedDebtFlows)).to.eq(JSON.stringify(debtFlows));
-            });
+        describe("when debt positional adjustments lead to negative results", async () => {
+          before(async () => {
+            daiDebtAdjustment = ether(101);
           });
 
-          describe("when equity positional adjustments lead to negative results", async () => {
-            before(async () => {
-              ethIssuanceAdjustment = ether(1.1).mul(-1);
-            });
-
-            after(async () => {
-              ethIssuanceAdjustment = ZERO;
-              daiDebtAdjustment = ZERO;
-            });
-
-            it("should revert", async () => {
-              await expect(subject()).to.be.revertedWith("SafeCast: value must be positive");
-            });
+          after(async () => {
+            ethIssuanceAdjustment = ZERO;
+            daiDebtAdjustment = ZERO;
           });
 
-          describe("when debt positional adjustments lead to negative results", async () => {
-            before(async () => {
-              daiDebtAdjustment = ether(101);
-            });
-
-            after(async () => {
-              ethIssuanceAdjustment = ZERO;
-              daiDebtAdjustment = ZERO;
-            });
-
-            it("should revert", async () => {
-              await expect(subject()).to.be.revertedWith("SafeCast: value must be positive");
-            });
+          it("should revert", async () => {
+            await expect(subject()).to.be.revertedWith("SafeCast: value must be positive");
           });
         });
       });
+    });
 
-      describe("#issueWithSlippage", async () => {
-        let subjectSetToken: Address;
-        let subjectQuantity: BigNumber;
-        let subjectCheckedComponents: Address[];
-        let subjectMaxTokenAmountsIn: BigNumber[];
-        let subjectTo: Address;
-        let subjectCaller: Account;
+    describe("#issueWithSlippage", async () => {
+      let subjectSetToken: Address;
+      let subjectQuantity: BigNumber;
+      let subjectCheckedComponents: Address[];
+      let subjectMaxTokenAmountsIn: BigNumber[];
+      let subjectTo: Address;
+      let subjectCaller: Account;
 
-        const debtUnits: BigNumber = ether(100);
+      const debtUnits: BigNumber = ether(100);
 
-        beforeEach(async () => {
-          await debtModule.addDebt(setToken.address, setup.dai.address, debtUnits);
-          await setup.dai.transfer(debtModule.address, ether(100.5));
+      beforeEach(async () => {
+        await debtModule.addDebt(setToken.address, setup.dai.address, debtUnits);
+        await setup.dai.transfer(debtModule.address, ether(100.5));
 
-          const [, equityFlows ] = await slippageIssuance.getRequiredComponentIssuanceUnits(setToken.address, ether(1));
-          await setup.weth.approve(slippageIssuance.address, equityFlows[0].mul(ether(1.005)));
+        const [, equityFlows ] = await slippageIssuance.getRequiredComponentIssuanceUnits(setToken.address, ether(1));
+        await setup.weth.approve(slippageIssuance.address, equityFlows[0].mul(ether(1.005)));
 
-          subjectSetToken = setToken.address;
-          subjectQuantity = ether(1);
-          subjectCheckedComponents = [];
-          subjectMaxTokenAmountsIn = [];
-          subjectTo = recipient.address;
-          subjectCaller = owner;
+        subjectSetToken = setToken.address;
+        subjectQuantity = ether(1);
+        subjectCheckedComponents = [];
+        subjectMaxTokenAmountsIn = [];
+        subjectTo = recipient.address;
+        subjectCaller = owner;
+      });
+
+      async function subject(): Promise<ContractTransaction> {
+        return slippageIssuance.connect(subjectCaller.wallet).issueWithSlippage(
+          subjectSetToken,
+          subjectQuantity,
+          subjectCheckedComponents,
+          subjectMaxTokenAmountsIn,
+          subjectTo,
+        );
+      }
+
+      it("should mint SetTokens to the correct addresses", async () => {
+        await subject();
+
+        const feeQuantity = preciseMulCeil(subjectQuantity, issueFee);
+        const managerBalance = await setToken.balanceOf(feeRecipient.address);
+        const toBalance = await setToken.balanceOf(subjectTo);
+
+        expect(toBalance).to.eq(subjectQuantity);
+        expect(managerBalance).to.eq(feeQuantity);
+      });
+
+      it("should have the correct token balances", async () => {
+        const preMinterWethBalance = await setup.weth.balanceOf(subjectCaller.address);
+        const preSetWethBalance = await setup.weth.balanceOf(subjectSetToken);
+        const preMinterDaiBalance = await setup.dai.balanceOf(subjectCaller.address);
+        const preSetDaiBalance = await setup.dai.balanceOf(subjectSetToken);
+        const preExternalDaiBalance = await setup.dai.balanceOf(debtModule.address);
+
+        await subject();
+
+        const mintQuantity = preciseMul(subjectQuantity, ether(1).add(issueFee));
+        const daiFlows = preciseMulCeil( mintQuantity, debtUnits);
+        const wethFlows = preciseMul(mintQuantity, ether(1));
+
+        const postMinterWethBalance = await setup.weth.balanceOf(subjectCaller.address);
+        const postSetWethBalance = await setup.weth.balanceOf(subjectSetToken);
+        const postMinterDaiBalance = await setup.dai.balanceOf(subjectCaller.address);
+        const postSetDaiBalance = await setup.dai.balanceOf(subjectSetToken);
+        const postExternalDaiBalance = await setup.dai.balanceOf(debtModule.address);
+
+        expect(postMinterWethBalance).to.eq(preMinterWethBalance.sub(wethFlows));
+        expect(postSetWethBalance).to.eq(preSetWethBalance.add(wethFlows));
+        expect(postMinterDaiBalance).to.eq(preMinterDaiBalance.add(daiFlows));
+        expect(postSetDaiBalance).to.eq(preSetDaiBalance);
+        expect(postExternalDaiBalance).to.eq(preExternalDaiBalance.sub(daiFlows));
+      });
+
+      it("should have called the module issue hook", async () => {
+        await subject();
+
+        const hookCalled = await debtModule.moduleIssueHookCalled();
+
+        expect(hookCalled).to.be.true;
+      });
+
+      it("should emit the correct SetTokenIssued event", async () => {
+        const feeQuantity = preciseMulCeil(subjectQuantity, issueFee);
+
+        await expect(subject()).to.emit(slippageIssuance, "SetTokenIssued").withArgs(
+          setToken.address,
+          subjectCaller.address,
+          subjectTo,
+          preIssueHook,
+          subjectQuantity,
+          feeQuantity,
+          ZERO
+        );
+      });
+
+      describe("when an external equity position is in place", async () => {
+        const externalUnits: BigNumber = ether(1);
+
+        before(async () => {
+          await externalPositionModule.addExternalPosition(setToken.address, setup.weth.address, externalUnits);
         });
 
-        async function subject(): Promise<ContractTransaction> {
-          return slippageIssuance.connect(subjectCaller.wallet).issueWithSlippage(
-            subjectSetToken,
-            subjectQuantity,
-            subjectCheckedComponents,
-            subjectMaxTokenAmountsIn,
-            subjectTo,
-          );
-        }
+        after(async () => {
+          await externalPositionModule.addExternalPosition(setToken.address, setup.weth.address, ZERO);
+        });
+
+        it("should have the correct token balances", async () => {
+          const preMinterWethBalance = await setup.weth.balanceOf(subjectCaller.address);
+          const preSetWethBalance = await setup.weth.balanceOf(subjectSetToken);
+          const preExternalWethBalance = await setup.weth.balanceOf(externalPositionModule.address);
+          const preMinterDaiBalance = await setup.dai.balanceOf(subjectCaller.address);
+          const preSetDaiBalance = await setup.dai.balanceOf(subjectSetToken);
+          const preExternalDaiBalance = await setup.dai.balanceOf(debtModule.address);
+
+          await subject();
+
+          const mintQuantity = preciseMul(subjectQuantity, ether(1).add(issueFee));
+          const daiFlows = preciseMulCeil(mintQuantity, debtUnits);
+          const wethDefaultFlows = preciseMul(mintQuantity, ether(1));
+          const wethExternalFlows = preciseMul(mintQuantity, externalUnits);
+
+          const postMinterWethBalance = await setup.weth.balanceOf(subjectCaller.address);
+          const postSetWethBalance = await setup.weth.balanceOf(subjectSetToken);
+          const postExternalWethBalance = await setup.weth.balanceOf(externalPositionModule.address);
+          const postMinterDaiBalance = await setup.dai.balanceOf(subjectCaller.address);
+          const postSetDaiBalance = await setup.dai.balanceOf(subjectSetToken);
+          const postExternalDaiBalance = await setup.dai.balanceOf(debtModule.address);
+
+          expect(postMinterWethBalance).to.eq(preMinterWethBalance.sub(wethDefaultFlows.add(wethExternalFlows)));
+          expect(postSetWethBalance).to.eq(preSetWethBalance.add(wethDefaultFlows));
+          expect(postExternalWethBalance).to.eq(preExternalWethBalance.add(wethExternalFlows));
+          expect(postMinterDaiBalance).to.eq(preMinterDaiBalance.add(daiFlows));
+          expect(postSetDaiBalance).to.eq(preSetDaiBalance);
+          expect(postExternalDaiBalance).to.eq(preExternalDaiBalance.sub(daiFlows));
+        });
+      });
+
+      describe("when the manager issuance fee is 0", async () => {
+        before(async () => {
+          issueFee = ZERO;
+        });
+
+        after(async () => {
+          issueFee = ether(0.005);
+        });
+
+        it("should mint SetTokens to the correct addresses", async () => {
+          await subject();
+
+          const toBalance = await setToken.balanceOf(subjectTo);
+
+          expect(toBalance).to.eq(subjectQuantity);
+        });
+
+        it("should have the correct token balances", async () => {
+          const preMinterWethBalance = await setup.weth.balanceOf(subjectCaller.address);
+          const preSetWethBalance = await setup.weth.balanceOf(subjectSetToken);
+          const preMinterDaiBalance = await setup.dai.balanceOf(subjectCaller.address);
+          const preSetDaiBalance = await setup.dai.balanceOf(subjectSetToken);
+          const preExternalDaiBalance = await setup.dai.balanceOf(debtModule.address);
+
+          await subject();
+
+          const mintQuantity = preciseMul(subjectQuantity, ether(1).add(issueFee));
+          const daiFlows = preciseMulCeil(mintQuantity, debtUnits);
+          const wethDefaultFlows = preciseMul(mintQuantity, ether(1));
+
+          const postMinterWethBalance = await setup.weth.balanceOf(subjectCaller.address);
+          const postSetWethBalance = await setup.weth.balanceOf(subjectSetToken);
+          const postMinterDaiBalance = await setup.dai.balanceOf(subjectCaller.address);
+          const postSetDaiBalance = await setup.dai.balanceOf(subjectSetToken);
+          const postExternalDaiBalance = await setup.dai.balanceOf(debtModule.address);
+
+          expect(postMinterWethBalance).to.eq(preMinterWethBalance.sub(wethDefaultFlows));
+          expect(postSetWethBalance).to.eq(preSetWethBalance.add(wethDefaultFlows));
+          expect(postMinterDaiBalance).to.eq(preMinterDaiBalance.add(daiFlows));
+          expect(postSetDaiBalance).to.eq(preSetDaiBalance);
+          expect(postExternalDaiBalance).to.eq(preExternalDaiBalance.sub(daiFlows));
+        });
+      });
+
+      describe("when protocol fees are enabled", async () => {
+        const protocolFee: BigNumber = ether(.2);
+
+        beforeEach(async () => {
+          await setup.controller.addFee(slippageIssuance.address, ZERO, protocolFee);
+        });
+
+        it("should mint SetTokens to the correct addresses", async () => {
+          await subject();
+
+          const feeQuantity = preciseMulCeil(subjectQuantity, issueFee);
+          const protocolSplit = preciseMul(feeQuantity, protocolFee);
+
+          const managerBalance = await setToken.balanceOf(feeRecipient.address);
+          const protocolBalance = await setToken.balanceOf(dummyModule.address);  // DummyModule is set as address in fixture setup
+          const toBalance = await setToken.balanceOf(subjectTo);
+
+          expect(toBalance).to.eq(subjectQuantity);
+          expect(managerBalance).to.eq(feeQuantity.sub(protocolSplit));
+          expect(protocolBalance).to.eq(protocolSplit);
+        });
+      });
+
+      describe("when manager issuance hook is defined", async () => {
+        before(async () => {
+          preIssueHook = issuanceHook.address;
+        });
+
+        after(async () => {
+          preIssueHook = ADDRESS_ZERO;
+        });
+
+        it("should call the issuance hook", async () => {
+          await subject();
+
+          const setToken = await issuanceHook.retrievedSetToken();
+
+          expect(setToken).to.eq(subjectSetToken);
+        });
+      });
+
+      describe("when a max token amount in is submitted", async () => {
+        beforeEach(async () => {
+          const mintQuantity = preciseMul(subjectQuantity, ether(1).add(issueFee));
+          const expectedWethFlows = preciseMul(mintQuantity, ether(1));
+
+          subjectCheckedComponents = [setup.weth.address];
+          subjectMaxTokenAmountsIn = [expectedWethFlows];
+        });
 
         it("should mint SetTokens to the correct addresses", async () => {
           await subject();
@@ -804,314 +727,302 @@ describe.only("SlippageIssuanceModule", () => {
           expect(postExternalDaiBalance).to.eq(preExternalDaiBalance.sub(daiFlows));
         });
 
-        it("should have called the module issue hook", async () => {
-          await subject();
-
-          const hookCalled = await debtModule.moduleIssueHookCalled();
-
-          expect(hookCalled).to.be.true;
-        });
-
-        it("should emit the correct SetTokenIssued event", async () => {
-          const feeQuantity = preciseMulCeil(subjectQuantity, issueFee);
-
-          await expect(subject()).to.emit(slippageIssuance, "SetTokenIssued").withArgs(
-            setToken.address,
-            subjectCaller.address,
-            subjectTo,
-            preIssueHook,
-            subjectQuantity,
-            feeQuantity,
-            ZERO
-          );
-        });
-
-        describe("when an external equity position is in place", async () => {
-          const externalUnits: BigNumber = ether(1);
-
-          before(async () => {
-            await externalPositionModule.addExternalPosition(setToken.address, setup.weth.address, externalUnits);
-          });
-
-          after(async () => {
-            await externalPositionModule.addExternalPosition(setToken.address, setup.weth.address, ZERO);
-          });
-
-          it("should have the correct token balances", async () => {
-            const preMinterWethBalance = await setup.weth.balanceOf(subjectCaller.address);
-            const preSetWethBalance = await setup.weth.balanceOf(subjectSetToken);
-            const preExternalWethBalance = await setup.weth.balanceOf(externalPositionModule.address);
-            const preMinterDaiBalance = await setup.dai.balanceOf(subjectCaller.address);
-            const preSetDaiBalance = await setup.dai.balanceOf(subjectSetToken);
-            const preExternalDaiBalance = await setup.dai.balanceOf(debtModule.address);
-
-            await subject();
-
-            const mintQuantity = preciseMul(subjectQuantity, ether(1).add(issueFee));
-            const daiFlows = preciseMulCeil(mintQuantity, debtUnits);
-            const wethDefaultFlows = preciseMul(mintQuantity, ether(1));
-            const wethExternalFlows = preciseMul(mintQuantity, externalUnits);
-
-            const postMinterWethBalance = await setup.weth.balanceOf(subjectCaller.address);
-            const postSetWethBalance = await setup.weth.balanceOf(subjectSetToken);
-            const postExternalWethBalance = await setup.weth.balanceOf(externalPositionModule.address);
-            const postMinterDaiBalance = await setup.dai.balanceOf(subjectCaller.address);
-            const postSetDaiBalance = await setup.dai.balanceOf(subjectSetToken);
-            const postExternalDaiBalance = await setup.dai.balanceOf(debtModule.address);
-
-            expect(postMinterWethBalance).to.eq(preMinterWethBalance.sub(wethDefaultFlows.add(wethExternalFlows)));
-            expect(postSetWethBalance).to.eq(preSetWethBalance.add(wethDefaultFlows));
-            expect(postExternalWethBalance).to.eq(preExternalWethBalance.add(wethExternalFlows));
-            expect(postMinterDaiBalance).to.eq(preMinterDaiBalance.add(daiFlows));
-            expect(postSetDaiBalance).to.eq(preSetDaiBalance);
-            expect(postExternalDaiBalance).to.eq(preExternalDaiBalance.sub(daiFlows));
-          });
-        });
-
-        describe("when the manager issuance fee is 0", async () => {
-          before(async () => {
-            issueFee = ZERO;
-          });
-
-          after(async () => {
-            issueFee = ether(0.005);
-          });
-
-          it("should mint SetTokens to the correct addresses", async () => {
-            await subject();
-
-            const toBalance = await setToken.balanceOf(subjectTo);
-
-            expect(toBalance).to.eq(subjectQuantity);
-          });
-
-          it("should have the correct token balances", async () => {
-            const preMinterWethBalance = await setup.weth.balanceOf(subjectCaller.address);
-            const preSetWethBalance = await setup.weth.balanceOf(subjectSetToken);
-            const preMinterDaiBalance = await setup.dai.balanceOf(subjectCaller.address);
-            const preSetDaiBalance = await setup.dai.balanceOf(subjectSetToken);
-            const preExternalDaiBalance = await setup.dai.balanceOf(debtModule.address);
-
-            await subject();
-
-            const mintQuantity = preciseMul(subjectQuantity, ether(1).add(issueFee));
-            const daiFlows = preciseMulCeil(mintQuantity, debtUnits);
-            const wethDefaultFlows = preciseMul(mintQuantity, ether(1));
-
-            const postMinterWethBalance = await setup.weth.balanceOf(subjectCaller.address);
-            const postSetWethBalance = await setup.weth.balanceOf(subjectSetToken);
-            const postMinterDaiBalance = await setup.dai.balanceOf(subjectCaller.address);
-            const postSetDaiBalance = await setup.dai.balanceOf(subjectSetToken);
-            const postExternalDaiBalance = await setup.dai.balanceOf(debtModule.address);
-
-            expect(postMinterWethBalance).to.eq(preMinterWethBalance.sub(wethDefaultFlows));
-            expect(postSetWethBalance).to.eq(preSetWethBalance.add(wethDefaultFlows));
-            expect(postMinterDaiBalance).to.eq(preMinterDaiBalance.add(daiFlows));
-            expect(postSetDaiBalance).to.eq(preSetDaiBalance);
-            expect(postExternalDaiBalance).to.eq(preExternalDaiBalance.sub(daiFlows));
-          });
-        });
-
-        describe("when protocol fees are enabled", async () => {
-          const protocolFee: BigNumber = ether(.2);
-
-          beforeEach(async () => {
-            await setup.controller.addFee(slippageIssuance.address, ZERO, protocolFee);
-          });
-
-          it("should mint SetTokens to the correct addresses", async () => {
-            await subject();
-
-            const feeQuantity = preciseMulCeil(subjectQuantity, issueFee);
-            const protocolSplit = preciseMul(feeQuantity, protocolFee);
-
-            const managerBalance = await setToken.balanceOf(feeRecipient.address);
-            const protocolBalance = await setToken.balanceOf(dummyModule.address);  // DummyModule is set as address in fixture setup
-            const toBalance = await setToken.balanceOf(subjectTo);
-
-            expect(toBalance).to.eq(subjectQuantity);
-            expect(managerBalance).to.eq(feeQuantity.sub(protocolSplit));
-            expect(protocolBalance).to.eq(protocolSplit);
-          });
-        });
-
-        describe("when manager issuance hook is defined", async () => {
-          before(async () => {
-            preIssueHook = issuanceHook.address;
-          });
-
-          after(async () => {
-            preIssueHook = ADDRESS_ZERO;
-          });
-
-          it("should call the issuance hook", async () => {
-            await subject();
-
-            const setToken = await issuanceHook.retrievedSetToken();
-
-            expect(setToken).to.eq(subjectSetToken);
-          });
-        });
-
-        describe("when a max token amount in is submitted", async () => {
+        describe("but the required amount exceeds the max limit set", async () => {
           beforeEach(async () => {
             const mintQuantity = preciseMul(subjectQuantity, ether(1).add(issueFee));
             const expectedWethFlows = preciseMul(mintQuantity, ether(1));
 
             subjectCheckedComponents = [setup.weth.address];
-            subjectMaxTokenAmountsIn = [expectedWethFlows];
-          });
-
-          it("should mint SetTokens to the correct addresses", async () => {
-            await subject();
-
-            const feeQuantity = preciseMulCeil(subjectQuantity, issueFee);
-            const managerBalance = await setToken.balanceOf(feeRecipient.address);
-            const toBalance = await setToken.balanceOf(subjectTo);
-
-            expect(toBalance).to.eq(subjectQuantity);
-            expect(managerBalance).to.eq(feeQuantity);
-          });
-
-          it("should have the correct token balances", async () => {
-            const preMinterWethBalance = await setup.weth.balanceOf(subjectCaller.address);
-            const preSetWethBalance = await setup.weth.balanceOf(subjectSetToken);
-            const preMinterDaiBalance = await setup.dai.balanceOf(subjectCaller.address);
-            const preSetDaiBalance = await setup.dai.balanceOf(subjectSetToken);
-            const preExternalDaiBalance = await setup.dai.balanceOf(debtModule.address);
-
-            await subject();
-
-            const mintQuantity = preciseMul(subjectQuantity, ether(1).add(issueFee));
-            const daiFlows = preciseMulCeil( mintQuantity, debtUnits);
-            const wethFlows = preciseMul(mintQuantity, ether(1));
-
-            const postMinterWethBalance = await setup.weth.balanceOf(subjectCaller.address);
-            const postSetWethBalance = await setup.weth.balanceOf(subjectSetToken);
-            const postMinterDaiBalance = await setup.dai.balanceOf(subjectCaller.address);
-            const postSetDaiBalance = await setup.dai.balanceOf(subjectSetToken);
-            const postExternalDaiBalance = await setup.dai.balanceOf(debtModule.address);
-
-            expect(postMinterWethBalance).to.eq(preMinterWethBalance.sub(wethFlows));
-            expect(postSetWethBalance).to.eq(preSetWethBalance.add(wethFlows));
-            expect(postMinterDaiBalance).to.eq(preMinterDaiBalance.add(daiFlows));
-            expect(postSetDaiBalance).to.eq(preSetDaiBalance);
-            expect(postExternalDaiBalance).to.eq(preExternalDaiBalance.sub(daiFlows));
-          });
-
-          describe("but the required amount exceeds the max limit set", async () => {
-            beforeEach(async () => {
-              const mintQuantity = preciseMul(subjectQuantity, ether(1).add(issueFee));
-              const expectedWethFlows = preciseMul(mintQuantity, ether(1));
-
-              subjectCheckedComponents = [setup.weth.address];
-              subjectMaxTokenAmountsIn = [expectedWethFlows.sub(1)];
-            });
-
-            it("should revert", async () => {
-              await expect(subject()).to.be.revertedWith("Too many tokens required for issuance");
-            });
-          });
-
-          describe("but a specified component isn't part of the Set", async () => {
-            beforeEach(async () => {
-              subjectCheckedComponents = [setup.usdc.address];
-              subjectMaxTokenAmountsIn = [usdc(100)];
-            });
-
-            it("should revert", async () => {
-              await expect(subject()).to.be.revertedWith("Limit passed for invalid component");
-            });
-          });
-
-          describe("but the array lengths mismatch", async () => {
-            beforeEach(async () => {
-              subjectCheckedComponents = [setup.weth.address];
-              subjectMaxTokenAmountsIn = [];
-            });
-
-            it("should revert", async () => {
-              await expect(subject()).to.be.revertedWith("Array length mismatch");
-            });
-          });
-
-          describe("but there are duplicates in the components array", async () => {
-            beforeEach(async () => {
-              subjectCheckedComponents = [setup.weth.address, setup.weth.address];
-              subjectMaxTokenAmountsIn = [ether(1), ether(1)];
-            });
-
-            it("should revert", async () => {
-              await expect(subject()).to.be.revertedWith("Cannot duplicate addresses");
-            });
-          });
-        });
-
-        describe("when the issue quantity is 0", async () => {
-          beforeEach(async () => {
-            subjectQuantity = ZERO;
+            subjectMaxTokenAmountsIn = [expectedWethFlows.sub(1)];
           });
 
           it("should revert", async () => {
-            await expect(subject()).to.be.revertedWith("SetToken quantity must be > 0");
+            await expect(subject()).to.be.revertedWith("Too many tokens required for issuance");
           });
         });
 
-        describe("when the SetToken is not enabled on the controller", async () => {
+        describe("but a specified component isn't part of the Set", async () => {
           beforeEach(async () => {
-            const nonEnabledSetToken = await setup.createNonControllerEnabledSetToken(
-              [setup.weth.address],
-              [ether(1)],
-              [slippageIssuance.address]
-            );
-
-            subjectSetToken = nonEnabledSetToken.address;
+            subjectCheckedComponents = [setup.usdc.address];
+            subjectMaxTokenAmountsIn = [usdc(100)];
           });
 
           it("should revert", async () => {
-            await expect(subject()).to.be.revertedWith("Must be a valid and initialized SetToken");
+            await expect(subject()).to.be.revertedWith("Limit passed for invalid component");
+          });
+        });
+
+        describe("but the array lengths mismatch", async () => {
+          beforeEach(async () => {
+            subjectCheckedComponents = [setup.weth.address];
+            subjectMaxTokenAmountsIn = [];
+          });
+
+          it("should revert", async () => {
+            await expect(subject()).to.be.revertedWith("Array length mismatch");
+          });
+        });
+
+        describe("but there are duplicates in the components array", async () => {
+          beforeEach(async () => {
+            subjectCheckedComponents = [setup.weth.address, setup.weth.address];
+            subjectMaxTokenAmountsIn = [ether(1), ether(1)];
+          });
+
+          it("should revert", async () => {
+            await expect(subject()).to.be.revertedWith("Cannot duplicate addresses");
           });
         });
       });
 
-      describe("#redeemWithSlippage", async () => {
-        let subjectSetToken: Address;
-        let subjectQuantity: BigNumber;
-        let subjectCheckedComponents: Address[];
-        let subjectMinTokenAmountsOut: BigNumber[];
-        let subjectTo: Address;
-        let subjectCaller: Account;
-
-        const debtUnits: BigNumber = ether(100);
-
+      describe("when the issue quantity is 0", async () => {
         beforeEach(async () => {
-          await debtModule.addDebt(setToken.address, setup.dai.address, debtUnits);
-          await setup.dai.transfer(debtModule.address, ether(100.5));
-
-          const [, equityFlows ] = await slippageIssuance.getRequiredComponentRedemptionUnits(setToken.address, ether(1));
-          await setup.weth.approve(slippageIssuance.address, equityFlows[0].mul(ether(1.005)));
-
-          await slippageIssuance.issue(setToken.address, ether(1), owner.address);
-
-          await setup.dai.approve(slippageIssuance.address, ether(100.5));
-
-          subjectSetToken = setToken.address;
-          subjectQuantity = ether(1);
-          subjectCheckedComponents = [];
-          subjectMinTokenAmountsOut = [];
-          subjectTo = recipient.address;
-          subjectCaller = owner;
+          subjectQuantity = ZERO;
         });
 
-        async function subject(): Promise<ContractTransaction> {
-          return slippageIssuance.connect(subjectCaller.wallet).redeemWithSlippage(
-            subjectSetToken,
-            subjectQuantity,
-            subjectCheckedComponents,
-            subjectMinTokenAmountsOut,
-            subjectTo,
+        it("should revert", async () => {
+          await expect(subject()).to.be.revertedWith("SetToken quantity must be > 0");
+        });
+      });
+
+      describe("when the SetToken is not enabled on the controller", async () => {
+        beforeEach(async () => {
+          const nonEnabledSetToken = await setup.createNonControllerEnabledSetToken(
+            [setup.weth.address],
+            [ether(1)],
+            [slippageIssuance.address]
           );
-        }
+
+          subjectSetToken = nonEnabledSetToken.address;
+        });
+
+        it("should revert", async () => {
+          await expect(subject()).to.be.revertedWith("Must be a valid and initialized SetToken");
+        });
+      });
+    });
+
+    describe("#redeemWithSlippage", async () => {
+      let subjectSetToken: Address;
+      let subjectQuantity: BigNumber;
+      let subjectCheckedComponents: Address[];
+      let subjectMinTokenAmountsOut: BigNumber[];
+      let subjectTo: Address;
+      let subjectCaller: Account;
+
+      const debtUnits: BigNumber = ether(100);
+
+      beforeEach(async () => {
+        await debtModule.addDebt(setToken.address, setup.dai.address, debtUnits);
+        await setup.dai.transfer(debtModule.address, ether(100.5));
+
+        const [, equityFlows ] = await slippageIssuance.getRequiredComponentRedemptionUnits(setToken.address, ether(1));
+        await setup.weth.approve(slippageIssuance.address, equityFlows[0].mul(ether(1.005)));
+
+        await slippageIssuance.issue(setToken.address, ether(1), owner.address);
+
+        await setup.dai.approve(slippageIssuance.address, ether(100.5));
+
+        subjectSetToken = setToken.address;
+        subjectQuantity = ether(1);
+        subjectCheckedComponents = [];
+        subjectMinTokenAmountsOut = [];
+        subjectTo = recipient.address;
+        subjectCaller = owner;
+      });
+
+      async function subject(): Promise<ContractTransaction> {
+        return slippageIssuance.connect(subjectCaller.wallet).redeemWithSlippage(
+          subjectSetToken,
+          subjectQuantity,
+          subjectCheckedComponents,
+          subjectMinTokenAmountsOut,
+          subjectTo,
+        );
+      }
+
+      it("should redeem SetTokens to the correct addresses", async () => {
+        const preManagerBalance = await setToken.balanceOf(feeRecipient.address);
+        const preCallerBalance = await setToken.balanceOf(subjectCaller.address);
+
+        await subject();
+
+        const feeQuantity = preciseMulCeil(subjectQuantity, redeemFee);
+        const postManagerBalance = await setToken.balanceOf(feeRecipient.address);
+        const postCallerBalance = await setToken.balanceOf(subjectCaller.address);
+
+        expect(postManagerBalance).to.eq(preManagerBalance.add(feeQuantity));
+        expect(postCallerBalance).to.eq(preCallerBalance.sub(subjectQuantity));
+      });
+
+      it("should have the correct token balances", async () => {
+        const preToWethBalance = await setup.weth.balanceOf(subjectTo);
+        const preSetWethBalance = await setup.weth.balanceOf(subjectSetToken);
+        const preRedeemerDaiBalance = await setup.dai.balanceOf(subjectCaller.address);
+        const preSetDaiBalance = await setup.dai.balanceOf(subjectSetToken);
+        const preExternalDaiBalance = await setup.dai.balanceOf(debtModule.address);
+
+        await subject();
+
+        const redeemQuantity = preciseMul(subjectQuantity, ether(1).sub(redeemFee));
+        const daiFlows = preciseMulCeil(redeemQuantity, debtUnits);
+        const wethFlows = preciseMul(redeemQuantity, ether(1));
+
+        const postToWethBalance = await setup.weth.balanceOf(subjectTo);
+        const postSetWethBalance = await setup.weth.balanceOf(subjectSetToken);
+        const postRedeemerDaiBalance = await setup.dai.balanceOf(subjectCaller.address);
+        const postSetDaiBalance = await setup.dai.balanceOf(subjectSetToken);
+        const postExternalDaiBalance = await setup.dai.balanceOf(debtModule.address);
+
+        expect(postToWethBalance).to.eq(preToWethBalance.add(wethFlows));
+        expect(postSetWethBalance).to.eq(preSetWethBalance.sub(wethFlows));
+        expect(postRedeemerDaiBalance).to.eq(preRedeemerDaiBalance.sub(daiFlows));
+        expect(postSetDaiBalance).to.eq(preSetDaiBalance);
+        expect(postExternalDaiBalance).to.eq(preExternalDaiBalance.add(daiFlows));
+      });
+
+      it("should have called the module issue hook", async () => {
+        await subject();
+
+        const hookCalled = await debtModule.moduleRedeemHookCalled();
+
+        expect(hookCalled).to.be.true;
+      });
+
+      it("should emit the correct SetTokenRedeemed event", async () => {
+        const feeQuantity = preciseMulCeil(subjectQuantity, issueFee);
+
+        await expect(subject()).to.emit(slippageIssuance, "SetTokenRedeemed").withArgs(
+          setToken.address,
+          subjectCaller.address,
+          subjectTo,
+          subjectQuantity,
+          feeQuantity,
+          ZERO
+        );
+      });
+
+      describe("when an external equity position is in place", async () => {
+        const externalUnits: BigNumber = ether(1);
+
+        before(async () => {
+          await externalPositionModule.addExternalPosition(setToken.address, setup.weth.address, externalUnits);
+        });
+
+        after(async () => {
+          await externalPositionModule.addExternalPosition(setToken.address, setup.weth.address, ZERO);
+        });
+
+        it("should have the correct token balances", async () => {
+          const preToWethBalance = await setup.weth.balanceOf(subjectTo);
+          const preSetWethBalance = await setup.weth.balanceOf(subjectSetToken);
+          const preExternalWethBalance = await setup.weth.balanceOf(externalPositionModule.address);
+          const preRedeemerDaiBalance = await setup.dai.balanceOf(subjectCaller.address);
+          const preSetDaiBalance = await setup.dai.balanceOf(subjectSetToken);
+          const preExternalDaiBalance = await setup.dai.balanceOf(debtModule.address);
+
+          await subject();
+
+          const redeemQuantity = preciseMul(subjectQuantity, ether(1).sub(redeemFee));
+          const daiFlows = preciseMulCeil(redeemQuantity, debtUnits);
+          const wethExternalFlows = preciseMul(redeemQuantity, externalUnits);
+          const wethDefaultFlows = preciseMul(redeemQuantity, ether(1));
+
+          const postToWethBalance = await setup.weth.balanceOf(subjectTo);
+          const postSetWethBalance = await setup.weth.balanceOf(subjectSetToken);
+          const postExternalWethBalance = await setup.weth.balanceOf(externalPositionModule.address);
+          const postRedeemerDaiBalance = await setup.dai.balanceOf(subjectCaller.address);
+          const postSetDaiBalance = await setup.dai.balanceOf(subjectSetToken);
+          const postExternalDaiBalance = await setup.dai.balanceOf(debtModule.address);
+
+          expect(postToWethBalance).to.eq(preToWethBalance.add(wethExternalFlows.add(wethDefaultFlows)));
+          expect(postSetWethBalance).to.eq(preSetWethBalance.sub(wethDefaultFlows));
+          expect(postExternalWethBalance).to.eq(preExternalWethBalance.sub(wethExternalFlows));
+          expect(postRedeemerDaiBalance).to.eq(preRedeemerDaiBalance.sub(daiFlows));
+          expect(postSetDaiBalance).to.eq(preSetDaiBalance);
+          expect(postExternalDaiBalance).to.eq(preExternalDaiBalance.add(daiFlows));
+        });
+      });
+
+      describe("when the manager redemption fee is 0", async () => {
+        before(async () => {
+          redeemFee = ZERO;
+        });
+
+        after(async () => {
+          redeemFee = ether(0.005);
+        });
+
+        it("should mint SetTokens to the correct addresses", async () => {
+          await subject();
+
+          const toBalance = await setToken.balanceOf(subjectTo);
+
+          expect(toBalance).to.eq(ZERO);
+        });
+
+        it("should have the correct token balances", async () => {
+          const preToWethBalance = await setup.weth.balanceOf(subjectTo);
+          const preSetWethBalance = await setup.weth.balanceOf(subjectSetToken);
+          const preRedeemerDaiBalance = await setup.dai.balanceOf(subjectCaller.address);
+          const preSetDaiBalance = await setup.dai.balanceOf(subjectSetToken);
+          const preExternalDaiBalance = await setup.dai.balanceOf(debtModule.address);
+
+          await subject();
+
+          const redeemQuantity = preciseMul(subjectQuantity, ether(1).sub(redeemFee));
+          const daiFlows = preciseMulCeil(redeemQuantity, debtUnits);
+          const wethFlows = preciseMul(redeemQuantity, ether(1));
+
+          const postToWethBalance = await setup.weth.balanceOf(subjectTo);
+          const postSetWethBalance = await setup.weth.balanceOf(subjectSetToken);
+          const postRedeemerDaiBalance = await setup.dai.balanceOf(subjectCaller.address);
+          const postSetDaiBalance = await setup.dai.balanceOf(subjectSetToken);
+          const postExternalDaiBalance = await setup.dai.balanceOf(debtModule.address);
+
+          expect(postToWethBalance).to.eq(preToWethBalance.add(wethFlows));
+          expect(postSetWethBalance).to.eq(preSetWethBalance.sub(wethFlows));
+          expect(postRedeemerDaiBalance).to.eq(preRedeemerDaiBalance.sub(daiFlows));
+          expect(postSetDaiBalance).to.eq(preSetDaiBalance);
+          expect(postExternalDaiBalance).to.eq(preExternalDaiBalance.add(daiFlows));
+        });
+      });
+
+      describe("when protocol fees are enabled", async () => {
+        const protocolFee: BigNumber = ether(.2);
+
+        beforeEach(async () => {
+          await setup.controller.addFee(slippageIssuance.address, ZERO, protocolFee);
+        });
+
+        it("should mint SetTokens to the correct addresses", async () => {
+          const preManagerBalance = await setToken.balanceOf(feeRecipient.address);
+          const preProtocolBalance = await setToken.balanceOf(dummyModule.address);
+          const preCallerBalance = await setToken.balanceOf(subjectCaller.address);
+
+          await subject();
+
+          const feeQuantity = preciseMulCeil(subjectQuantity, redeemFee);
+          const protocolSplit = preciseMul(feeQuantity, protocolFee);
+
+          const postManagerBalance = await setToken.balanceOf(feeRecipient.address);
+          const postProtocolBalance = await setToken.balanceOf(dummyModule.address);  // DummyModule is set as address in fixture setup
+          const postCallerBalance = await setToken.balanceOf(subjectCaller.address);
+
+          expect(postCallerBalance).to.eq(preCallerBalance.sub(subjectQuantity));
+          expect(postManagerBalance).to.eq(preManagerBalance.add(feeQuantity.sub(protocolSplit)));
+          expect(postProtocolBalance).to.eq(preProtocolBalance.add(protocolSplit));
+        });
+      });
+
+      describe("when a min token amount out is submitted", async () => {
+        beforeEach(async () => {
+          const mintQuantity = preciseMul(subjectQuantity, ether(1).sub(issueFee));
+          const expectedWethFlows = preciseMul(mintQuantity, ether(1));
+
+          subjectCheckedComponents = [setup.weth.address];
+          subjectMinTokenAmountsOut = [expectedWethFlows];
+        });
 
         it("should redeem SetTokens to the correct addresses", async () => {
           const preManagerBalance = await setToken.balanceOf(feeRecipient.address);
@@ -1153,406 +1064,70 @@ describe.only("SlippageIssuanceModule", () => {
           expect(postExternalDaiBalance).to.eq(preExternalDaiBalance.add(daiFlows));
         });
 
-        it("should have called the module issue hook", async () => {
-          await subject();
-
-          const hookCalled = await debtModule.moduleRedeemHookCalled();
-
-          expect(hookCalled).to.be.true;
-        });
-
-        it("should emit the correct SetTokenRedeemed event", async () => {
-          const feeQuantity = preciseMulCeil(subjectQuantity, issueFee);
-
-          await expect(subject()).to.emit(slippageIssuance, "SetTokenRedeemed").withArgs(
-            setToken.address,
-            subjectCaller.address,
-            subjectTo,
-            subjectQuantity,
-            feeQuantity,
-            ZERO
-          );
-        });
-
-        describe("when an external equity position is in place", async () => {
-          const externalUnits: BigNumber = ether(1);
-
-          before(async () => {
-            await externalPositionModule.addExternalPosition(setToken.address, setup.weth.address, externalUnits);
-          });
-
-          after(async () => {
-            await externalPositionModule.addExternalPosition(setToken.address, setup.weth.address, ZERO);
-          });
-
-          it("should have the correct token balances", async () => {
-            const preToWethBalance = await setup.weth.balanceOf(subjectTo);
-            const preSetWethBalance = await setup.weth.balanceOf(subjectSetToken);
-            const preExternalWethBalance = await setup.weth.balanceOf(externalPositionModule.address);
-            const preRedeemerDaiBalance = await setup.dai.balanceOf(subjectCaller.address);
-            const preSetDaiBalance = await setup.dai.balanceOf(subjectSetToken);
-            const preExternalDaiBalance = await setup.dai.balanceOf(debtModule.address);
-
-            await subject();
-
-            const redeemQuantity = preciseMul(subjectQuantity, ether(1).sub(redeemFee));
-            const daiFlows = preciseMulCeil(redeemQuantity, debtUnits);
-            const wethExternalFlows = preciseMul(redeemQuantity, externalUnits);
-            const wethDefaultFlows = preciseMul(redeemQuantity, ether(1));
-
-            const postToWethBalance = await setup.weth.balanceOf(subjectTo);
-            const postSetWethBalance = await setup.weth.balanceOf(subjectSetToken);
-            const postExternalWethBalance = await setup.weth.balanceOf(externalPositionModule.address);
-            const postRedeemerDaiBalance = await setup.dai.balanceOf(subjectCaller.address);
-            const postSetDaiBalance = await setup.dai.balanceOf(subjectSetToken);
-            const postExternalDaiBalance = await setup.dai.balanceOf(debtModule.address);
-
-            expect(postToWethBalance).to.eq(preToWethBalance.add(wethExternalFlows.add(wethDefaultFlows)));
-            expect(postSetWethBalance).to.eq(preSetWethBalance.sub(wethDefaultFlows));
-            expect(postExternalWethBalance).to.eq(preExternalWethBalance.sub(wethExternalFlows));
-            expect(postRedeemerDaiBalance).to.eq(preRedeemerDaiBalance.sub(daiFlows));
-            expect(postSetDaiBalance).to.eq(preSetDaiBalance);
-            expect(postExternalDaiBalance).to.eq(preExternalDaiBalance.add(daiFlows));
-          });
-        });
-
-        describe("when the manager redemption fee is 0", async () => {
-          before(async () => {
-            redeemFee = ZERO;
-          });
-
-          after(async () => {
-            redeemFee = ether(0.005);
-          });
-
-          it("should mint SetTokens to the correct addresses", async () => {
-            await subject();
-
-            const toBalance = await setToken.balanceOf(subjectTo);
-
-            expect(toBalance).to.eq(ZERO);
-          });
-
-          it("should have the correct token balances", async () => {
-            const preToWethBalance = await setup.weth.balanceOf(subjectTo);
-            const preSetWethBalance = await setup.weth.balanceOf(subjectSetToken);
-            const preRedeemerDaiBalance = await setup.dai.balanceOf(subjectCaller.address);
-            const preSetDaiBalance = await setup.dai.balanceOf(subjectSetToken);
-            const preExternalDaiBalance = await setup.dai.balanceOf(debtModule.address);
-
-            await subject();
-
-            const redeemQuantity = preciseMul(subjectQuantity, ether(1).sub(redeemFee));
-            const daiFlows = preciseMulCeil(redeemQuantity, debtUnits);
-            const wethFlows = preciseMul(redeemQuantity, ether(1));
-
-            const postToWethBalance = await setup.weth.balanceOf(subjectTo);
-            const postSetWethBalance = await setup.weth.balanceOf(subjectSetToken);
-            const postRedeemerDaiBalance = await setup.dai.balanceOf(subjectCaller.address);
-            const postSetDaiBalance = await setup.dai.balanceOf(subjectSetToken);
-            const postExternalDaiBalance = await setup.dai.balanceOf(debtModule.address);
-
-            expect(postToWethBalance).to.eq(preToWethBalance.add(wethFlows));
-            expect(postSetWethBalance).to.eq(preSetWethBalance.sub(wethFlows));
-            expect(postRedeemerDaiBalance).to.eq(preRedeemerDaiBalance.sub(daiFlows));
-            expect(postSetDaiBalance).to.eq(preSetDaiBalance);
-            expect(postExternalDaiBalance).to.eq(preExternalDaiBalance.add(daiFlows));
-          });
-        });
-
-        describe("when protocol fees are enabled", async () => {
-          const protocolFee: BigNumber = ether(.2);
-
+        describe("but the returned amount isn't enough", async () => {
           beforeEach(async () => {
-            await setup.controller.addFee(slippageIssuance.address, ZERO, protocolFee);
-          });
-
-          it("should mint SetTokens to the correct addresses", async () => {
-            const preManagerBalance = await setToken.balanceOf(feeRecipient.address);
-            const preProtocolBalance = await setToken.balanceOf(dummyModule.address);
-            const preCallerBalance = await setToken.balanceOf(subjectCaller.address);
-
-            await subject();
-
-            const feeQuantity = preciseMulCeil(subjectQuantity, redeemFee);
-            const protocolSplit = preciseMul(feeQuantity, protocolFee);
-
-            const postManagerBalance = await setToken.balanceOf(feeRecipient.address);
-            const postProtocolBalance = await setToken.balanceOf(dummyModule.address);  // DummyModule is set as address in fixture setup
-            const postCallerBalance = await setToken.balanceOf(subjectCaller.address);
-
-            expect(postCallerBalance).to.eq(preCallerBalance.sub(subjectQuantity));
-            expect(postManagerBalance).to.eq(preManagerBalance.add(feeQuantity.sub(protocolSplit)));
-            expect(postProtocolBalance).to.eq(preProtocolBalance.add(protocolSplit));
-          });
-        });
-
-        describe("when a min token amount out is submitted", async () => {
-          beforeEach(async () => {
-            const mintQuantity = preciseMul(subjectQuantity, ether(1).sub(issueFee));
+            const mintQuantity = preciseMul(subjectQuantity, ether(1).add(issueFee));
             const expectedWethFlows = preciseMul(mintQuantity, ether(1));
 
             subjectCheckedComponents = [setup.weth.address];
-            subjectMinTokenAmountsOut = [expectedWethFlows];
-          });
-
-          it("should redeem SetTokens to the correct addresses", async () => {
-            const preManagerBalance = await setToken.balanceOf(feeRecipient.address);
-            const preCallerBalance = await setToken.balanceOf(subjectCaller.address);
-
-            await subject();
-
-            const feeQuantity = preciseMulCeil(subjectQuantity, redeemFee);
-            const postManagerBalance = await setToken.balanceOf(feeRecipient.address);
-            const postCallerBalance = await setToken.balanceOf(subjectCaller.address);
-
-            expect(postManagerBalance).to.eq(preManagerBalance.add(feeQuantity));
-            expect(postCallerBalance).to.eq(preCallerBalance.sub(subjectQuantity));
-          });
-
-          it("should have the correct token balances", async () => {
-            const preToWethBalance = await setup.weth.balanceOf(subjectTo);
-            const preSetWethBalance = await setup.weth.balanceOf(subjectSetToken);
-            const preRedeemerDaiBalance = await setup.dai.balanceOf(subjectCaller.address);
-            const preSetDaiBalance = await setup.dai.balanceOf(subjectSetToken);
-            const preExternalDaiBalance = await setup.dai.balanceOf(debtModule.address);
-
-            await subject();
-
-            const redeemQuantity = preciseMul(subjectQuantity, ether(1).sub(redeemFee));
-            const daiFlows = preciseMulCeil(redeemQuantity, debtUnits);
-            const wethFlows = preciseMul(redeemQuantity, ether(1));
-
-            const postToWethBalance = await setup.weth.balanceOf(subjectTo);
-            const postSetWethBalance = await setup.weth.balanceOf(subjectSetToken);
-            const postRedeemerDaiBalance = await setup.dai.balanceOf(subjectCaller.address);
-            const postSetDaiBalance = await setup.dai.balanceOf(subjectSetToken);
-            const postExternalDaiBalance = await setup.dai.balanceOf(debtModule.address);
-
-            expect(postToWethBalance).to.eq(preToWethBalance.add(wethFlows));
-            expect(postSetWethBalance).to.eq(preSetWethBalance.sub(wethFlows));
-            expect(postRedeemerDaiBalance).to.eq(preRedeemerDaiBalance.sub(daiFlows));
-            expect(postSetDaiBalance).to.eq(preSetDaiBalance);
-            expect(postExternalDaiBalance).to.eq(preExternalDaiBalance.add(daiFlows));
-          });
-
-          describe("but the returned amount isn't enough", async () => {
-            beforeEach(async () => {
-              const mintQuantity = preciseMul(subjectQuantity, ether(1).add(issueFee));
-              const expectedWethFlows = preciseMul(mintQuantity, ether(1));
-
-              subjectCheckedComponents = [setup.weth.address];
-              subjectMinTokenAmountsOut = [expectedWethFlows.add(1)];
-            });
-
-            it("should revert", async () => {
-              await expect(subject()).to.be.revertedWith("Too few tokens returned for redemption");
-            });
-          });
-
-          describe("but a specified component isn't part of the Set", async () => {
-            beforeEach(async () => {
-              subjectCheckedComponents = [setup.usdc.address];
-              subjectMinTokenAmountsOut = [usdc(100)];
-            });
-
-            it("should revert", async () => {
-              await expect(subject()).to.be.revertedWith("Limit passed for invalid component");
-            });
-          });
-
-          describe("but the array lengths mismatch", async () => {
-            beforeEach(async () => {
-              subjectCheckedComponents = [setup.weth.address];
-              subjectMinTokenAmountsOut = [];
-            });
-
-            it("should revert", async () => {
-              await expect(subject()).to.be.revertedWith("Array length mismatch");
-            });
-          });
-
-          describe("but there are duplicated in the components array", async () => {
-            beforeEach(async () => {
-              subjectCheckedComponents = [setup.weth.address, setup.weth.address];
-              subjectMinTokenAmountsOut = [ether(1), ether(1)];
-            });
-
-            it("should revert", async () => {
-              await expect(subject()).to.be.revertedWith("Cannot duplicate addresses");
-            });
-          });
-        });
-
-        describe("when the redeem quantity is 0", async () => {
-          beforeEach(async () => {
-            subjectQuantity = ZERO;
+            subjectMinTokenAmountsOut = [expectedWethFlows.add(1)];
           });
 
           it("should revert", async () => {
-            await expect(subject()).to.be.revertedWith("SetToken quantity must be > 0");
+            await expect(subject()).to.be.revertedWith("Too few tokens returned for redemption");
           });
         });
 
-        describe("when the SetToken is not enabled on the controller", async () => {
+        describe("but a specified component isn't part of the Set", async () => {
           beforeEach(async () => {
-            const nonEnabledSetToken = await setup.createNonControllerEnabledSetToken(
-              [setup.weth.address],
-              [ether(1)],
-              [slippageIssuance.address]
-            );
-
-            subjectSetToken = nonEnabledSetToken.address;
+            subjectCheckedComponents = [setup.usdc.address];
+            subjectMinTokenAmountsOut = [usdc(100)];
           });
 
           it("should revert", async () => {
-            await expect(subject()).to.be.revertedWith("Must be a valid and initialized SetToken");
+            await expect(subject()).to.be.revertedWith("Limit passed for invalid component");
+          });
+        });
+
+        describe("but the array lengths mismatch", async () => {
+          beforeEach(async () => {
+            subjectCheckedComponents = [setup.weth.address];
+            subjectMinTokenAmountsOut = [];
+          });
+
+          it("should revert", async () => {
+            await expect(subject()).to.be.revertedWith("Array length mismatch");
+          });
+        });
+
+        describe("but there are duplicated in the components array", async () => {
+          beforeEach(async () => {
+            subjectCheckedComponents = [setup.weth.address, setup.weth.address];
+            subjectMinTokenAmountsOut = [ether(1), ether(1)];
+          });
+
+          it("should revert", async () => {
+            await expect(subject()).to.be.revertedWith("Cannot duplicate addresses");
           });
         });
       });
 
-      describe("#updateFeeRecipient", async () => {
-        let subjectSetToken: Address;
-        let subjectNewFeeRecipient: Address;
-        let subjectCaller: Account;
-
+      describe("when the redeem quantity is 0", async () => {
         beforeEach(async () => {
-          subjectNewFeeRecipient = recipient.address;
-          subjectSetToken = setToken.address;
-          subjectCaller = manager;
-        });
-
-        async function subject(): Promise<ContractTransaction> {
-          return slippageIssuance.connect(subjectCaller.wallet).updateFeeRecipient(
-            subjectSetToken,
-            subjectNewFeeRecipient
-          );
-        }
-
-        it("should have set the new fee recipient address", async () => {
-          await subject();
-
-          const settings: any = await slippageIssuance.issuanceSettings(subjectSetToken);
-
-          expect(settings.feeRecipient).to.eq(subjectNewFeeRecipient);
-        });
-
-        it("should emit the correct FeeRecipientUpdated event", async () => {
-          await expect(subject()).to.emit(slippageIssuance, "FeeRecipientUpdated").withArgs(
-            subjectSetToken,
-            subjectNewFeeRecipient
-          );
-        });
-
-        describe("when fee recipient address is null address", async () => {
-          beforeEach(async () => {
-            subjectNewFeeRecipient = ADDRESS_ZERO;
-          });
-
-          it("should revert", async () => {
-            await expect(subject()).to.be.revertedWith("Fee Recipient must be non-zero address.");
-          });
-        });
-
-        describe("when fee recipient address is same address", async () => {
-          beforeEach(async () => {
-            subjectNewFeeRecipient = (await slippageIssuance.issuanceSettings(subjectSetToken)).feeRecipient;
-          });
-
-          it("should revert", async () => {
-            await expect(subject()).to.be.revertedWith("Same fee recipient passed");
-          });
-        });
-
-        describe("when SetToken is not valid", async () => {
-          beforeEach(async () => {
-            const nonEnabledSetToken = await setup.createNonControllerEnabledSetToken(
-              [setup.weth.address],
-              [ether(1)],
-              [slippageIssuance.address],
-              manager.address
-            );
-
-            subjectSetToken = nonEnabledSetToken.address;
-          });
-
-          it("should revert", async () => {
-            await expect(subject()).to.be.revertedWith("Must be a valid and initialized SetToken");
-          });
-        });
-
-        describe("when the caller is not the SetToken manager", async () => {
-          beforeEach(async () => {
-            subjectCaller = owner;
-          });
-
-          it("should revert", async () => {
-            await expect(subject()).to.be.revertedWith("Must be the SetToken manager");
-          });
-        });
-      });
-    });
-
-    describe("#updateIssueFee", async () => {
-      let subjectSetToken: Address;
-      let subjectNewIssueFee: BigNumber;
-      let subjectCaller: Account;
-
-      beforeEach(async () => {
-        subjectNewIssueFee = ether(.01);
-        subjectSetToken = setToken.address;
-        subjectCaller = manager;
-      });
-
-      async function subject(): Promise<ContractTransaction> {
-        return slippageIssuance.connect(subjectCaller.wallet).updateIssueFee(
-          subjectSetToken,
-          subjectNewIssueFee
-        );
-      }
-
-      it("should have set the new fee recipient address", async () => {
-        await subject();
-
-        const settings: any = await slippageIssuance.issuanceSettings(subjectSetToken);
-
-        expect(settings.managerIssueFee).to.eq(subjectNewIssueFee);
-      });
-
-      it("should emit the correct IssueFeeUpdated event", async () => {
-        await expect(subject()).to.emit(slippageIssuance, "IssueFeeUpdated").withArgs(
-          subjectSetToken,
-          subjectNewIssueFee
-        );
-      });
-
-      describe("when new issue fee is greater than max fee", async () => {
-        beforeEach(async () => {
-          subjectNewIssueFee = ether(0.03);
+          subjectQuantity = ZERO;
         });
 
         it("should revert", async () => {
-          await expect(subject()).to.be.revertedWith("Issue fee can't exceed maximum");
+          await expect(subject()).to.be.revertedWith("SetToken quantity must be > 0");
         });
       });
 
-      describe("when issue fee is same amount", async () => {
-        beforeEach(async () => {
-          subjectNewIssueFee = (await slippageIssuance.issuanceSettings(subjectSetToken)).managerIssueFee;
-        });
-
-        it("should revert", async () => {
-          await expect(subject()).to.be.revertedWith("Same issue fee passed");
-        });
-      });
-
-      describe("when SetToken is not valid", async () => {
+      describe("when the SetToken is not enabled on the controller", async () => {
         beforeEach(async () => {
           const nonEnabledSetToken = await setup.createNonControllerEnabledSetToken(
             [setup.weth.address],
             [ether(1)],
-            [slippageIssuance.address],
-            manager.address
+            [slippageIssuance.address]
           );
 
           subjectSetToken = nonEnabledSetToken.address;
@@ -1560,97 +1135,6 @@ describe.only("SlippageIssuanceModule", () => {
 
         it("should revert", async () => {
           await expect(subject()).to.be.revertedWith("Must be a valid and initialized SetToken");
-        });
-      });
-
-      describe("when the caller is not the SetToken manager", async () => {
-        beforeEach(async () => {
-          subjectCaller = owner;
-        });
-
-        it("should revert", async () => {
-          await expect(subject()).to.be.revertedWith("Must be the SetToken manager");
-        });
-      });
-    });
-
-    describe("#updateRedeemFee", async () => {
-      let subjectSetToken: Address;
-      let subjectNewRedeemFee: BigNumber;
-      let subjectCaller: Account;
-
-      beforeEach(async () => {
-        subjectNewRedeemFee = ether(.01);
-        subjectSetToken = setToken.address;
-        subjectCaller = manager;
-      });
-
-      async function subject(): Promise<ContractTransaction> {
-        return slippageIssuance.connect(subjectCaller.wallet).updateRedeemFee(
-          subjectSetToken,
-          subjectNewRedeemFee
-        );
-      }
-
-      it("should have set the new fee recipient address", async () => {
-        await subject();
-
-        const settings: any = await slippageIssuance.issuanceSettings(subjectSetToken);
-
-        expect(settings.managerRedeemFee).to.eq(subjectNewRedeemFee);
-      });
-
-      it("should emit the correct RedeemFeeUpdated event", async () => {
-        await expect(subject()).to.emit(slippageIssuance, "RedeemFeeUpdated").withArgs(
-          subjectSetToken,
-          subjectNewRedeemFee
-        );
-      });
-
-      describe("when new redeem fee is greater than max fee", async () => {
-        beforeEach(async () => {
-          subjectNewRedeemFee = ether(0.03);
-        });
-
-        it("should revert", async () => {
-          await expect(subject()).to.be.revertedWith("Redeem fee can't exceed maximum");
-        });
-      });
-
-      describe("when redeem fee is same amount", async () => {
-        beforeEach(async () => {
-          subjectNewRedeemFee = (await slippageIssuance.issuanceSettings(subjectSetToken)).managerRedeemFee;
-        });
-
-        it("should revert", async () => {
-          await expect(subject()).to.be.revertedWith("Same redeem fee passed");
-        });
-      });
-
-      describe("when SetToken is not valid", async () => {
-        beforeEach(async () => {
-          const nonEnabledSetToken = await setup.createNonControllerEnabledSetToken(
-            [setup.weth.address],
-            [ether(1)],
-            [slippageIssuance.address],
-            manager.address
-          );
-
-          subjectSetToken = nonEnabledSetToken.address;
-        });
-
-        it("should revert", async () => {
-          await expect(subject()).to.be.revertedWith("Must be a valid and initialized SetToken");
-        });
-      });
-
-      describe("when the caller is not the SetToken manager", async () => {
-        beforeEach(async () => {
-          subjectCaller = owner;
-        });
-
-        it("should revert", async () => {
-          await expect(subject()).to.be.revertedWith("Must be the SetToken manager");
         });
       });
     });


### PR DESCRIPTION
CHANGELOG:
- Updated logic in `SlippageIssuanceModule` to expect return values from `getIssuanceAdjustments` and `getRedemptionAdjustments` to be difference in current position unit vs expected position unit after issuance
- Made small javadoc updates
- Removed some tests that were testing logic from an inherited contract
