### PR TITLE
Fix dist package for typescript

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,21 @@ OR `yarn test:clean` if contracts have been typings need to be updated
 
 We publish our contracts as well as [hardhat][22] and [typechain][23] compilation artifacts to npm.
 
+```
+npm install @setprotocol/set-protocol-v2
+```
+
 The distribution also comes with fixtures for mocking and testing SetProtocol's interactions with
 other protocols including Uniswap, Balancer, Compound (and many more.) To use these you'll need to install the peer dependencies listed in `package.json`.
 
-```
-npm install @setprotocol/set-protocol-v2
+#### Example Usage
+
+```ts
+import { PerpV2Fixture } from "@setprotocol/set-protocol-v2/dist/utils/fixtures/PerpV2Fixture";
+import { getPerpV2Fixture } from "@setprotocol/set-protocol-v2/dist/utils/test";
+
+let perpSetup: PerpV2Fixture;
+perpSetup = getPerpV2Fixture(...);
 ```
 
 [22]: https://www.npmjs.com/package/hardhat

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@setprotocol/set-protocol-v2",
-  "version": "0.1.5-tsdebug.2",
+  "version": "0.1.5-tsdebug.3",
   "description": "",
   "main": "dist",
   "types": "dist/types",
@@ -17,7 +17,7 @@
   "scripts": {
     "build": "yarn clean && yarn compile && yarn build:typechain",
     "build:npm": "yarn clean && yarn compile:npm && yarn build:typechain",
-    "build:typechain": "yarn typechain && yarn transpile-dist",
+    "build:typechain": "yarn typechain && yarn transpile-dist && cp -rf typechain dist",
     "chain": "npx hardhat node",
     "clean": "rm -rf coverage.json .coverage_cache .coverage_contracts cache coverage typechain artifacts dist",
     "compile": "npx hardhat compile",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@setprotocol/set-protocol-v2",
-  "version": "0.1.5-tsdebug.1",
+  "version": "0.1.5-tsdebug.2",
   "description": "",
   "main": "dist",
   "types": "dist/types",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@setprotocol/set-protocol-v2",
-  "version": "0.1.5",
+  "version": "0.1.5-tsdebug.0",
   "description": "",
   "main": "dist",
   "types": "dist/types",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@setprotocol/set-protocol-v2",
-  "version": "0.1.5-tsdebug.0",
+  "version": "0.1.4",
   "description": "",
   "main": "dist",
   "types": "dist/types",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@setprotocol/set-protocol-v2",
-  "version": "0.1.4",
+  "version": "0.1.5-tsdebug.1",
   "description": "",
   "main": "dist",
   "types": "dist/types",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@setprotocol/set-protocol-v2",
-  "version": "0.1.5-tsdebug.3",
+  "version": "0.1.6",
   "description": "",
   "main": "dist",
   "types": "dist/types",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
     "outDir": "dist",
     "resolveJsonModule": true,
     "declaration": true,
-    "declarationDir": "./dist/types",
+    "declarationMap": true,
+    "sourceMap": true,
     "baseUrl": ".",
     "moduleResolution": "node",
     "paths": {


### PR DESCRIPTION
When you install `@setprotocol/set-protocol-v2` from npm, the fixtures etc are currently unusable because TS throws errors like this:
```
test/manager/baseManagerV2.spec.ts:23:31 - error TS7016: Could not find a declaration file for module '@setprotocol/set-protocol-v2/dist/utils/fixtures/PerpV2Fixture'. '/Users/cgewecke/code/set/set-v2-strategies/node_modules/@setprotocol/set-protocol-v2/dist/utils/fixtures/PerpV2Fixture.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/setprotocol__set-protocol-v2` if it exists or add a new declaration (.d.ts) file containing `declare module '@setprotocol/set-protocol-v2/dist/utils/fixtures/PerpV2Fixture';`

23 import { PerpV2Fixture } from "@setprotocol/set-protocol-v2/dist/utils/fixtures/PerpV2Fixture";
                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

**PR:**
+ changes the tsconfig to generate source and types maps so imports from node_modules behave as expected
+ copies typechain folder into the dist folder post-build (as part of npm command)
+ updates README with npm package usage example 

-----

Have checked that this works by publishing to tag `tsdebug`
```
yarn add @setprotocol/set-protocol-v2@tsdebug
```

... and importing the fixture into the repo we've seen this problem in (on the richard/perp... branch) as below:
```ts
import { PerpV2Fixture } from "@setprotocol/set-protocol-v2/dist/utils/fixtures/PerpV2Fixture";
import { getPerpV2Fixture } from "@setprotocol/set-protocol-v2/dist/utils/test";

let perpSetup: PerpV2Fixture;
perpSetup = getPerpV2Fixture(...);
```

