### PR TITLE
Make SlippageIssuanceModule issuance & redemption component units getters non-view

### DIFF
--- a/contracts/interfaces/IModuleIssuanceHookV2.sol
+++ b/contracts/interfaces/IModuleIssuanceHookV2.sol
@@ -26,14 +26,14 @@ import { ISetToken } from "./ISetToken.sol";
  * CHANGELOG:
  *      - Added a module level issue hook that can be used to set state ahead of component level
  *        issue hooks
- *      - Added view function that return expected positional adjustments during issue/redeem to
+ *      - Added non-view getter that returns expected positional adjustments during issue/redeem to
  *        the issuance module in order to give more accurate token flow information
  */
 interface IModuleIssuanceHookV2 {
 
     function moduleIssueHook(ISetToken _setToken, uint256 _setTokenQuantity) external;
     function moduleRedeemHook(ISetToken _setToken, uint256 _setTokenQuantity) external;
-    
+
     function componentIssueHook(
         ISetToken _setToken,
         uint256 _setTokenQuantity,
@@ -53,6 +53,9 @@ interface IModuleIssuanceHookV2 {
      * components array (i.e. if debt is greater than current debt position unit return negative number).
      * Each entry in the returned arrays should index to the same component in the SetToken's components
      * array (called using getComponents()).
+     *
+     * NOTE: This getter is non-view to allow module hooks to determine units by simulating state changes in
+     * an external protocol and reverting. It should only be called by off-chain methods via static call.
      */
     function getIssuanceAdjustments(
         ISetToken _setToken,
@@ -66,6 +69,9 @@ interface IModuleIssuanceHookV2 {
      * components array (i.e. if debt is greater than current debt position unit return negative number).
      * Each entry in the returned arrays should index to the same component in the SetToken's components
      * array (called using getComponents()).
+     *
+     * NOTE: This getter is non-view to allow module hooks to determine units by simulating state changes in
+     * an external protocol and reverting. It should only be called by off-chain methods via static call.
      */
     function getRedemptionAdjustments(
         ISetToken _setToken,

--- a/contracts/interfaces/IModuleIssuanceHookV2.sol
+++ b/contracts/interfaces/IModuleIssuanceHookV2.sol
@@ -59,7 +59,6 @@ interface IModuleIssuanceHookV2 {
         uint256 _setTokenQuantity
     )
         external
-        view
         returns (int256[] memory, int256[] memory);
 
     /**
@@ -73,6 +72,5 @@ interface IModuleIssuanceHookV2 {
         uint256 _setTokenQuantity
     )
         external
-        view
         returns (int256[] memory, int256[] memory);
 }

--- a/contracts/protocol/modules/PerpV2LeverageModule.sol
+++ b/contracts/protocol/modules/PerpV2LeverageModule.sol
@@ -36,7 +36,7 @@ import { IQuoter } from "../../interfaces/external/perp-v2/IQuoter.sol";
 import { IMarketRegistry } from "../../interfaces/external/perp-v2/IMarketRegistry.sol";
 import { IController } from "../../interfaces/IController.sol";
 import { IDebtIssuanceModule } from "../../interfaces/IDebtIssuanceModule.sol";
-import { IModuleIssuanceHook } from "../../interfaces/IModuleIssuanceHook.sol";
+import { IModuleIssuanceHookV2 } from "../../interfaces/IModuleIssuanceHookV2.sol";
 import { ISetToken } from "../../interfaces/ISetToken.sol";
 import { ModuleBase } from "../lib/ModuleBase.sol";
 import { SetTokenAccessible } from "../lib/SetTokenAccessible.sol";
@@ -60,7 +60,7 @@ import { UnitConversionUtils } from "../../lib/UnitConversionUtils.sol";
  * NOTE: The external position unit is only updated on an as-needed basis during issuance/redemption. It does not reflect the current
  * value of the Set's perpetual position. The current value can be calculated from getPositionNotionalInfo.
  */
-contract PerpV2LeverageModule is ModuleBase, ReentrancyGuard, Ownable, SetTokenAccessible, IModuleIssuanceHook {
+contract PerpV2LeverageModule is ModuleBase, ReentrancyGuard, Ownable, SetTokenAccessible, IModuleIssuanceHookV2 {
     using PerpV2 for ISetToken;
     using PreciseUnitMath for int256;
     using SignedSafeMath for int256;
@@ -546,6 +546,7 @@ contract PerpV2LeverageModule is ModuleBase, ReentrancyGuard, Ownable, SetTokenA
         uint256 _setTokenQuantity
     )
         external
+        override
         returns (int256[] memory, int256[] memory)
     {
         address[] memory components = _setToken.getComponents();
@@ -573,6 +574,7 @@ contract PerpV2LeverageModule is ModuleBase, ReentrancyGuard, Ownable, SetTokenA
         uint256 _setTokenQuantity
     )
         external
+        override
         returns (int256[] memory, int256[] memory _)
     {
         address[] memory components = _setToken.getComponents();

--- a/contracts/protocol/modules/SlippageIssuanceModule.sol
+++ b/contracts/protocol/modules/SlippageIssuanceModule.sol
@@ -191,6 +191,9 @@ contract SlippageIssuanceModule is DebtIssuanceModule {
      * that will be returned to caller. Overrides inherited function to take into account position updates from pre action module hooks.
      * (manager hooks not included).
      *
+     * NOTE: This getter is non-view to allow module hooks to determine units by simulating state changes in an external protocol and
+     * reverting. It should only be called by off-chain methods via static call.
+     *
      * @param _setToken         Instance of the SetToken to issue
      * @param _quantity         Amount of Sets to be issued
      *
@@ -198,13 +201,11 @@ contract SlippageIssuanceModule is DebtIssuanceModule {
      * @return uint256[]        Array of equity notional amounts of each component, respectively, represented as uint256
      * @return uint256[]        Array of debt notional amounts of each component, respectively, represented as uint256
      */
-    function getRequiredComponentIssuanceUnits(
+    function getRequiredComponentIssuanceUnitsOffChain(
         ISetToken _setToken,
         uint256 _quantity
     )
         external
-        view
-        override
         returns (address[] memory, uint256[] memory, uint256[] memory)
     {
         bool isIssue = true;
@@ -231,6 +232,9 @@ contract SlippageIssuanceModule is DebtIssuanceModule {
      * Calculates the amount of each component that will be returned on redemption net of fees as well as how much debt needs to be paid down to
      * redeem. Overrides inherited function to take into account position updates from pre action module hooks (manager hooks not included).
      *
+     * NOTE: This getter is non-view to allow module hooks to determine units by simulating state changes in an external protocol and
+     * reverting. It should only be called by off-chain methods via static call.
+     *
      * @param _setToken         Instance of the SetToken to issue
      * @param _quantity         Amount of Sets to be redeemed
      *
@@ -238,13 +242,11 @@ contract SlippageIssuanceModule is DebtIssuanceModule {
      * @return uint256[]        Array of equity notional amounts of each component, respectively, represented as uint256
      * @return uint256[]        Array of debt notional amounts of each component, respectively, represented as uint256
      */
-    function getRequiredComponentRedemptionUnits(
+    function getRequiredComponentRedemptionUnitsOffChain(
         ISetToken _setToken,
         uint256 _quantity
     )
         external
-        view
-        override
         returns (address[] memory, uint256[] memory, uint256[] memory)
     {
         bool isIssue = false;
@@ -348,7 +350,6 @@ contract SlippageIssuanceModule is DebtIssuanceModule {
         bool _isIssue
     )
         internal
-        view
         returns (int256[] memory, int256[] memory) 
     {
         uint256 componentsLength = _setToken.getComponents().length;

--- a/contracts/protocol/modules/SlippageIssuanceModule.sol
+++ b/contracts/protocol/modules/SlippageIssuanceModule.sol
@@ -188,7 +188,7 @@ contract SlippageIssuanceModule is DebtIssuanceModule {
 
     /**
      * Calculates the amount of each component needed to collateralize passed issue quantity plus fees of Sets as well as amount of debt
-     * that will be returned to caller. Overrides inherited function to take into account position updates from pre action module hooks.
+     * that will be returned to caller. Takes into account position updates from pre action module hooks.
      * (manager hooks not included).
      *
      * NOTE: This getter is non-view to allow module hooks to determine units by simulating state changes in an external protocol and
@@ -230,7 +230,7 @@ contract SlippageIssuanceModule is DebtIssuanceModule {
 
     /**
      * Calculates the amount of each component that will be returned on redemption net of fees as well as how much debt needs to be paid down to
-     * redeem. Overrides inherited function to take into account position updates from pre action module hooks (manager hooks not included).
+     * redeem. Takes into account position updates from pre action module hooks (manager hooks not included).
      *
      * NOTE: This getter is non-view to allow module hooks to determine units by simulating state changes in an external protocol and
      * reverting. It should only be called by off-chain methods via static call.

--- a/contracts/protocol/modules/SlippageIssuanceModule.sol
+++ b/contracts/protocol/modules/SlippageIssuanceModule.sol
@@ -184,8 +184,6 @@ contract SlippageIssuanceModule is DebtIssuanceModule {
         );
     }
 
-    /* ============ External View Functions ============ */
-
     /**
      * Calculates the amount of each component needed to collateralize passed issue quantity plus fees of Sets as well as amount of debt
      * that will be returned to caller. Takes into account position updates from pre action module hooks.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@setprotocol/set-protocol-v2",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "",
   "main": "dist",
   "types": "dist/types",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "build": "yarn clean && yarn compile && yarn build:typechain",
     "build:npm": "yarn clean && yarn compile:npm && yarn build:typechain",
-    "build:typechain": "yarn typechain && yarn transpile-dist && cp -rf typechain dist",
+    "build:typechain": "yarn typechain && yarn transpile-dist",
     "chain": "npx hardhat node",
     "clean": "rm -rf coverage.json .coverage_cache .coverage_contracts cache coverage typechain artifacts dist",
     "compile": "npx hardhat compile",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@setprotocol/set-protocol-v2",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "",
   "main": "dist",
   "types": "dist/types",

--- a/test/protocol/modules/slippageIssuanceModule.spec.ts
+++ b/test/protocol/modules/slippageIssuanceModule.spec.ts
@@ -105,7 +105,7 @@ describe("SlippageIssuanceModule", () => {
       await debtModule.connect(manager.wallet).initialize(setToken.address);
     });
 
-    describe("#getRequiredComponentIssuanceUnits", async () => {
+    describe("#getRequiredComponentIssuanceUnitsOffChain", async () => {
       let subjectSetToken: Address;
       let subjectQuantity: BigNumber;
 
@@ -119,7 +119,7 @@ describe("SlippageIssuanceModule", () => {
       });
 
       async function subject(): Promise<any> {
-        return slippageIssuance.getRequiredComponentIssuanceUnits(
+        return slippageIssuance.callStatic.getRequiredComponentIssuanceUnitsOffChain(
           subjectSetToken,
           subjectQuantity
         );
@@ -287,7 +287,7 @@ describe("SlippageIssuanceModule", () => {
       });
     });
 
-    describe("#getRequiredComponentRedemptionUnits", async () => {
+    describe("#getRequiredComponentRedemptionUnitsOffChain", async () => {
       let subjectSetToken: Address;
       let subjectQuantity: BigNumber;
 
@@ -301,7 +301,7 @@ describe("SlippageIssuanceModule", () => {
       });
 
       async function subject(): Promise<any> {
-        return slippageIssuance.getRequiredComponentRedemptionUnits(
+        return slippageIssuance.callStatic.getRequiredComponentRedemptionUnitsOffChain(
           subjectSetToken,
           subjectQuantity
         );
@@ -474,7 +474,10 @@ describe("SlippageIssuanceModule", () => {
         await debtModule.addDebt(setToken.address, setup.dai.address, debtUnits);
         await setup.dai.transfer(debtModule.address, ether(100.5));
 
-        const [, equityFlows ] = await slippageIssuance.getRequiredComponentIssuanceUnits(setToken.address, ether(1));
+        const [, equityFlows ] = await slippageIssuance
+          .callStatic
+          .getRequiredComponentIssuanceUnitsOffChain(setToken.address, ether(1));
+
         await setup.weth.approve(slippageIssuance.address, equityFlows[0].mul(ether(1.005)));
 
         subjectSetToken = setToken.address;
@@ -816,7 +819,10 @@ describe("SlippageIssuanceModule", () => {
         await debtModule.addDebt(setToken.address, setup.dai.address, debtUnits);
         await setup.dai.transfer(debtModule.address, ether(100.5));
 
-        const [, equityFlows ] = await slippageIssuance.getRequiredComponentRedemptionUnits(setToken.address, ether(1));
+        const [, equityFlows ] = await slippageIssuance
+          .callStatic
+          .getRequiredComponentRedemptionUnitsOffChain(setToken.address, ether(1));
+
         await setup.weth.approve(slippageIssuance.address, equityFlows[0].mul(ether(1.005)));
 
         await slippageIssuance.issue(setToken.address, ether(1), owner.address);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "outDir": "dist",
     "resolveJsonModule": true,
     "declaration": true,
+    "declarationDir": "./dist/types",
     "declarationMap": true,
     "sourceMap": true,
     "baseUrl": ".",


### PR DESCRIPTION
`getComponent...Units` methods throw when used with the PerpV2LeverageModule because its issuance and redemption adjustments getters are non-view. They simulate trades on UniswapV3 and revert in order to discover swap outcomes and can only be called off-chain via methods like `ethers.callStatic`

Have made the smallest intervention possible here, renaming the getters to reflect their intended use context and adding / updating tests. 

**Open Questions**
+ Should this PR also override the inherited getters and revert (to prevent incorrect use of those methods)
+ Or ... should we change the state-mutability signature for these methods across the inheritance chain (instead just of renaming and changing SlippageIssuance's)

 
