### PR TITLE
Additional PerpLeveragModule intergration tests

### DIFF
--- a/test/integration/perpV2LeverageSlippageIssuance.spec.ts
+++ b/test/integration/perpV2LeverageSlippageIssuance.spec.ts
@@ -587,17 +587,17 @@ describe("PerpV2LeverageSlippageIssuance", () => {
 
       describe("when flash-issuing at high margin (failure)", async () => {
         beforeEach(async () => {
-          subjectQuantity = ether(3.5);
+          subjectQuantity = ether(4.5);
         });
 
-        // Calculated leverage = 9_911_554_370_685_102_958
-        it("~9.9X fails", async () => {
+        // Calculated leverage = 12_318_370_314_634_461_976
+        it("~12.3X fails", async () => {
           const flashLeverage = await calculateFlashLeverage(subjectSetToken, subjectQuantity);
 
           await expect(subject()).to.be.revertedWith("CH_NEFCI");
 
-          expect(flashLeverage).to.be.gt(ether(9));
-          expect(flashLeverage).to.be.lt(ether(10));
+          expect(flashLeverage).to.be.gt(ether(12));
+          expect(flashLeverage).to.be.lt(ether(13));
         });
       });
 

--- a/test/integration/perpV2LeverageSlippageIssuance.spec.ts
+++ b/test/integration/perpV2LeverageSlippageIssuance.spec.ts
@@ -1179,16 +1179,16 @@ describe("PerpV2LeverageSlippageIssuance", () => {
             true
           );
 
-          // Move oracle price down to 5 USDC to enable liquidation
-          await perpSetup.setBaseTokenOraclePrice(vETH, usdcUnits(5.0));
+          // Move oracle price down to 500 USDC to enable liquidation
+          await perpSetup.setBaseTokenOraclePrice(vETH, usdcUnits(500));
 
-          // Move price down by maker selling 20k USDC of vETH
-          // Post trade spot price rises from ~10 USDC to 6_370_910_537_702_299_856
+          // Move price down by maker selling 200M USDC of vETH
+          // Post trade spot price drops from ~1000 USDC to 636_772_014_614_233_874_296
           await perpSetup.clearingHouse.connect(maker.wallet).openPosition({
             baseToken: vETH.address,
             isBaseToQuote: true,       // short
             isExactInput: false,       // `amount` is USDC
-            amount: ether(20000),
+            amount: ether(200_000_000),
             oppositeAmountBound: ZERO,
             deadline: MAX_UINT_256,
             sqrtPriceLimitX96: ZERO,
@@ -1209,7 +1209,7 @@ describe("PerpV2LeverageSlippageIssuance", () => {
           const accountValue = await perpSetup.clearingHouse.getAccountValue(subjectSetToken);
 
           // collateralBalance:  20_100_000 (10^6)
-          // accountValue:      -43_466_857_276_051_287_954 (10^18)
+          // accountValue:      -43_515_369_499_756_442_084 (10^18)
           expect(collateralBalance).gt(1);
           expect(freeCollateral).eq(0);
           expect(accountValue).lt(-1);


### PR DESCRIPTION
Adds a test that replicates Perp markets setup in the set-v2-strategies tests and verifies that module can redeem a large number of sets to zero total supply. 

(Part of a debugging effort for test suite issues in set-v2-strategies) 
