### PR TITLE
Ensure returned accountValueIssued never negative in  #_executePositionTrades

### DIFF
--- a/contracts/protocol/modules/PerpV2LeverageModule.sol
+++ b/contracts/protocol/modules/PerpV2LeverageModule.sol
@@ -774,8 +774,8 @@ contract PerpV2LeverageModule is ModuleBase, ReentrancyGuard, Ownable, SetTokenA
 
         // After trading, verify that accountValueIssued is not negative. In some post-liquidation states the
         // account could be bankrupt and we represent that as zero.
-        if (accountValueIssued < 0) {
-            accountValueIssued = 0;
+        if (accountValueIssued <= 0) {
+            return 0;
         }
 
         // Return value in collateral decimals (e.g USDC = 6)

--- a/contracts/protocol/modules/PerpV2LeverageModule.sol
+++ b/contracts/protocol/modules/PerpV2LeverageModule.sol
@@ -772,6 +772,12 @@ contract PerpV2LeverageModule is ModuleBase, ReentrancyGuard, Ownable, SetTokenA
                 accountValueIssued.sub(deltaQuote.toInt256());
         }
 
+        // After trading, verify that accountValueIssued is not negative. In some post-liquidation states the
+        // account could be bankrupt and we represent that as zero.
+        if (accountValueIssued < 0) {
+            accountValueIssued = 0;
+        }
+
         // Return value in collateral decimals (e.g USDC = 6)
         // Use preciseDivCeil when issuing to ensure we don't under-collateralize due to rounding error
         return (_isIssue)


### PR DESCRIPTION
Context for this change is Iosiro's audit item (item 5.12: Invalid state after liquidation) about scenarios where the token is insolvent, e.g has 
+ positive collateral balance
+ no positions open
+ a negative owedRealizedPnl greater than the collateral balance

They note:

> It was possible to have a negative account balance after liquidation. Users attempting to redeem tokens would transfer collateral into an untracked default position, while issuance would result in a revert due to the SetToken not having any collateral available.

> In the context of a SetToken, it would be best for users to not have to repay the outstanding debt and instead be allowed to redeem any remaining assets kept in other external positions or as default positions. This would require removal of the module and preventing any further issuance while the module is still present. Unfortunately, removal of the module was prevented by the account’s collateral balance being greater than zero.

> **Recommendation**
> In the unfortunate event that a SetToken is liquidated and the resulting account balance is zero, the module should permanently prevent any further issuance for the specific SetToken.

> The ideal behavior for redemption is debatable. One approach could be to require the manager or governance to remove the module from the SetToken before allowing users to redeem. Alternatively, users could be permitted to redeem, with the manager and governance deleting the module after some time.

------

We've already made sure the module is removable under these conditions.

This PR adds a check in #_executePositionTrades that makes sure `accountValueIssued` (the value being set as the externalPositionUnit) is positive. If not, it's set to zero. 

This ensures that issuance and redemption can continue without transferring any usdc in or out of the Perp account position or reverting. It's possible tokens will have default positions in addition to the Perp account and these operations need to proceed normally. 

Methods that consume `accountValueIssued` in some form are:
+ moduleIssueHook
+ moduleRedeemHook
+ componentIssueHook 
+ componentRedeemHook 
+ the adjustments getters

Two other cases where an insolvent Perp account state matter are:
+ manager.withdraw: throws NEFC (reasonable)
+ manager.deposit: needs discussion... there may be some risks in forbidding this but it seems irrational to deposit into an account with a large negative owed PnL. 

 

