### PR TITLE
fix bug in function preciseDivCeil

### DIFF
--- a/contracts/lib/PreciseUnitMath.sol
+++ b/contracts/lib/PreciseUnitMath.sol
@@ -147,9 +147,11 @@ library PreciseUnitMath {
         
         a = a.mul(PRECISE_UNIT_INT);
         int256 c = a.div(b);
-        if (c * b != a) {
-            c = c > 0 ? c + 1 : c - 1;
+
+        if (a % b != 0) {
+            (a ^ b > 0) ? ++c : --c;
         }
+
         return c;
     }
 

--- a/utils/common/mathUtils.ts
+++ b/utils/common/mathUtils.ts
@@ -39,14 +39,15 @@ export const preciseDivCeil = (a: BigNumber, b: BigNumber): BigNumber => {
 };
 
 export const preciseDivCeilInt = (a: BigNumber, b: BigNumber): BigNumber => {
-  if (a.eq(0) || b.eq(0)) {
-    return ZERO;
+  const result = a.mul(PRECISE_UNIT).div(b);
+  if (result.mul(b).eq(a.mul(PRECISE_UNIT))) {
+    return result;
   }
 
-  if (a.gt(0) && b.gt(0) || a.lt(0) && b.lt(0)) {
-    return a.mul(PRECISE_UNIT).sub(1).div(b).add(1);
+  if ((a.gt(0) && b.gt(0)) || (a.lt(0) && b.lt(0))) {
+    return result.add(1);
   } else {
-    return a.mul(PRECISE_UNIT).add(1).div(b).sub(1);
+    return result.sub(1);
   }
 };
 


### PR DESCRIPTION
There's a bug in current version:
```solidity
    function preciseDivCeil(int256 a, int256 b) internal pure returns (int256) {
        require(b != 0, "Cant divide by 0");
        
        a = a.mul(PRECISE_UNIT_INT);
        int256 c = a.div(b);
        if (c * b != a) {
            c = c > 0 ? c + 1 : c - 1;
        }
        return c;
    }
```
For example: when a is 1, b is 1000000000000000000000, preciseDivCei should return 1. But in function preciseDivCeil, the value  of  c = a.div(b) is 0, and since c * b != a is true, c > 0 is false, then c = c - 1 = -1, which is not right!