### PR TITLE
fix bug in function setMarketBorrowRate of class AaveV2Fixture

### DIFF
--- a/utils/fixtures/aaveV2Fixture.ts
+++ b/utils/fixtures/aaveV2Fixture.ts
@@ -234,7 +234,7 @@ export class AaveV2Fixture {
   }
 
   public async setMarketBorrowRate(asset: Address, rate: BigNumberish): Promise<void> {
-    this.lendingRateOracle.setMarketBorrowRate(asset, rate);
+    await this.lendingRateOracle.setMarketBorrowRate(asset, rate);
   }
 
   public getForkedAaveLendingPoolAddressesProvider(): AaveV2LendingPoolAddressesProvider {


### PR DESCRIPTION
should add keyword `await` before `this.lendingRateOracle.setMarketBorrowRate(asset, rate);`
```js
  public async setMarketBorrowRate(asset: Address, rate: BigNumberish): Promise<void> {
    this.lendingRateOracle.setMarketBorrowRate(asset, rate);
  }
```
