### PR TITLE
fix bug in library ExplicitERC20

### DIFF
--- a/contracts/lib/ExplicitERC20.sol
+++ b/contracts/lib/ExplicitERC20.sol
@@ -63,7 +63,7 @@ library ExplicitERC20 {
 
             // Verify transfer quantity is reflected in balance
             require(
-                newBalance == existingBalance.add(_quantity),
+                newBalance == existingBalance.add(_quantity) || _from == _to,
                 "Invalid post transfer balance"
             );
         }


### PR DESCRIPTION
In some special cases, function transferFrom's parameters _from and _to are same account, then the condition `newBalance == existingBalance.add(_quantity)` is not met. So we need to check ` _from == _to` also.