### PR TITLE
newFee can equals maxStreamingFeePercentage in StreamingFeeModule

### DIFF
--- a/contracts/protocol/modules/StreamingFeeModule.sol
+++ b/contracts/protocol/modules/StreamingFeeModule.sol
@@ -155,7 +155,7 @@ contract StreamingFeeModule is ModuleBase, ReentrancyGuard {
         onlySetManager(_setToken, msg.sender)
         onlyValidAndInitializedSet(_setToken)
     {
-        require(_newFee < _maxStreamingFeePercentage(_setToken), "Fee must be less than max");
+        require(_newFee <= _maxStreamingFeePercentage(_setToken), "Fee must <= max");
         accrueFee(_setToken);
 
         feeStates[_setToken].streamingFeePercentage = _newFee;


### PR DESCRIPTION
In StreamingFeeModule, `streamingFeePercentage` can be equal to `maxStreamingFeePercentage` when initialize:    
```solidity
require(_settings.streamingFeePercentage <= _settings.maxStreamingFeePercentage, "Fee must be <= max.");
```
But when updateStreamingFee `_newFee` can't be equal to `_maxStreamingFeePercentage`:    
```solidity
require(_newFee < _maxStreamingFeePercentage(_setToken), "Fee must be less than max");
```
It seems that use `<=` to check is better.