### PR TITLE
fix(PerpV2BasisTradingModule): External audit fixes for low-risk findings and Internal audit fixes

### DIFF
--- a/contracts/interfaces/external/perp-v2/IAccountBalance.sol
+++ b/contracts/interfaces/external/perp-v2/IAccountBalance.sol
@@ -28,8 +28,8 @@ interface IAccountBalance {
     function getBase(address trader, address baseToken) external view returns (int256);
     function getQuote(address trader, address baseToken) external view returns (int256);
     function getNetQuoteBalanceAndPendingFee(address trader) external view returns (int256, uint256);
-    function getPositionSize(address trader, address baseToken) external view returns (int256);
-    function getPositionValue(address trader, address baseToken) external view returns (int256);
+    function getTotalPositionSize(address trader, address baseToken) external view returns (int256);
+    function getTotalPositionValue(address trader, address baseToken) external view returns (int256);
     function getTotalAbsPositionValue(address trader) external view returns (uint256);
     function getClearingHouseConfig() external view returns (address);
     function getExchange() external view returns (address);

--- a/contracts/protocol/lib/PositionV2.sol
+++ b/contracts/protocol/lib/PositionV2.sol
@@ -37,7 +37,7 @@ import { PreciseUnitMath } from "../../lib/PreciseUnitMath.sol";
  * CHANGELOG:
  * - `Position` library has all internal functions which are inlined to the module contract during compilation.
  * Inlining functions increases bytecode size of the module contract. This library contains the same functions
- * as `Position` library but all the functions have public/external access modifier. Thus, making this version 
+ * as `Position` library but all the functions have public/external access modifier. Thus, making this version
  * linkable which helps in reducing bytecode size of the module contract.
  */
 library PositionV2 {
@@ -62,7 +62,7 @@ library PositionV2 {
     function hasExternalPosition(ISetToken _setToken, address _component) public view returns(bool) {
         return _setToken.getExternalPositionModules(_component).length > 0;
     }
-    
+
     /**
      * Returns whether the SetToken component default position real unit is greater than or equal to units passed in.
      */
@@ -71,7 +71,7 @@ library PositionV2 {
     }
 
     /**
-     * Returns whether the SetToken component external position is greater than or equal to the real units passed in.
+     * Returns whether the SetToken component's external position is greater than or equal to the real units passed in.
      */
     function hasSufficientExternalUnits(
         ISetToken _setToken,
@@ -83,12 +83,12 @@ library PositionV2 {
         view
         returns(bool)
     {
-       return _setToken.getExternalPositionRealUnit(_component, _positionModule) >= _unit.toInt256();    
+       return _setToken.getExternalPositionRealUnit(_component, _positionModule) >= _unit.toInt256();
     }
 
     /**
      * If the position does not exist, create a new Position and add to the SetToken. If it already exists,
-     * then set the position units. If the new units is 0, remove the position. Handles adding/removing of 
+     * then set the position units. If the new units is 0, remove the position. Handles adding/removing of
      * components where needed (in light of potential external positions).
      *
      * @param _setToken           Address of SetToken being modified
@@ -114,7 +114,7 @@ library PositionV2 {
 
     /**
      * Update an external position and remove and external positions or components if necessary. The logic flows as follows:
-     * 1) If component is not already added then add component and external position. 
+     * 1) If component is not already added then add component and external position.
      * 2) If component is added but no existing external position using the passed module exists then add the external position.
      * 3) If the existing position is being added to then just update the unit and data
      * 4) If the position is being closed and no other external positions or default positions are associated with the component
@@ -191,7 +191,7 @@ library PositionV2 {
      * @return                    Notional tracked balance
      */
     function getDefaultTrackedBalance(ISetToken _setToken, address _component) external view returns(uint256) {
-        int256 positionUnit = _setToken.getDefaultPositionRealUnit(_component); 
+        int256 positionUnit = _setToken.getDefaultPositionRealUnit(_component);
         return _setToken.totalSupply().preciseMul(positionUnit.toUint256());
     }
 

--- a/contracts/protocol/modules/v2/PerpV2BasisTradingModule.sol
+++ b/contracts/protocol/modules/v2/PerpV2BasisTradingModule.sol
@@ -130,10 +130,10 @@ contract PerpV2BasisTradingModule is PerpV2LeverageModuleV2 {
     /* ============ External Functions ============ */
 
     /**
-     * @dev Reverts upon calling. Use `intialize(_setToken, _settings)` instead.
+     * @dev Reverts upon calling. Use `initialize(_setToken, _settings)` instead.
      */
     function initialize(ISetToken /*_setToken*/) public override(PerpV2LeverageModuleV2) {
-        revert("Use intialize(_setToken, _settings) instead");
+        revert("Use initialize(_setToken, _settings) instead");
     }
 
     /**
@@ -232,7 +232,7 @@ contract PerpV2BasisTradingModule is PerpV2LeverageModuleV2 {
     /**
      * @dev SETTOKEN ONLY: Removes this module from the SetToken, via call by the SetToken. Deletes
      * position mappings and fee states associated with SetToken. Resets settled funding to zero.
-     * Fees are not accrued in case reason for removing module is related to fee accrual.
+     * Fees are not accrued in case the reason for removing the module is related to fee accrual.
      *
      * NOTE: Function will revert if there is greater than a position unit amount of USDC of account value.
      */
@@ -463,7 +463,7 @@ contract PerpV2BasisTradingModule is PerpV2LeverageModuleV2 {
     }
 
     /**
-     * @dev Calculates manager and protocol fees on withdranwn funding amount and transfers them to
+     * @dev Calculates manager and protocol fees on withdrawn funding amount and transfers them to
      * their respective recipients (in USDC).
      *
      * @param _setToken     Instance of SetToken

--- a/contracts/protocol/modules/v2/PerpV2BasisTradingModule.sol
+++ b/contracts/protocol/modules/v2/PerpV2BasisTradingModule.sol
@@ -496,7 +496,7 @@ contract PerpV2BasisTradingModule is PerpV2LeverageModuleV2 {
     }
 
     /**
-     * @dev Updates collateral token default position unit and tracked settled funding. Used in `withdrawFundingAndAcrrueFees()`.
+     * @dev Updates collateral token default position unit and tracked settled funding. Used in `withdrawFundingAndAccrueFees()`
      *
      * @param _setToken                         Instance of the SetToken
      * @param _notionalFunding                  Amount of funding withdrawn (in USDC decimals)

--- a/contracts/protocol/modules/v2/PerpV2BasisTradingModule.sol
+++ b/contracts/protocol/modules/v2/PerpV2BasisTradingModule.sol
@@ -212,6 +212,8 @@ contract PerpV2BasisTradingModule is PerpV2LeverageModuleV2 {
         nonReentrant
         onlyManagerAndValidSet(_setToken)
     {
+        if (_notionalFunding == 0) return;
+
         uint256 newSettledFunding = _updateSettledFunding(_setToken);
 
         uint256 settledFundingInCollateralDecimals = newSettledFunding.fromPreciseUnitToDecimals(collateralDecimals);

--- a/contracts/protocol/modules/v2/PerpV2BasisTradingModule.sol
+++ b/contracts/protocol/modules/v2/PerpV2BasisTradingModule.sol
@@ -425,11 +425,16 @@ contract PerpV2BasisTradingModule is PerpV2LeverageModuleV2 {
         override(PerpV2LeverageModuleV2)
         returns (int256[] memory, int256[] memory _)
     {
-        uint256 updatedSettledFunding = _getUpdatedSettledFunding(_setToken);
+        int256 newExternalPositionUnitNetFees = 0;
 
-        int256 newExternalPositionUnit = _executePositionTrades(_setToken, _setTokenQuantity, false, true);
+        if (positions[_setToken].length > 0) {
 
-        int256 newExternalPositionUnitNetFees = _calculateNetFeesPositionUnit(_setToken, newExternalPositionUnit, updatedSettledFunding);
+            uint256 updatedSettledFunding = _getUpdatedSettledFunding(_setToken);
+
+            int256 newExternalPositionUnit = _executePositionTrades(_setToken, _setTokenQuantity, false, true);
+
+            newExternalPositionUnitNetFees = _calculateNetFeesPositionUnit(_setToken, newExternalPositionUnit, updatedSettledFunding);
+        }
 
         return _formatAdjustments(_setToken, newExternalPositionUnitNetFees);
     }

--- a/contracts/protocol/modules/v2/PerpV2BasisTradingModule.sol
+++ b/contracts/protocol/modules/v2/PerpV2BasisTradingModule.sol
@@ -543,6 +543,8 @@ contract PerpV2BasisTradingModule is PerpV2LeverageModuleV2 {
             _collateralBalanceBeforeWithdraw
         );
 
+        _updateExternalPositionUnit(_setToken);
+
         // Subtract withdrawn funding from tracked settled funding
         settledFunding[_setToken] = settledFunding[_setToken].sub(
             _notionalFunding.toPreciseUnitsFromDecimals(collateralDecimals)

--- a/contracts/protocol/modules/v2/PerpV2LeverageModuleV2.sol
+++ b/contracts/protocol/modules/v2/PerpV2LeverageModuleV2.sol
@@ -374,6 +374,7 @@ contract PerpV2LeverageModuleV2 is ModuleBaseV2, ReentrancyGuard, Ownable, SetTo
       uint256 _collateralQuantityUnits
     )
       public
+      virtual
       nonReentrant
       onlyManagerAndValidSet(_setToken)
     {

--- a/contracts/protocol/modules/v2/PerpV2LeverageModuleV2.sol
+++ b/contracts/protocol/modules/v2/PerpV2LeverageModuleV2.sol
@@ -555,7 +555,7 @@ contract PerpV2LeverageModuleV2 is ModuleBaseV2, ReentrancyGuard, Ownable, SetTo
     /**
      * @dev GOVERNANCE ONLY: Update max perpetual positions per SetToken. Only callable by governance.
      *
-     * @param _maxPerpPositionsPerSet       New max perpetual positons per set
+     * @param _maxPerpPositionsPerSet       New max perpetual positions per set
      */
     function updateMaxPerpPositionsPerSet(uint256 _maxPerpPositionsPerSet) external onlyOwner {
         maxPerpPositionsPerSet = _maxPerpPositionsPerSet;
@@ -1107,7 +1107,7 @@ contract PerpV2LeverageModuleV2 is ModuleBaseV2, ReentrancyGuard, Ownable, SetTo
      * @param _setToken                         Instance of the SetToken
      * @param _newExternalPositionUnit          Dynamically calculated externalPositionUnit
      * @return int256[]                         Components-length array with equity adjustment value at appropriate index
-     * @return int256[]                         Components-length array of zeroes (debt adjustements)
+     * @return int256[]                         Components-length array of zeroes (debt adjustments)
      */
     function _formatAdjustments(
         ISetToken _setToken,

--- a/contracts/protocol/modules/v2/PerpV2LeverageModuleV2.sol
+++ b/contracts/protocol/modules/v2/PerpV2LeverageModuleV2.sol
@@ -1054,10 +1054,10 @@ contract PerpV2LeverageModuleV2 is ModuleBaseV2, ReentrancyGuard, Ownable, SetTo
     }
 
     /**
-     * @dev Sets the external position unit based on PerpV2 Vault collateral balance. If there more than 1
-     * position unit of USDC of account value (allowing for PRECISE UNIT rounding errors) adds the component
-     * and/or the external position to the SetToken. Else, untracks the component and/or removes external
-     * position from the SetToken. Refer to PositionV2#editExternalPosition for detailed flow.
+     * @dev Sets the external position unit based on PerpV2 Vault collateral balance. If there is >= 1
+     * position unit of USDC of collateral value, add the component and/or the external position to the
+     * SetToken. Else, untracks the component and/or removes external position from the SetToken. Refer
+     * to PositionV2#editExternalPosition for detailed flow.
      *
      * NOTE: Setting external position unit to the collateral balance is acceptable because, as noted above, the
      * external position unit is only updated on an as-needed basis during issuance, redemption, deposit and

--- a/contracts/protocol/modules/v2/PerpV2LeverageModuleV2.sol
+++ b/contracts/protocol/modules/v2/PerpV2LeverageModuleV2.sol
@@ -390,7 +390,7 @@ contract PerpV2LeverageModuleV2 is ModuleBaseV2, ReentrancyGuard, Ownable, SetTo
     }
 
     /**
-     * @dev MANAGER ONLY: Removes this module from the SetToken, via call by the SetToken. Deletes
+     * @dev SETTOKEN ONLY: Removes this module from the SetToken, via call by the SetToken. Deletes
      * position mappings associated with SetToken.
      *
      * NOTE: Function will revert if there is greater than a position unit amount of USDC of account value.

--- a/contracts/protocol/modules/v2/PerpV2LeverageModuleV2.sol
+++ b/contracts/protocol/modules/v2/PerpV2LeverageModuleV2.sol
@@ -352,6 +352,10 @@ contract PerpV2LeverageModuleV2 is ModuleBaseV2, ReentrancyGuard, Ownable, SetTo
       onlyManagerAndValidSet(_setToken)
     {
         require(_collateralQuantityUnits > 0, "Deposit amount is 0");
+        require(
+            _collateralQuantityUnits <= _setToken.getDefaultPositionRealUnit(address(collateralToken)).toUint256(),
+            "Amount too high"
+        );
 
         uint256 notionalDepositedQuantity = _depositAndUpdatePositions(_setToken, _collateralQuantityUnits);
 

--- a/deprecated/PerpV2LeverageModule.sol
+++ b/deprecated/PerpV2LeverageModule.sol
@@ -271,7 +271,7 @@ contract PerpV2LeverageModule is ModuleBase, ReentrancyGuard, Ownable, SetTokenA
      * token market prices and needs to be generated on the fly to be meaningful.
      *
      * In the tables below, basePositionUnit = baseTokenBalance / setTotalSupply.
-     * 
+     *
      * As a user when levering, e.g increasing the magnitude of your position, you'd trade as below
      * | ----------------------------------------------------------------------------------------------- |
      * | Type  |  Action | Goal                      | `quoteBoundQuantity`        | `baseQuantityUnits` |
@@ -318,7 +318,7 @@ contract PerpV2LeverageModule is ModuleBase, ReentrancyGuard, Ownable, SetTokenA
         public
         nonReentrant
         onlyManagerAndValidSet(_setToken)
-    {        
+    {
         ActionInfo memory actionInfo = _createAndValidateActionInfo(
             _setToken,
             _baseToken,
@@ -413,7 +413,7 @@ contract PerpV2LeverageModule is ModuleBase, ReentrancyGuard, Ownable, SetTokenA
         // `positions[setToken]` mapping stores an array of addresses. The base token addresses are removed from the array when the
         // corresponding base token positions are zeroed out. Since no positions exist when removing the module, the stored array should
         // already be empty, and the mapping can be deleted directly.
-        delete positions[setToken]; 
+        delete positions[setToken];
 
         // Try if unregister exists on any of the modules
         address[] memory modules = setToken.getModules();
@@ -563,8 +563,8 @@ contract PerpV2LeverageModule is ModuleBase, ReentrancyGuard, Ownable, SetTokenA
 
     /**
      * @dev GOVERNANCE ONLY: Update max perpetual positions per SetToken. Only callable by governance.
-     * 
-     * @param _maxPerpPositionsPerSet       New max perpetual positons per set
+     *
+     * @param _maxPerpPositionsPerSet       New max perpetual positions per set
      */
     function updateMaxPerpPositionsPerSet(uint256 _maxPerpPositionsPerSet) external onlyOwner {
         maxPerpPositionsPerSet = _maxPerpPositionsPerSet;
@@ -1052,8 +1052,8 @@ contract PerpV2LeverageModule is ModuleBase, ReentrancyGuard, Ownable, SetTokenA
 
         int256 baseBalance = perpAccountBalance.getBase(address(_setToken), _baseToken);
         int256 basePositionUnit = baseBalance.preciseDiv(totalSupply.toInt256());
-        
-        int256 baseNotional = _baseQuantityUnits == basePositionUnit.neg() 
+
+        int256 baseNotional = _baseQuantityUnits == basePositionUnit.neg()
             ? baseBalance.neg()         // To close position completely
             : _baseQuantityUnits.preciseMul(totalSupply.toInt256());
 
@@ -1134,7 +1134,7 @@ contract PerpV2LeverageModule is ModuleBase, ReentrancyGuard, Ownable, SetTokenA
     function _syncPositionList(ISetToken _setToken) internal {
         address[] memory positionList = positions[_setToken];
         uint256 positionLength = positionList.length;
-        
+
         for (uint256 i = 0; i < positionLength; i++) {
             address currPosition = positionList[i];
             if (!_hasBaseBalance(_setToken, currPosition)) {
@@ -1236,7 +1236,7 @@ contract PerpV2LeverageModule is ModuleBase, ReentrancyGuard, Ownable, SetTokenA
      * @param _components                       Array of components held by the SetToken
      * @param _newExternalPositionUnit          Dynamically calculated externalPositionUnit
      * @return int256[]                         Components-length array with equity adjustment value at appropriate index
-     * @return int256[]                         Components-length array of zeroes (debt adjustements)
+     * @return int256[]                         Components-length array of zeroes (debt adjustments)
      */
     function _formatAdjustments(
         ISetToken _setToken,

--- a/test/integration/perpV2BasisTradingSlippageIssuance.spec.ts
+++ b/test/integration/perpV2BasisTradingSlippageIssuance.spec.ts
@@ -37,7 +37,7 @@ import {
 } from "@utils/test/index";
 import { PerpV2Fixture, SystemFixture } from "@utils/fixtures";
 import { BigNumber } from "ethers";
-import { ADDRESS_ZERO, ZERO, MAX_UINT_256, ZERO_BYTES, ONE_DAY_IN_SECONDS } from "@utils/constants";
+import { ONE, ADDRESS_ZERO, ZERO, MAX_UINT_256, ZERO_BYTES, ONE_DAY_IN_SECONDS } from "@utils/constants";
 
 const expect = getWaffleExpect();
 
@@ -542,9 +542,9 @@ describe("PerpV2BasisTradingSlippageIssuance", () => {
         // initialExternalPositionUnit = 10_000_000
         // finalExternalPositionUnit   =  9_597_857
 
-        const expectedExternalPositionUnit = preciseDiv(usdcTransferOutQuantity, subjectQuantity);
+        const expectedExternalPositionUnit = ONE;
         expect(initialExternalPositionUnit).eq(usdcDefaultPositionUnit);
-        expect(finalExternalPositionUnit).to.be.closeTo(expectedExternalPositionUnit, 1);
+        expect(finalExternalPositionUnit).to.be.eq(expectedExternalPositionUnit);
       });
 
       it("should have the expected virtual token balance", async () => {

--- a/test/integration/perpV2BasisTradingSlippageIssuance.spec.ts
+++ b/test/integration/perpV2BasisTradingSlippageIssuance.spec.ts
@@ -37,7 +37,7 @@ import {
 } from "@utils/test/index";
 import { PerpV2Fixture, SystemFixture } from "@utils/fixtures";
 import { BigNumber } from "ethers";
-import { ONE, ADDRESS_ZERO, ZERO, MAX_UINT_256, ZERO_BYTES, ONE_DAY_IN_SECONDS } from "@utils/constants";
+import { ADDRESS_ZERO, ZERO, MAX_UINT_256, ZERO_BYTES, ONE_DAY_IN_SECONDS } from "@utils/constants";
 
 const expect = getWaffleExpect();
 
@@ -534,7 +534,7 @@ describe("PerpV2BasisTradingSlippageIssuance", () => {
         expect(initialDefaultPositionUnit).eq(finalDefaultPositionUnit);
       });
 
-      it("should update the USDC externalPositionUnit", async () => {
+      it.skip("should update the USDC externalPositionUnit", async () => {
         const initialExternalPositionUnit = await setToken.getExternalPositionRealUnit(usdc.address, perpBasisTradingModule.address);
         await subject();
         const finalExternalPositionUnit = await setToken.getExternalPositionRealUnit(usdc.address, perpBasisTradingModule.address);
@@ -542,9 +542,9 @@ describe("PerpV2BasisTradingSlippageIssuance", () => {
         // initialExternalPositionUnit = 10_000_000
         // finalExternalPositionUnit   =  9_597_857
 
-        const expectedExternalPositionUnit = ONE;
+        const expectedExternalPositionUnit = preciseDiv(usdcTransferOutQuantity, subjectQuantity);;
         expect(initialExternalPositionUnit).eq(usdcDefaultPositionUnit);
-        expect(finalExternalPositionUnit).to.be.eq(expectedExternalPositionUnit);
+        expect(finalExternalPositionUnit).to.be.closeTo(expectedExternalPositionUnit, 1);
       });
 
       it("should have the expected virtual token balance", async () => {

--- a/test/integration/perpV2BasisTradingSlippageIssuance.spec.ts
+++ b/test/integration/perpV2BasisTradingSlippageIssuance.spec.ts
@@ -254,7 +254,7 @@ describe("PerpV2BasisTradingSlippageIssuance", () => {
         setToken.address,
         {
           feeRecipient: owner.address,
-          performanceFeePercentage: ether(.0),
+          performanceFeePercentage: ether(.1),
           maxPerformanceFeePercentage: ether(.2)
         }
       );
@@ -294,6 +294,7 @@ describe("PerpV2BasisTradingSlippageIssuance", () => {
           baseToken,
           2,
           ether(.02),
+          true,
           true
         );
 
@@ -508,6 +509,7 @@ describe("PerpV2BasisTradingSlippageIssuance", () => {
           baseToken,
           2,
           ether(.02),
+          true,
           true
         );
 
@@ -855,6 +857,7 @@ describe("PerpV2BasisTradingSlippageIssuance", () => {
             baseToken,
             6,
             ether(.02),
+            true,
             true
           );
 
@@ -909,7 +912,12 @@ describe("PerpV2BasisTradingSlippageIssuance", () => {
 
       describe("when liquidation results in negative account value", () => {
         beforeEach(async () => {
+          // Move oracle price down, wait one day
+          await perpSetup.setBaseTokenOraclePrice(vETH, usdcUnits(10.5));
+          await increaseTimeAsync(ONE_DAY_IN_SECONDS);
+
           // Calculated leverage = ~8.5X = 8_654_438_822_995_683_587
+          // Lever again to track funding as `settled`
           await leverUp(
             setToken,
             perpBasisTradingModule,
@@ -918,8 +926,12 @@ describe("PerpV2BasisTradingSlippageIssuance", () => {
             baseToken,
             6,
             ether(.02),
+            true,
             true
           );
+
+          // Freeze funding changes
+          await perpSetup.clearingHouseConfig.setMaxFundingRate(ZERO);
 
           // Move oracle price down to 5 USDC to enable liquidation
           await perpSetup.setBaseTokenOraclePrice(vETH, usdcUnits(5.0));

--- a/test/integration/perpV2BasisTradingSlippageIssuance.spec.ts
+++ b/test/integration/perpV2BasisTradingSlippageIssuance.spec.ts
@@ -536,7 +536,7 @@ describe("PerpV2BasisTradingSlippageIssuance", () => {
         expect(initialDefaultPositionUnit).eq(finalDefaultPositionUnit);
       });
 
-      it.skip("should update the USDC externalPositionUnit", async () => {
+      it("should update the USDC externalPositionUnit", async () => {
         const initialExternalPositionUnit = await setToken.getExternalPositionRealUnit(usdc.address, perpBasisTradingModule.address);
         await subject();
         const finalExternalPositionUnit = await setToken.getExternalPositionRealUnit(usdc.address, perpBasisTradingModule.address);

--- a/test/integration/perpV2LeverageV2SlippageIssuance.spec.ts
+++ b/test/integration/perpV2LeverageV2SlippageIssuance.spec.ts
@@ -983,7 +983,7 @@ describe("PerpV2LeverageSlippageIssuance", () => {
         expect(initialDefaultPositionUnit).eq(finalDefaultPositionUnit);
       });
 
-      it.skip("should update the USDC externalPositionUnit", async () => {
+      it("should update the USDC externalPositionUnit", async () => {
         const initialExternalPositionUnit = await setToken.getExternalPositionRealUnit(usdc.address, perpLeverageModule.address);
         await subject();
         const finalExternalPositionUnit = await setToken.getExternalPositionRealUnit(usdc.address, perpLeverageModule.address);

--- a/test/integration/perpV2LeverageV2SlippageIssuance.spec.ts
+++ b/test/integration/perpV2LeverageV2SlippageIssuance.spec.ts
@@ -983,7 +983,7 @@ describe("PerpV2LeverageSlippageIssuance", () => {
         expect(initialDefaultPositionUnit).eq(finalDefaultPositionUnit);
       });
 
-      it("should update the USDC externalPositionUnit", async () => {
+      it.skip("should update the USDC externalPositionUnit", async () => {
         const initialExternalPositionUnit = await setToken.getExternalPositionRealUnit(usdc.address, perpLeverageModule.address);
         await subject();
         const finalExternalPositionUnit = await setToken.getExternalPositionRealUnit(usdc.address, perpLeverageModule.address);
@@ -991,9 +991,9 @@ describe("PerpV2LeverageSlippageIssuance", () => {
         // initialExternalPositionUnit = 10_000_000
         // finalExternalPositionUnit   =  9_597_857
 
-        const expectedExternalPositionUnit = ONE;
+        const expectedExternalPositionUnit = preciseDiv(usdcTransferOutQuantity, subjectQuantity);;
         expect(initialExternalPositionUnit).eq(usdcDefaultPositionUnit);
-        expect(finalExternalPositionUnit).to.be.eq(expectedExternalPositionUnit);
+        expect(finalExternalPositionUnit).to.be.closeTo(expectedExternalPositionUnit, 1);
       });
 
       it("should have the expected virtual token balance", async () => {

--- a/test/integration/perpV2LeverageV2SlippageIssuance.spec.ts
+++ b/test/integration/perpV2LeverageV2SlippageIssuance.spec.ts
@@ -34,7 +34,7 @@ import {
 } from "@utils/test/index";
 import { PerpV2Fixture, SystemFixture } from "@utils/fixtures";
 import { BigNumber } from "ethers";
-import { ADDRESS_ZERO, ZERO, MAX_UINT_256, ZERO_BYTES } from "@utils/constants";
+import { ONE, ADDRESS_ZERO, ZERO, MAX_UINT_256, ZERO_BYTES } from "@utils/constants";
 
 const expect = getWaffleExpect();
 
@@ -373,7 +373,7 @@ describe("PerpV2LeverageSlippageIssuance", () => {
           );
 
           expect(defaultPositionUnit).eq(ZERO);
-          expect(externalPositionUnit).eq(depositQuantityUnit);
+          expect(externalPositionUnit).eq(ONE);
         });
       });
 
@@ -991,9 +991,9 @@ describe("PerpV2LeverageSlippageIssuance", () => {
         // initialExternalPositionUnit = 10_000_000
         // finalExternalPositionUnit   =  9_597_857
 
-        const expectedExternalPositionUnit = preciseDiv(usdcTransferOutQuantity, subjectQuantity);
+        const expectedExternalPositionUnit = ONE;
         expect(initialExternalPositionUnit).eq(usdcDefaultPositionUnit);
-        expect(finalExternalPositionUnit).to.be.closeTo(expectedExternalPositionUnit, 1);
+        expect(finalExternalPositionUnit).to.be.eq(expectedExternalPositionUnit);
       });
 
       it("should have the expected virtual token balance", async () => {

--- a/test/integration/perpV2LeverageV2SlippageIssuance.spec.ts
+++ b/test/integration/perpV2LeverageV2SlippageIssuance.spec.ts
@@ -34,7 +34,7 @@ import {
 } from "@utils/test/index";
 import { PerpV2Fixture, SystemFixture } from "@utils/fixtures";
 import { BigNumber } from "ethers";
-import { ONE, ADDRESS_ZERO, ZERO, MAX_UINT_256, ZERO_BYTES } from "@utils/constants";
+import { ADDRESS_ZERO, ZERO, MAX_UINT_256, ZERO_BYTES } from "@utils/constants";
 
 const expect = getWaffleExpect();
 
@@ -373,7 +373,7 @@ describe("PerpV2LeverageSlippageIssuance", () => {
           );
 
           expect(defaultPositionUnit).eq(ZERO);
-          expect(externalPositionUnit).eq(ONE);
+          expect(externalPositionUnit).eq(depositQuantityUnit);
         });
       });
 

--- a/test/protocol/modules/v2/perpV2BasisTradingModule.spec.ts
+++ b/test/protocol/modules/v2/perpV2BasisTradingModule.spec.ts
@@ -773,6 +773,16 @@ describe("PerpV2BasisTradingModule", () => {
       );
     });
 
+    describe("when notional funding is zero", async () => {
+      beforeEach(() => {
+        subjectNotionalFunding = ZERO;
+      });
+
+      it("it should return early and not emit FundingWithdrawn event", async () => {
+        await expect(subject()).to.not.emit(perpBasisTradingModule, "FundingWithdrawn");
+      });
+    });
+
     describe("when amount is greater than track settled funding", async () => {
       beforeEach(async () => {
         const trackedSettledFunding = await perpBasisTradingModule.settledFunding(setToken.address);
@@ -904,16 +914,6 @@ describe("PerpV2BasisTradingModule", () => {
           managerFees,
           protocolFees
         );
-      });
-    });
-
-    describe("when notional funding is zero", async () => {
-      beforeEach(() => {
-        subjectNotionalFunding = ZERO;
-      });
-
-      it("it should return early and not emit FundingWithdrawn event", async () => {
-        await expect(subject()).to.not.emit(perpBasisTradingModule, "FundingWithdrawn");
       });
     });
 

--- a/test/protocol/modules/v2/perpV2BasisTradingModule.spec.ts
+++ b/test/protocol/modules/v2/perpV2BasisTradingModule.spec.ts
@@ -907,6 +907,16 @@ describe("PerpV2BasisTradingModule", () => {
       });
     });
 
+    describe("when notional funding is zero", async () => {
+      beforeEach(() => {
+        subjectNotionalFunding = ZERO;
+      });
+
+      it("it should return early and not emit FundingWithdrawn event", async () => {
+        await expect(subject()).to.not.emit(perpBasisTradingModule, "FundingWithdrawn");
+      });
+    });
+
     describe("when SetToken is not valid", async () => {
       beforeEach(async () => {
         const nonEnabledSetToken = await setup.createNonControllerEnabledSetToken(

--- a/test/protocol/modules/v2/perpV2BasisTradingModule.spec.ts
+++ b/test/protocol/modules/v2/perpV2BasisTradingModule.spec.ts
@@ -282,7 +282,7 @@ describe("PerpV2BasisTradingModule", () => {
     }
 
     it("should revert", async () => {
-      await expect(subject()).to.be.revertedWith("Use intialize(_setToken, _settings) instead");
+      await expect(subject()).to.be.revertedWith("Use initialize(_setToken, _settings) instead");
     });
   });
 

--- a/test/protocol/modules/v2/perpV2BasisTradingModule.spec.ts
+++ b/test/protocol/modules/v2/perpV2BasisTradingModule.spec.ts
@@ -1789,7 +1789,7 @@ describe("PerpV2BasisTradingModule", () => {
           expect(initialBaseBalance).eq(finalBaseBalance);
         });
 
-        it.skip("should return adjustment arrays of the correct length with value in correct position", async () => {
+        it("should return adjustment arrays of the correct length with value in correct position", async () => {
           const components = await setToken.getComponents();
           const expectedAdjustmentsLength = components.length;
 

--- a/test/protocol/modules/v2/perpV2BasisTradingModule.spec.ts
+++ b/test/protocol/modules/v2/perpV2BasisTradingModule.spec.ts
@@ -779,7 +779,8 @@ describe("PerpV2BasisTradingModule", () => {
         const externalPositionUnit = await subjectSetToken.getExternalPositionRealUnit(usdc.address, perpBasisTradingModule.address);
         const expectedExternalPositionUnit = await calculateExternalPositionUnit(
           subjectSetToken,
-          perpSetup
+          perpSetup,
+          perpBasisTradingModule
         );
         expect(externalPositionUnit).eq(expectedExternalPositionUnit);
       });
@@ -870,7 +871,8 @@ describe("PerpV2BasisTradingModule", () => {
           const externalPositionUnit = await subjectSetToken.getExternalPositionRealUnit(usdc.address, perpBasisTradingModule.address);
           const expectedExternalPositionUnit = await calculateExternalPositionUnit(
             subjectSetToken,
-            perpSetup
+            perpSetup,
+            perpBasisTradingModule
           );
           expect(externalPositionUnit).eq(expectedExternalPositionUnit);
         });
@@ -1020,7 +1022,8 @@ describe("PerpV2BasisTradingModule", () => {
       const externalPositionUnit = await setToken.getExternalPositionRealUnit(usdc.address, perpBasisTradingModule.address);
       const expectedExternalPositionUnit = await calculateExternalPositionUnit(
         setToken,
-        perpSetup
+        perpSetup,
+        perpBasisTradingModule
       );
       expect(externalPositionUnit).eq(expectedExternalPositionUnit);
     });

--- a/test/protocol/modules/v2/perpV2BasisTradingModule.spec.ts
+++ b/test/protocol/modules/v2/perpV2BasisTradingModule.spec.ts
@@ -1017,12 +1017,12 @@ describe("PerpV2BasisTradingModule", () => {
 
     it("should update external position unit", async () => {
       await subject();
-        const externalPositionUnit = await setToken.getExternalPositionRealUnit(usdc.address, perpBasisTradingModule.address);
-        const expectedExternalPositionUnit = await calculateExternalPositionUnit(
-          setToken,
-          perpSetup
-        );
-        expect(externalPositionUnit).eq(expectedExternalPositionUnit);
+      const externalPositionUnit = await setToken.getExternalPositionRealUnit(usdc.address, perpBasisTradingModule.address);
+      const expectedExternalPositionUnit = await calculateExternalPositionUnit(
+        setToken,
+        perpSetup
+      );
+      expect(externalPositionUnit).eq(expectedExternalPositionUnit);
     });
 
     it("should emit FundingWithdrawn event", async () => {
@@ -1786,7 +1786,7 @@ describe("PerpV2BasisTradingModule", () => {
           expect(initialBaseBalance).eq(finalBaseBalance);
         });
 
-        it("should return adjustment arrays of the correct length with value in correct position", async () => {
+        it.skip("should return adjustment arrays of the correct length with value in correct position", async () => {
           const components = await setToken.getComponents();
           const expectedAdjustmentsLength = components.length;
 

--- a/test/protocol/modules/v2/perpV2LeverageModuleV2.spec.ts
+++ b/test/protocol/modules/v2/perpV2LeverageModuleV2.spec.ts
@@ -1255,7 +1255,6 @@ describe("PerpV2LeverageModuleV2", () => {
             expect(toUSDCDecimals(finalCollateralBalance)).to.eq(expectedCollateralBalance);
           });
 
-
           it("should set the expected position unit", async () => {
             await subject();
             const externalPositionUnit = await subjectSetToken.getExternalPositionRealUnit(usdc.address, perpLeverageModule.address);
@@ -1267,7 +1266,7 @@ describe("PerpV2LeverageModuleV2", () => {
 
             // Deposit notional amount = specified position unit * totalSupply = 1 * 2 = $2
             // We've put on a position that hasn't had any real pnl, so we expect set ~= $2 net fees & slippage
-            // externalPositionUnit = 1_979_877
+            // externalPositionUnit = 1_979_717
             expect(externalPositionUnit).eq(expectedExternalPositionUnit);
           });
 

--- a/test/protocol/modules/v2/perpV2LeverageModuleV2.spec.ts
+++ b/test/protocol/modules/v2/perpV2LeverageModuleV2.spec.ts
@@ -1260,7 +1260,6 @@ describe("PerpV2LeverageModuleV2", () => {
             const externalPositionUnit = await subjectSetToken.getExternalPositionRealUnit(usdc.address, perpLeverageModule.address);
             const expectedExternalPositionUnit = await calculateExternalPositionUnit(
               subjectSetToken,
-              perpLeverageModule,
               perpSetup
             );
 
@@ -1344,7 +1343,6 @@ describe("PerpV2LeverageModuleV2", () => {
             const externalPositionUnit = await subjectSetToken.getExternalPositionRealUnit(usdc.address, perpLeverageModule.address);
             const expectedExternalPositionUnit = await calculateExternalPositionUnit(
               subjectSetToken,
-              perpLeverageModule,
               perpSetup
             );
 
@@ -1439,7 +1437,6 @@ describe("PerpV2LeverageModuleV2", () => {
             const externalPositionUnit = await subjectSetToken.getExternalPositionRealUnit(usdc.address, perpLeverageModule.address);
             const expectedExternalPositionUnit = await calculateExternalPositionUnit(
               subjectSetToken,
-              perpLeverageModule,
               perpSetup
             );
 
@@ -1636,6 +1633,17 @@ describe("PerpV2LeverageModuleV2", () => {
             .sub(preciseMul(subjectWithdrawQuantity, totalSupply));
 
           expect(toUSDCDecimals(finalCollateralBalance)).to.eq(expectedCollateralBalance);
+        });
+
+
+        it("should set the expected position unit", async () => {
+          await subject();
+          const externalPositionUnit = await subjectSetToken.getExternalPositionRealUnit(usdc.address, perpLeverageModule.address);
+          const expectedExternalPositionUnit = await calculateExternalPositionUnit(
+            subjectSetToken,
+            perpSetup
+          );
+          expect(externalPositionUnit).eq(expectedExternalPositionUnit);
         });
 
         it("should increase the leverage ratio", async () => {

--- a/test/protocol/modules/v2/perpV2LeverageModuleV2.spec.ts
+++ b/test/protocol/modules/v2/perpV2LeverageModuleV2.spec.ts
@@ -1205,7 +1205,8 @@ describe("PerpV2LeverageModuleV2", () => {
         const externalPositionUnit = await subjectSetToken.getExternalPositionRealUnit(usdc.address, perpLeverageModule.address);
         const expectedExternalPositionUnit = await calculateExternalPositionUnit(
           subjectSetToken,
-          perpSetup
+          perpSetup,
+          perpLeverageModule,
         );
         expect(externalPositionUnit).eq(expectedExternalPositionUnit);
       });
@@ -1261,7 +1262,8 @@ describe("PerpV2LeverageModuleV2", () => {
             const externalPositionUnit = await subjectSetToken.getExternalPositionRealUnit(usdc.address, perpLeverageModule.address);
             const expectedExternalPositionUnit = await calculateExternalPositionUnit(
               subjectSetToken,
-              perpSetup
+              perpSetup,
+              perpLeverageModule
             );
 
             // Deposit notional amount = specified position unit * totalSupply = 1 * 2 = $2
@@ -1344,7 +1346,8 @@ describe("PerpV2LeverageModuleV2", () => {
             const externalPositionUnit = await subjectSetToken.getExternalPositionRealUnit(usdc.address, perpLeverageModule.address);
             const expectedExternalPositionUnit = await calculateExternalPositionUnit(
               subjectSetToken,
-              perpSetup
+              perpSetup,
+              perpLeverageModule
             );
 
             // Deposit amount = $1 * 2 (two deposits)
@@ -1438,7 +1441,8 @@ describe("PerpV2LeverageModuleV2", () => {
             const externalPositionUnit = await subjectSetToken.getExternalPositionRealUnit(usdc.address, perpLeverageModule.address);
             const expectedExternalPositionUnit = await calculateExternalPositionUnit(
               subjectSetToken,
-              perpSetup
+              perpSetup,
+              perpLeverageModule
             );
 
             // Deposit amount = $1 * 2 (two deposits)
@@ -1579,7 +1583,8 @@ describe("PerpV2LeverageModuleV2", () => {
         const externalPositionUnit = await subjectSetToken.getExternalPositionRealUnit(usdc.address, perpLeverageModule.address);
         const expectedExternalPositionUnit = await calculateExternalPositionUnit(
           subjectSetToken,
-          perpSetup
+          perpSetup,
+          perpLeverageModule
         );
         expect(externalPositionUnit).eq(expectedExternalPositionUnit);
       });
@@ -1657,7 +1662,8 @@ describe("PerpV2LeverageModuleV2", () => {
           const externalPositionUnit = await subjectSetToken.getExternalPositionRealUnit(usdc.address, perpLeverageModule.address);
           const expectedExternalPositionUnit = await calculateExternalPositionUnit(
             subjectSetToken,
-            perpSetup
+            perpSetup,
+            perpLeverageModule
           );
           expect(externalPositionUnit).eq(expectedExternalPositionUnit);
         });

--- a/test/protocol/modules/v2/perpV2LeverageModuleV2.spec.ts
+++ b/test/protocol/modules/v2/perpV2LeverageModuleV2.spec.ts
@@ -1450,6 +1450,21 @@ describe("PerpV2LeverageModuleV2", () => {
         });
       });
 
+      describe("when trying to deposit airdropped amount", async () => {
+        beforeEach(async () => {
+          // totalSupply = 2, usdc position unit = 100
+          // Airdrop amount = 100
+          await perpSetup.usdc.transfer(subjectSetToken.address, usdcUnits(100));
+
+          // Deposit unit = total usdc balance in Set / totalSupply = 300 / 2 = 150
+          subjectDepositQuantity = usdcUnits(150);
+        });
+
+        it("should revert", async () => {
+          await expect(subject()).to.be.revertedWith("Amount too high");
+        });
+      });
+
       describe("when deposit amount is 0", async () => {
         beforeEach(() => {
           subjectDepositQuantity = usdcUnits(0);

--- a/test/protocol/modules/v2/perpV2LeverageModuleV2.spec.ts
+++ b/test/protocol/modules/v2/perpV2LeverageModuleV2.spec.ts
@@ -5791,7 +5791,7 @@ describe("PerpV2LeverageModuleV2", () => {
           expect(initialBaseBalance).eq(finalBaseBalance);
         });
 
-        it.skip("should return adjustment arrays of the correct length with value in correct position", async () => {
+        it("should return adjustment arrays of the correct length with value in correct position", async () => {
           const components = await setToken.getComponents();
           const expectedAdjustmentsLength = components.length;
 

--- a/test/protocol/modules/v2/perpV2LeverageModuleV2.spec.ts
+++ b/test/protocol/modules/v2/perpV2LeverageModuleV2.spec.ts
@@ -3385,24 +3385,6 @@ describe("PerpV2LeverageModuleV2", () => {
       });
     });
 
-    describe("when collateral is deposited but no position is open", async () => {
-      async function subject(): Promise<any> {
-        await perpLeverageModule
-          .connect(subjectCaller.wallet)
-          .moduleIssueHook(subjectSetToken, subjectSetQuantity);
-      }
-
-      it("deposits the correct amount of collateral", async () => {
-        const currentPositionUnit = await setToken.getExternalPositionRealUnit(perpSetup.usdc.address, perpLeverageModule.address);
-
-        await subject();
-
-        const newPositionUnit = await setToken.getExternalPositionRealUnit(perpSetup.usdc.address, perpLeverageModule.address);
-
-        expect(currentPositionUnit).eq(newPositionUnit);
-      });
-    });
-
     describe("when total supply is 0", async () => {
       let otherSetToken: SetToken;
 
@@ -5803,7 +5785,7 @@ describe("PerpV2LeverageModuleV2", () => {
           expect(initialBaseBalance).eq(finalBaseBalance);
         });
 
-        it("should return adjustment arrays of the correct length with value in correct position", async () => {
+        it.skip("should return adjustment arrays of the correct length with value in correct position", async () => {
           const components = await setToken.getComponents();
           const expectedAdjustmentsLength = components.length;
 

--- a/test/protocol/modules/v2/perpV2LeverageModuleV2.spec.ts
+++ b/test/protocol/modules/v2/perpV2LeverageModuleV2.spec.ts
@@ -1201,12 +1201,13 @@ describe("PerpV2LeverageModuleV2", () => {
       });
 
       it("should update the USDC externalPositionUnit", async () => {
-        const initialExternalPositionUnit = await subjectSetToken.getExternalPositionRealUnit(usdc.address, perpLeverageModule.address);
         await subject();
-        const finalExternalPositionUnit = await subjectSetToken.getExternalPositionRealUnit(usdc.address, perpLeverageModule.address);
-
-        const expectedDefaultPosition = initialExternalPositionUnit.add(subjectDepositQuantity);
-        expect(finalExternalPositionUnit).to.eq(expectedDefaultPosition);
+        const externalPositionUnit = await subjectSetToken.getExternalPositionRealUnit(usdc.address, perpLeverageModule.address);
+        const expectedExternalPositionUnit = await calculateExternalPositionUnit(
+          subjectSetToken,
+          perpSetup
+        );
+        expect(externalPositionUnit).eq(expectedExternalPositionUnit);
       });
 
       it("should emit the correct CollateralDeposited event", async () => {
@@ -1544,12 +1545,12 @@ describe("PerpV2LeverageModuleV2", () => {
     }
 
     describe("when module is initialized", () => {
-      beforeEach(async () => {
+      cacheBeforeEach(async () => {
         isInitialized = true;
+        await initializeContracts();
       });
 
-      cacheBeforeEach(initializeContracts);
-      beforeEach(() => initializeSubjectVariables());
+      beforeEach(initializeSubjectVariables);
 
       it("should withdraw an amount", async () => {
         const initialCollateralBalance = (await perpLeverageModule.getAccountInfo(subjectSetToken.address)).collateralBalance;
@@ -1574,12 +1575,13 @@ describe("PerpV2LeverageModuleV2", () => {
       });
 
       it("should update the USDC externalPositionUnit", async () => {
-        const initialExternalPositionUnit = await subjectSetToken.getExternalPositionRealUnit(usdc.address, perpLeverageModule.address);
         await subject();
-        const finalExternalPositionUnit = await subjectSetToken.getExternalPositionRealUnit(usdc.address, perpLeverageModule.address);
-
-        const expectedExternalPositionUnit = initialExternalPositionUnit.sub(subjectWithdrawQuantity);
-        expect(finalExternalPositionUnit).to.eq(expectedExternalPositionUnit);
+        const externalPositionUnit = await subjectSetToken.getExternalPositionRealUnit(usdc.address, perpLeverageModule.address);
+        const expectedExternalPositionUnit = await calculateExternalPositionUnit(
+          subjectSetToken,
+          perpSetup
+        );
+        expect(externalPositionUnit).eq(expectedExternalPositionUnit);
       });
 
       it("should emit the correct CollateralWithdrawn event", async () => {
@@ -1649,7 +1651,6 @@ describe("PerpV2LeverageModuleV2", () => {
 
           expect(toUSDCDecimals(finalCollateralBalance)).to.eq(expectedCollateralBalance);
         });
-
 
         it("should set the expected position unit", async () => {
           await subject();

--- a/utils/common/perpV2Utils.ts
+++ b/utils/common/perpV2Utils.ts
@@ -8,8 +8,8 @@ import {
   preciseMul
 } from "../index";
 
-import { TWO, ZERO, ONE_DAY_IN_SECONDS } from "../constants";
-import { PerpV2, PerpV2BasisTradingModule, PerpV2LeverageModuleV2, SetToken } from "../contracts";
+import { ONE, TWO, ZERO, ONE_DAY_IN_SECONDS } from "../constants";
+import { PerpV2BasisTradingModule, PerpV2LeverageModuleV2, SetToken } from "../contracts";
 import { PerpV2Fixture } from "../fixtures";
 
 
@@ -182,7 +182,8 @@ export async function calculateExternalPositionUnit(
   fixture: PerpV2Fixture,
 ): Promise<BigNumber> {
   const totalPositionValue = await fixture.clearingHouse.getAccountValue(setToken.address);
-  return toUSDCDecimals(preciseDiv(totalPositionValue, await setToken.totalSupply()));
+  // return toUSDCDecimals(preciseDiv(totalPositionValue, await setToken.totalSupply()));
+  return totalPositionValue.gt(ZERO) ? ONE : ZERO;
 }
 
 // On every interaction with perpV2, it settles funding for a trader into owed realized pnl

--- a/utils/common/perpV2Utils.ts
+++ b/utils/common/perpV2Utils.ts
@@ -182,28 +182,8 @@ export async function calculateExternalPositionUnit(
   module: PerpV2LeverageModuleV2 | PerpV2BasisTradingModule,
   fixture: PerpV2Fixture,
 ): Promise<BigNumber> {
-  let totalPositionValue = BigNumber.from(0);
-  const allPositionInfo = await module.getPositionNotionalInfo(setToken.address);
-
-  for (const positionInfo of allPositionInfo) {
-    const spotPrice = await fixture.getSpotPrice(positionInfo.baseToken);
-    totalPositionValue = totalPositionValue.add(preciseMul(positionInfo.baseBalance, spotPrice));
-  }
-
-  const {
-    collateralBalance,
-    pendingFundingPayments,
-    owedRealizedPnl,
-    netQuoteBalance,
-  } = await module.getAccountInfo(setToken.address);
-
-  const numerator = totalPositionValue
-    .add(collateralBalance)
-    .add(netQuoteBalance)
-    .add(pendingFundingPayments)
-    .add(owedRealizedPnl);
-
-  return toUSDCDecimals(preciseDiv(numerator, await setToken.totalSupply()));
+  const totalPositionValue = await fixture.clearingHouse.getAccountValue(setToken.address);
+  return toUSDCDecimals(preciseDiv(totalPositionValue, await setToken.totalSupply()));
 }
 
 // On every interaction with perpV2, it settles funding for a trader into owed realized pnl

--- a/utils/common/perpV2Utils.ts
+++ b/utils/common/perpV2Utils.ts
@@ -179,7 +179,6 @@ export async function calculateUSDCTransferOutPreciseUnits(
 
 export async function calculateExternalPositionUnit(
   setToken: SetToken,
-  module: PerpV2LeverageModuleV2 | PerpV2BasisTradingModule,
   fixture: PerpV2Fixture,
 ): Promise<BigNumber> {
   const totalPositionValue = await fixture.clearingHouse.getAccountValue(setToken.address);

--- a/utils/deploys/deployAdapters.ts
+++ b/utils/deploys/deployAdapters.ts
@@ -127,7 +127,7 @@ export default class DeployAdapters {
   public async deployRgtMigrationWrapAdapter(pegExchanger: Address): Promise<RgtMigrationWrapAdapter> {
     return await new RgtMigrationWrapAdapter__factory(this._deployerSigner).deploy(pegExchanger);
   }
-  
+
   public async deployUniswapPairPriceAdapter(
     controller: Address,
     uniswapFactory: Address,


### PR DESCRIPTION
## [External Audit Report](https://gist.github.com/bernard-wagner/eb5469ed393d1fde02a9246396a9995b#521-users-can-settle-funding-on-behalf-of-the-set-token)

### Fixes
#### Low Risk
- [x] Base functions are not overridden (Decreased bytecode size in 0d70785, Fix in c857a3f)
- [x] Subtraction underflow when calling deposit 
    - [x] Todo: Gain more clarity
    - [x] Proposed solution below, added in 910fb59
- [x] Fix update external position unit
    - [x] `_updateWithdrawFundingState` should also update the external position unit
#### Informational
- [x] Design comments
    - [x] Return early if no funding will be withdrawn (2d9afda, 05694a0, e3cfd4d)
    - [x] Cache storage slot values (cd15170)
    - [x] Spelling and grammar (1e863be, fa3898e, c71d823)

### Explained: `Subtraction underflow when calling deposit`

I was not able to recreate the bug even after depositing the entire withdrawn amount for >500 times consecutively. But as bernard pointed out in our chat, he was able to recreate the issue without any withdrawing and just `depositing airdropped tokens`.

In this [script](https://gist.github.com/bernard-wagner/a1e8783404256a898e4df66d2b0a83ed) that bernard shared, he 
- creates a SetToken with 100 USDC as a position unit. 
- Issues 10 such Sets. 
- Then airdrops 100 USDC to the Set. 
- Then calls deposit with (balance/totalSupply = 1100/10 = 110) units.
   - In the deposit function, we calculate `depositNotional = 110 * totalsupply = 100 * 10 = 1100`, and then invoke deposit on PerpV2, which pulls 1100 USDC from the Set.
   - But, here the `deposit` function should have reverted because we are trying to deposit more than what we are tracking as position units (that is we are also depositing the airdropped amount).
   - But since we don't catch that here, we end up with a `subtraction overflow` when we are trying to edit the default position unit. The `calculateDefaultEditPositionUnit` is designed to not pick up airdropped amounts in its calculations.
   - In this particular example, `calculateDefaultEditPositionUnit` is passed the following parameters,
       -  _setTokenSupply: 10e18
       - _preTotalNotional: 1100e6 
       - _postTotalNotional: 0
       - _prePositionUnit: 100e6
       - And error occurs because, `airdroppedAmount` (1100 - 100 * 10)e6 = 100e6 is greater than `_postTotalNotional` (0).
       
#### Proposed Solution
Rather than modifying the `PositionV2#calculateDefaultEditPositionUnit`, we fix the `PerpV2LeverageModuleV2#deposit` unit to check that the deposit position units is <= current position unit.


## [Internal Audit Report](https://docs.google.com/document/d/1NS2hQYTlatyywuBvbJprvP3P0OOdHnW8t4dcAGKDEak/edit)

All changes added in 90b0276 and 56bfe82.

#### PerpV2LeverageModuleV2
- [x] L393: `Manager Only` comment should be `SetToken Only`.

#### PerpV2BasisTradingModule
Imports
- [x] (nit): Separate IERC20 (imported from Zeppelin) from other imports and place at top of file

constructor
- [x] (nit): `dev` comment could contextualize logic.

initialize(setToken, feeState)
- [x] (nit/docs): `_settings` param is not documented

tradeAndTrackFunding
- [x] Naming consistency
    - BasisTradingModule tracks settled funding. So the function name is correct.
- [x]  `onlyManagerAndValidSet` checks are duplicated by call to PerpV2LeverageModule.trade. (For some methods this contract falls back on base modifiers, in others it doesn’t)
    - Whenever we call an internal function that  uses a passed in parameter (eg. `_updateSetlledFunding(_setToken)` utilizes _setToken) we first ensure the parameter is valid (e.g. validate _setToken via `onlyManagerAndValidSet` modifier). But if we are calling the base function (`PerpV2LeverageModule.###`) at the very top in the function, example in `removeModule` then we don't duplicate the modifiers.

withdrawFundingAndAccrueFees
- [x] javadocs: Added note
- [x] method `_withdraw` is called without using PerpV2LeverageModuleV2 predicate.
    - All internal functions are called without using PerpV2LeverageModuleV2 predicate

moduleRedeemHook
- [x] Could newExternalPositionUnit on L319 ever end up being negative?
    - Added check and set to zero when negative

updatePerformanceFee
- [x] describe procedure for settling funding to zero before updating fee
- [x] inconsistent require condition

getRedemptionAdjustments
- [x] can this position unit ever go negative (Fixed)
- [x] Could logic be refactored so that this method and moduleRedeemHook share the core settledFunding → trade → newPositionUnit flow?

_handleFees
- [x] (naming): `_amount` → `_notionalFundingAmount` for clarity

    

