### PR TITLE
perf: simplify function removeStorage

### DIFF
--- a/contracts/lib/AddressArrayUtils.sol
+++ b/contracts/lib/AddressArrayUtils.sol
@@ -103,12 +103,13 @@ library AddressArrayUtils {
         internal
     {
         (uint256 index, bool isIn) = indexOf(A, a);
-        if (!isIn) {
-            revert("Address not in array.");
-        } else {
-            uint256 lastIndex = A.length - 1; // If the array would be empty, the previous line would throw, so no underflow here
-            if (index != lastIndex) { A[index] = A[lastIndex]; }
+
+        if (isIn) { // address a is in array A, so array A is not emtpy, and A.length >= 1
+            uint256 lastIndex = A.length - 1;
+            A[index] = A[lastIndex]; // for save gas, we not check: index != lastIndex
             A.pop();
+        } else {
+            revert("Address not in array.");
         }
     }
 

--- a/contracts/lib/StringArrayUtils.sol
+++ b/contracts/lib/StringArrayUtils.sol
@@ -50,12 +50,13 @@ library StringArrayUtils {
         internal
     {
         (uint256 index, bool isIn) = indexOf(A, a);
-        if (!isIn) {
-            revert("String not in array.");
-        } else {
-            uint256 lastIndex = A.length - 1; // If the array would be empty, the previous line would throw, so no underflow here
-            if (index != lastIndex) { A[index] = A[lastIndex]; }
+
+        if (isIn) { // string a is in the array A, so array A is not empty, and A.length >= 1
+            uint256 lastIndex = A.length - 1; 
+            A[index] = A[lastIndex]; // to save gas, we not check: index != lastIndex
             A.pop();
+        } else {
+            revert("String not in array.");
         }
     }
 }


### PR DESCRIPTION
Below is current version of function removeStorage:
```solidity
    function removeStorage(string[] storage A, string memory a)
        internal
    {
        (uint256 index, bool isIn) = indexOf(A, a);
        if (!isIn) {
            revert("String not in array.");
        } else {
            uint256 lastIndex = A.length - 1; // If the array would be empty, the previous line would throw, so no underflow here
            if (index != lastIndex) { A[index] = A[lastIndex]; }
            A.pop();
        }
    }
```
When isIn is ture, then value a is in array A, so  A.length > 0, `uint256 lastIndex = A.length - 1;` will not underflow. And if not check `(index != lastIndex)` will save gas in most cases.