### PR TITLE
PriceOracle return constant price when base asset and quote asset are same

### DIFF
--- a/contracts/protocol/PriceOracle.sol
+++ b/contracts/protocol/PriceOracle.sol
@@ -120,6 +120,10 @@ contract PriceOracle is Ownable {
             "PriceOracle.getPrice: Caller must be system contract."
         );
 
+        if (_assetOne == _assetTwo) {
+            return 10**18;
+        }
+        
         bool priceFound;
         uint256 price;
 


### PR DESCRIPTION
In PriceOracle, when base asset equals quote asset, we can return 10**18 directly, no need to run other rules.
```solidity
    function getPrice(address _assetOne, address _assetTwo) external view returns (uint256) {
        require(
            controller.isSystemContract(msg.sender),
            "PriceOracle.getPrice: Caller must be system contract."
        );

        if (_assetOne == _assetTwo) {
            return 10**18;
        }
```