### PR TITLE
fix(PerpV2LeverageModuleV2): Round up during withdraw

### DIFF
--- a/contracts/protocol/modules/v2/PerpV2LeverageModuleV2.sol
+++ b/contracts/protocol/modules/v2/PerpV2LeverageModuleV2.sol
@@ -876,7 +876,12 @@ contract PerpV2LeverageModuleV2 is ModuleBaseV2, ReentrancyGuard, Ownable, SetTo
         returns (uint256)
     {
         uint256 initialCollateralPositionBalance = collateralToken.balanceOf(address(_setToken));
-        uint256 collateralNotionalQuantity = _collateralQuantityUnits.preciseMul(_setToken.totalSupply());
+        // Round up to calculate notional, so that we make atleast `_collateralQuantityUnits` position unit after withdraw.
+        // Example, let totalSupply = 1.005e18, _collateralQuantityUnits = 13159, then
+        // collateralNotionalQuantity = 13159 * 1.005e18 / 1e18 = 13225 (13224.795 rounded up)
+        // We withdraw 13225 from Perp and make a position unit from it. So newPositionUnit = (13225 / 1.005e18) * 1e18
+        // = 13159 (13159.2039801 rounded down)
+        uint256 collateralNotionalQuantity = _collateralQuantityUnits.preciseMulCeil(_setToken.totalSupply());
 
         _withdraw(_setToken, collateralNotionalQuantity);
 

--- a/test/integration/perpV2BasisTradingSlippageIssuance.spec.ts
+++ b/test/integration/perpV2BasisTradingSlippageIssuance.spec.ts
@@ -778,7 +778,7 @@ describe("PerpV2BasisTradingSlippageIssuance", () => {
           expect(finalOwnerUSDCBalance).to.be.closeTo(expectedUSDCBalance, 1);
         });
 
-        it("should remove the module when dust is in the account and be able to add module back", async () => {
+        it("should remove the module and be able to add module back", async () => {
           // Redeem to `1`
           await subject();
 
@@ -811,18 +811,12 @@ describe("PerpV2BasisTradingSlippageIssuance", () => {
             .connect(owner.wallet)
             .withdraw(subjectSetToken, freeCollateralPositionUnit);
 
-          const {
-            collateralBalance: finalCollateralBalance
-          } = await perpBasisTradingModule.getAccountInfo(subjectSetToken);
-
-
           /// Remove module
           await setToken.removeModule(perpBasisTradingModule.address);
           const finalModules = await setToken.getModules();
 
           expect(finalModules.includes(perpBasisTradingModule.address)).eq(false);
           expect(positionInfo.length).eq(0);
-          expect(toUSDCDecimals(finalCollateralBalance)).eq(1); // <-- DUST
 
           // Restore module
           await setToken.connect(owner.wallet).addModule(perpBasisTradingModule.address);

--- a/test/integration/perpV2LeverageV2SlippageIssuance.spec.ts
+++ b/test/integration/perpV2LeverageV2SlippageIssuance.spec.ts
@@ -1129,7 +1129,7 @@ describe("PerpV2LeverageSlippageIssuance", () => {
           expect(finalOwnerUSDCBalance).to.be.closeTo(expectedUSDCBalance, 1);
         });
 
-        it("should remove the module when dust is in the account and be able to add module back", async () => {
+        it("should remove the module and be able to add module back", async () => {
           // Redeem to `1`
           await subject();
 
@@ -1162,18 +1162,12 @@ describe("PerpV2LeverageSlippageIssuance", () => {
             .connect(owner.wallet)
             .withdraw(subjectSetToken, freeCollateralPositionUnit);
 
-          const {
-            collateralBalance: finalCollateralBalance
-          } = await perpLeverageModule.getAccountInfo(subjectSetToken);
-
-
           /// Remove module
           await setToken.removeModule(perpLeverageModule.address);
           const finalModules = await setToken.getModules();
 
           expect(finalModules.includes(perpLeverageModule.address)).eq(false);
           expect(positionInfo.length).eq(0);
-          expect(toUSDCDecimals(finalCollateralBalance)).eq(1); // <-- DUST
 
           // Restore module
           await setToken.connect(owner.wallet).addModule(perpLeverageModule.address);

--- a/test/protocol/modules/v2/perpV2LeverageModuleV2.spec.ts
+++ b/test/protocol/modules/v2/perpV2LeverageModuleV2.spec.ts
@@ -1505,7 +1505,7 @@ describe("PerpV2LeverageModuleV2", () => {
   });
 
   describe("#withdraw", () => {
-    let depositQuantity: BigNumber;
+    const depositQuantity: BigNumber = usdcUnits(10);
     let subjectSetToken: SetToken;
     let subjectWithdrawQuantity: BigNumber;
     let subjectCaller: Account;


### PR DESCRIPTION
In this [transaction](https://optimistic.etherscan.io/tx/0x423c23252f271bfb4b2004abd0d1a88acc9cbaec592c31684c0476aa66aa543f), rebalance fails because, (quoting @bweick from slack)
```
nvm so basically there 1.005 Sets we try to withdraw 13159 per Set which would calculate to 13224.795 
which is rounded down to 13224 so that's the amount we get back from Perp
When we then go to make a position out of it 13224/1.005 = 13158.20 so rounded down to 13158
And then we try to trade 13159
```