### PR TITLE
fix(SlippageIssuanceModule): Fix issuance & redemption flows to not update position units

### DIFF
--- a/contracts/protocol/modules/v1/SlippageIssuanceModule.sol
+++ b/contracts/protocol/modules/v1/SlippageIssuanceModule.sol
@@ -40,9 +40,21 @@ contract SlippageIssuanceModule is DebtIssuanceModule {
 
     constructor(IController _controller) public DebtIssuanceModule(_controller) {}
 
-    // TODO: Override issue and redeem?
-
     /* ============ External Functions ============ */
+
+    /**
+     * @dev Reverts upon calling. Call `issueWithSlippage` instead.
+     */
+    function issue(ISetToken /*_setToken*/, uint256 /*_quantity*/, address /*_to*/) external override(DebtIssuanceModule) {
+        revert("Call issueWithSlippage instead");
+    }
+
+    /**
+     * @dev Reverts upon calling. Call `redeemWithSlippage` instead.
+     */
+    function redeem(ISetToken /*_setToken*/, uint256 /*_quantity*/, address /*_to*/) external override(DebtIssuanceModule) {
+        revert("Call redeemWithSlippage instead");
+    }
 
     /**
      * Deposits components to the SetToken, replicates any external module component positions and mints

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@setprotocol/set-protocol-v2",
-  "version": "0.10.3-basis.0",
+  "version": "0.10.3",
   "description": "",
   "main": "dist",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@setprotocol/set-protocol-v2",
-  "version": "0.10.3",
+  "version": "0.10.3-basis.0",
   "description": "",
   "main": "dist",
   "files": [

--- a/test/integration/perpV2BasisTradingSlippageIssuance.spec.ts
+++ b/test/integration/perpV2BasisTradingSlippageIssuance.spec.ts
@@ -324,12 +324,34 @@ describe("PerpV2BasisTradingSlippageIssuance", () => {
         );
       });
 
-      it("should not update the USDC defaultPositionUnit", async () => {
+      it("should NOT update the USDC defaultPositionUnit", async () => {
         const initialDefaultPositionUnit = await setToken.getDefaultPositionRealUnit(usdc.address);
         await subject();
         const finalDefaultPositionUnit = await setToken.getDefaultPositionRealUnit(usdc.address);
 
         expect(initialDefaultPositionUnit).eq(finalDefaultPositionUnit);
+      });
+
+      it("should NOT update the USDC defaultPositionUnit", async () => {
+        const initialDefaultPositionUnit = await setToken.getDefaultPositionRealUnit(usdc.address);
+        await subject();
+        const finalDefaultPositionUnit = await setToken.getDefaultPositionRealUnit(usdc.address);;
+
+        expect(finalDefaultPositionUnit).to.eq(initialDefaultPositionUnit);
+      });
+
+      it("should NOT update the virtual quote token position unit", async () => {
+        const totalSupply = await setToken.totalSupply();
+        const initialBaseBalance = (await perpBasisTradingModule.getPositionNotionalInfo(subjectSetToken))[0].baseBalance;
+        const initialBasePositionUnit = preciseDiv(initialBaseBalance, totalSupply);
+
+        await subject();
+
+        const newTotalSupply = await setToken.totalSupply();
+        const finalBaseBalance = (await perpBasisTradingModule.getPositionNotionalInfo(subjectSetToken))[0].baseBalance;
+        const finalBasePositionUnit = preciseDiv(finalBaseBalance, newTotalSupply);
+
+        expect(initialBasePositionUnit).to.eq(finalBasePositionUnit);
       });
 
       it("should have updated the USDC externalPositionUnit", async () => {
@@ -539,12 +561,34 @@ describe("PerpV2BasisTradingSlippageIssuance", () => {
         );
       });
 
-      it("should not update the USDC defaultPositionUnit", async () => {
+      it("should NOT update the USDC defaultPositionUnit", async () => {
         const initialDefaultPositionUnit = await setToken.getDefaultPositionRealUnit(usdc.address);
         await subject();
         const finalDefaultPositionUnit = await setToken.getDefaultPositionRealUnit(usdc.address);
 
         expect(initialDefaultPositionUnit).eq(finalDefaultPositionUnit);
+      });
+
+      it("should NOT update the USDC defaultPositionUnit", async () => {
+        const initialDefaultPositionUnit = await setToken.getDefaultPositionRealUnit(usdc.address);
+        await subject();
+        const finalDefaultPositionUnit = await setToken.getDefaultPositionRealUnit(usdc.address);;
+
+        expect(finalDefaultPositionUnit).to.eq(initialDefaultPositionUnit);
+      });
+
+      it("should NOT update the virtual quote token position unit", async () => {
+        const totalSupply = await setToken.totalSupply();
+        const initialBaseBalance = (await perpBasisTradingModule.getPositionNotionalInfo(subjectSetToken))[0].baseBalance;
+        const initialBasePositionUnit = preciseDiv(initialBaseBalance, totalSupply);
+
+        await subject();
+
+        const newTotalSupply = await setToken.totalSupply();
+        const finalBaseBalance = (await perpBasisTradingModule.getPositionNotionalInfo(subjectSetToken))[0].baseBalance;
+        const finalBasePositionUnit = preciseDiv(finalBaseBalance, newTotalSupply);
+
+        expect(initialBasePositionUnit).to.eq(finalBasePositionUnit);
       });
 
       it("should update the USDC externalPositionUnit", async () => {

--- a/test/integration/perpV2BasisTradingSlippageIssuance.spec.ts
+++ b/test/integration/perpV2BasisTradingSlippageIssuance.spec.ts
@@ -253,7 +253,7 @@ describe("PerpV2BasisTradingSlippageIssuance", () => {
       await slippageIssuanceModule.initialize(
         setToken.address,
         ether(0.02),
-        ether(0.005),
+        issueFee,
         redeemFee,
         feeRecipient.address,
         ADDRESS_ZERO
@@ -289,7 +289,7 @@ describe("PerpV2BasisTradingSlippageIssuance", () => {
       beforeEach(async () => {
         // Issue 1 SetToken
         issueQuantity = ether(1);
-        await slippageIssuanceModule.issue(setToken.address, issueQuantity, owner.address);
+        await slippageIssuanceModule.issueWithSlippage(setToken.address, issueQuantity, [], [], owner.address);
 
         depositQuantityUnit = usdcUnits(10);
         await perpBasisTradingModule.deposit(setToken.address, depositQuantityUnit);
@@ -525,7 +525,7 @@ describe("PerpV2BasisTradingSlippageIssuance", () => {
       beforeEach(async () => {
         // Issue 2 SetTokens
         issueQuantity = ether(2);
-        await slippageIssuanceModule.issue(setToken.address, issueQuantity, owner.address);
+        await slippageIssuanceModule.issueWithSlippage(setToken.address, issueQuantity, [], [], owner.address);
 
         // Deposit entire default position
         depositQuantityUnit = usdcDefaultPositionUnit;

--- a/test/integration/perpV2BasisTradingSlippageIssuance.spec.ts
+++ b/test/integration/perpV2BasisTradingSlippageIssuance.spec.ts
@@ -37,7 +37,7 @@ import {
 } from "@utils/test/index";
 import { PerpV2Fixture, SystemFixture } from "@utils/fixtures";
 import { BigNumber } from "ethers";
-import { ADDRESS_ZERO, ZERO, MAX_UINT_256, ZERO_BYTES, ONE_DAY_IN_SECONDS } from "@utils/constants";
+import { ADDRESS_ZERO, ZERO, MAX_UINT_256, ZERO_BYTES, ONE_DAY_IN_SECONDS, PRECISE_UNIT } from "@utils/constants";
 
 const expect = getWaffleExpect();
 
@@ -159,17 +159,12 @@ describe("PerpV2BasisTradingSlippageIssuance", () => {
 
   async function calculateRedemptionData(
     setToken: Address,
-    redeemQuantity: BigNumber,
+    redeemQuantityNetFees: BigNumber,
     usdcTransferOutQuantity: BigNumber
   ) {
     // Calculate fee adjusted usdcTransferOut
-    const redeemQuantityWithFees = (await slippageIssuanceModule.calculateTotalFees(
-      setToken,
-      redeemQuantity,
-      false
-    ))[0];
-
-    const feeAdjustedTransferOutUSDC = preciseMul(redeemQuantityWithFees, usdcTransferOutQuantity);
+    const externalPositionUnit = preciseDiv(usdcTransferOutQuantity, redeemQuantityNetFees);
+    const feeAdjustedTransferOutUSDC = preciseMul(redeemQuantityNetFees, externalPositionUnit);
 
     // Calculate realizedPnl. The amount is debited from collateral returned to redeemer *and*
     // debited from the Perp account collateral balance because withdraw performs a settlement.
@@ -177,7 +172,7 @@ describe("PerpV2BasisTradingSlippageIssuance", () => {
     const positionUnitInfo = await perpBasisTradingModule.getPositionUnitInfo(setToken);
 
     for (const info of positionUnitInfo) {
-      const baseTradeQuantityNotional = preciseMul(info.baseUnit, redeemQuantity);
+      const baseTradeQuantityNotional = preciseMul(info.baseUnit, redeemQuantityNetFees);
 
       const { deltaQuote } = await perpSetup.getSwapQuote(
         info.baseToken,
@@ -198,9 +193,21 @@ describe("PerpV2BasisTradingSlippageIssuance", () => {
 
     return {
       feeAdjustedTransferOutUSDC,
-      realizedPnlUSDC,
-      redeemQuantityWithFees
+      realizedPnlUSDC
     };
+  }
+
+  function calculateQuantityNetFees(
+    setQuantity: BigNumber,
+    issueFee: BigNumber,
+    redeemFee: BigNumber,
+    isIssue: boolean,
+  ): BigNumber {
+    if (isIssue) {
+      return preciseMul(setQuantity, PRECISE_UNIT.add(issueFee));
+    } else {
+      return preciseMul(setQuantity, PRECISE_UNIT.sub(redeemFee));
+    }
   }
 
   // PerpV2BasisTradingModule#moduleIssueHook implementation calls PerpV2LeverageModuleV2#moduleIssueHook to handle issuance
@@ -219,10 +226,12 @@ describe("PerpV2BasisTradingSlippageIssuance", () => {
   describe("#redemption", async () => {
     let setToken: SetToken;
     let baseToken: Address;
+    let issueFee: BigNumber;
     let redeemFee: BigNumber;
     let depositQuantityUnit: BigNumber;
     let usdcDefaultPositionUnit: BigNumber;
     let usdcTransferOutQuantity: BigNumber;
+    let quantityNetFees: BigNumber;
 
     let subjectSetToken: Address;
     let subjectQuantity: BigNumber;
@@ -239,6 +248,7 @@ describe("PerpV2BasisTradingSlippageIssuance", () => {
         [usdcDefaultPositionUnit],
         [perpBasisTradingModule.address, slippageIssuanceModule.address]
       );
+      issueFee = ether(0.005);
       redeemFee = ether(0.005);
       await slippageIssuanceModule.initialize(
         setToken.address,
@@ -305,9 +315,10 @@ describe("PerpV2BasisTradingSlippageIssuance", () => {
         subjectTo = owner.address;
         subjectCaller = owner;
 
+        quantityNetFees = calculateQuantityNetFees(subjectQuantity, issueFee, redeemFee, false);
         usdcTransferOutQuantity = await calculateUSDCTransferOut(
           setToken,
-          subjectQuantity,
+          quantityNetFees,
           perpBasisTradingModule,
           perpSetup
         );
@@ -326,10 +337,10 @@ describe("PerpV2BasisTradingSlippageIssuance", () => {
         await subject();
         const finalExternalPositionUnit = await setToken.getExternalPositionRealUnit(usdc.address, perpBasisTradingModule.address);
 
-        const expectedExternalPositionUnit = usdcTransferOutQuantity;
+        const expectedExternalPositionUnit = preciseDiv(usdcTransferOutQuantity, quantityNetFees);
 
         expect(initialExternalPositionUnit).not.eq(finalExternalPositionUnit);
-        expect(finalExternalPositionUnit).eq(expectedExternalPositionUnit);
+        expect(finalExternalPositionUnit).closeTo(expectedExternalPositionUnit, 1);
       });
 
       it("should have the expected virtual token balance", async () => {
@@ -340,7 +351,7 @@ describe("PerpV2BasisTradingSlippageIssuance", () => {
         const finalBaseBalance = (await perpBasisTradingModule.getPositionNotionalInfo(subjectSetToken))[0].baseBalance;
 
         const basePositionUnit = preciseDiv(initialBaseBalance, totalSupply);
-        const baseTokenBoughtNotional = preciseMul(basePositionUnit, subjectQuantity);
+        const baseTokenBoughtNotional = preciseMul(basePositionUnit, quantityNetFees);
         const expectedBaseBalance = initialBaseBalance.sub(baseTokenBoughtNotional);
 
         expect(finalBaseBalance).eq(expectedBaseBalance);
@@ -367,7 +378,6 @@ describe("PerpV2BasisTradingSlippageIssuance", () => {
           expect(accountInfo.pendingFundingPayments).to.be.gt(ZERO);
         });
 
-
         it("should not update the USDC defaultPositionUnit", async () => {
           const initialDefaultPositionUnit = await setToken.getDefaultPositionRealUnit(usdc.address);
           await subject();
@@ -380,7 +390,7 @@ describe("PerpV2BasisTradingSlippageIssuance", () => {
           const baseBalance = await perpSetup.accountBalance.getBase(setToken.address, vETH.address);
           usdcTransferOutQuantity = await calculateUSDCTransferOutPreciseUnits(
             setToken,
-            subjectQuantity,
+            quantityNetFees,
             perpBasisTradingModule,
             perpSetup
           );
@@ -401,7 +411,7 @@ describe("PerpV2BasisTradingSlippageIssuance", () => {
           );
 
           const expectedExternalPositionUnit = toUSDCDecimals(
-            preciseDiv(usdcTransferOutQuantity, subjectQuantity)
+            preciseDiv(usdcTransferOutQuantity, quantityNetFees)
           ).sub(performanceFeeUnit);
 
           const finalExternalPositionUnit = await setToken.getExternalPositionRealUnit(usdc.address, perpBasisTradingModule.address);
@@ -418,7 +428,7 @@ describe("PerpV2BasisTradingSlippageIssuance", () => {
           const finalBaseBalance = (await perpBasisTradingModule.getPositionNotionalInfo(subjectSetToken))[0].baseBalance;
 
           const basePositionUnit = preciseDiv(initialBaseBalance, totalSupply);
-          const baseTokenBoughtNotional = preciseMul(basePositionUnit, subjectQuantity);
+          const baseTokenBoughtNotional = preciseMul(basePositionUnit, quantityNetFees);
           const expectedBaseBalance = initialBaseBalance.sub(baseTokenBoughtNotional);
 
           expect(finalBaseBalance).eq(expectedBaseBalance);
@@ -444,7 +454,7 @@ describe("PerpV2BasisTradingSlippageIssuance", () => {
             realizedPnlUSDC
           } = await calculateRedemptionData(
             subjectSetToken,
-            subjectQuantity,
+            quantityNetFees,
             usdcTransferOutQuantity
           ));
         });
@@ -479,7 +489,7 @@ describe("PerpV2BasisTradingSlippageIssuance", () => {
           const finalOwnerUSDCBalance = await usdc.balanceOf(subjectCaller.address);
 
           const expectedUSDCBalance = initialOwnerUSDCBalance.add(feeAdjustedTransferOutUSDC);
-          expect(finalOwnerUSDCBalance).eq(expectedUSDCBalance);
+          expect(finalOwnerUSDCBalance).closeTo(expectedUSDCBalance, 1);
         });
       });
     });
@@ -520,9 +530,10 @@ describe("PerpV2BasisTradingSlippageIssuance", () => {
         subjectTo = owner.address;
         subjectCaller = owner;
 
+        quantityNetFees = calculateQuantityNetFees(subjectQuantity, issueFee, redeemFee, false);
         usdcTransferOutQuantity = await calculateUSDCTransferOut(
           setToken,
-          subjectQuantity,
+          quantityNetFees,
           perpBasisTradingModule,
           perpSetup
         );
@@ -544,7 +555,7 @@ describe("PerpV2BasisTradingSlippageIssuance", () => {
         // initialExternalPositionUnit = 10_000_000
         // finalExternalPositionUnit   =  9_597_857
 
-        const expectedExternalPositionUnit = preciseDiv(usdcTransferOutQuantity, subjectQuantity);;
+        const expectedExternalPositionUnit = preciseDiv(usdcTransferOutQuantity, quantityNetFees);
         expect(initialExternalPositionUnit).eq(usdcDefaultPositionUnit);
         expect(finalExternalPositionUnit).to.be.closeTo(expectedExternalPositionUnit, 1);
       });
@@ -557,21 +568,15 @@ describe("PerpV2BasisTradingSlippageIssuance", () => {
         const finalBaseBalance = (await perpBasisTradingModule.getPositionNotionalInfo(subjectSetToken))[0].baseBalance;
 
         const basePositionUnit = preciseDiv(initialBaseBalance, totalSupply);
-        const baseTokenSoldNotional = preciseMul(basePositionUnit, subjectQuantity);
+        const baseTokenSoldNotional = preciseMul(basePositionUnit, quantityNetFees);
         const expectedBaseBalance = initialBaseBalance.sub(baseTokenSoldNotional);
 
         expect(finalBaseBalance).eq(expectedBaseBalance);
       });
 
       it("should get required component redemption units correctly", async () => {
-        const issueQuantityWithFees = (await slippageIssuanceModule.calculateTotalFees(
-          subjectSetToken,
-          subjectQuantity,
-          false
-        ))[0];
-
-        const externalPositionUnit = preciseDiv(usdcTransferOutQuantity, subjectQuantity);
-        const feeAdjustedTransferOut = preciseMul(issueQuantityWithFees, externalPositionUnit);
+        const externalPositionUnit = preciseDiv(usdcTransferOutQuantity, quantityNetFees);
+        const feeAdjustedTransferOut = preciseMul(quantityNetFees, externalPositionUnit);
 
         const [components, equityFlows, debtFlows] = await slippageIssuanceModule
           .callStatic
@@ -675,7 +680,7 @@ describe("PerpV2BasisTradingSlippageIssuance", () => {
           const baseBalance = await perpSetup.accountBalance.getBase(setToken.address, vETH.address);
           usdcTransferOutQuantity = await calculateUSDCTransferOutPreciseUnits(
             setToken,
-            subjectQuantity,
+            quantityNetFees,
             perpBasisTradingModule,
             perpSetup
           );
@@ -696,7 +701,7 @@ describe("PerpV2BasisTradingSlippageIssuance", () => {
           );
 
           const expectedExternalPositionUnit = toUSDCDecimals(
-            preciseDiv(usdcTransferOutQuantity, subjectQuantity)
+            preciseDiv(usdcTransferOutQuantity, quantityNetFees)
           ).sub(performanceFeeUnit);
 
           const finalExternalPositionUnit = await setToken.getExternalPositionRealUnit(usdc.address, perpBasisTradingModule.address);
@@ -713,7 +718,7 @@ describe("PerpV2BasisTradingSlippageIssuance", () => {
           const finalBaseBalance = (await perpBasisTradingModule.getPositionNotionalInfo(subjectSetToken))[0].baseBalance;
 
           const basePositionUnit = preciseDiv(initialBaseBalance, totalSupply);
-          const baseTokenBoughtNotional = preciseMul(basePositionUnit, subjectQuantity);
+          const baseTokenBoughtNotional = preciseMul(basePositionUnit, quantityNetFees);
           const expectedBaseBalance = initialBaseBalance.sub(baseTokenBoughtNotional);
 
           expect(finalBaseBalance).eq(expectedBaseBalance);
@@ -738,7 +743,7 @@ describe("PerpV2BasisTradingSlippageIssuance", () => {
             realizedPnlUSDC
           } = await calculateRedemptionData(
             subjectSetToken,
-            subjectQuantity,
+            quantityNetFees,
             usdcTransferOutQuantity)
           );
         });
@@ -841,6 +846,7 @@ describe("PerpV2BasisTradingSlippageIssuance", () => {
       describe("when redeeming after a liquidation", async () => {
         beforeEach(async () => {
           subjectQuantity = ether(1);
+          quantityNetFees = calculateQuantityNetFees(subjectQuantity, issueFee, redeemFee, false);
 
           // Calculated leverage = ~8.5X = 8_654_438_822_995_683_587
           await leverUp(
@@ -879,21 +885,20 @@ describe("PerpV2BasisTradingSlippageIssuance", () => {
 
           const usdcTransferOutQuantity = await calculateUSDCTransferOut(
             setToken,
-            subjectQuantity,
+            quantityNetFees,
             perpBasisTradingModule,
             perpSetup
           );
 
           const {
             feeAdjustedTransferOutUSDC,
-            redeemQuantityWithFees
           } = await calculateRedemptionData(
             subjectSetToken,
-            subjectQuantity,
+            quantityNetFees,
             usdcTransferOutQuantity
           );
 
-          const expectedTotalSupply = initialTotalSupply.sub(redeemQuantityWithFees);
+          const expectedTotalSupply = initialTotalSupply.sub(quantityNetFees);
           const expectedCollateralBalance = toUSDCDecimals(initialCollateralBalance)
             .sub(feeAdjustedTransferOutUSDC)
             .add(owedRealizedPnlUSDC);
@@ -953,12 +958,6 @@ describe("PerpV2BasisTradingSlippageIssuance", () => {
         // collateralBalance =  10050000000000000000
         // owedRealizedPnl =   -31795534271984084912
         it("should redeem without transferring any usdc (because account worth 0)", async () => {
-          const redeemQuantityWithFees = (await slippageIssuanceModule.calculateTotalFees(
-            subjectSetToken,
-            subjectQuantity,
-            false
-          ))[0];
-
           const initialRedeemerUSDCBalance = await usdc.balanceOf(subjectCaller.address);
           const initialTotalSupply = await setToken.totalSupply();
 
@@ -967,7 +966,7 @@ describe("PerpV2BasisTradingSlippageIssuance", () => {
           const finalRedeemerUSDCBalance = await usdc.balanceOf(subjectCaller.address);
           const finalTotalSupply = await setToken.totalSupply();
 
-          const expectedTotalSupply = initialTotalSupply.sub(redeemQuantityWithFees);
+          const expectedTotalSupply = initialTotalSupply.sub(quantityNetFees);
 
           expect(finalTotalSupply).eq(expectedTotalSupply);
           expect(finalRedeemerUSDCBalance).eq(initialRedeemerUSDCBalance);

--- a/test/integration/perpV2LeverageV2SlippageIssuance.spec.ts
+++ b/test/integration/perpV2LeverageV2SlippageIssuance.spec.ts
@@ -400,12 +400,26 @@ describe("PerpV2LeverageSlippageIssuance", () => {
           );
         });
 
-        it("should not update the USDC defaultPositionUnit", async () => {
+        it("should NOT update the USDC defaultPositionUnit", async () => {
           const initialDefaultPositionUnit = await setToken.getDefaultPositionRealUnit(usdc.address);
           await subject();
           const finalDefaultPositionUnit = await setToken.getDefaultPositionRealUnit(usdc.address);;
 
           expect(finalDefaultPositionUnit).to.eq(initialDefaultPositionUnit);
+        });
+
+        it("should NOT update the virtual quote token position unit", async () => {
+          const totalSupply = await setToken.totalSupply();
+          const initialBaseBalance = (await perpLeverageModule.getPositionNotionalInfo(subjectSetToken))[0].baseBalance;
+          const initialBasePositionUnit = preciseDiv(initialBaseBalance, totalSupply);
+
+          await subject();
+
+          const newTotalSupply = await setToken.totalSupply();
+          const finalBaseBalance = (await perpLeverageModule.getPositionNotionalInfo(subjectSetToken))[0].baseBalance;
+          const finalBasePositionUnit = preciseDiv(finalBaseBalance, newTotalSupply);
+
+          expect(initialBasePositionUnit).to.eq(finalBasePositionUnit);
         });
 
         it("should have set the expected USDC externalPositionUnit", async () => {
@@ -474,6 +488,28 @@ describe("PerpV2LeverageSlippageIssuance", () => {
             perpLeverageModule,
             perpSetup
           );
+        });
+
+        it("should NOT update the USDC defaultPositionUnit", async () => {
+          const initialDefaultPositionUnit = await setToken.getDefaultPositionRealUnit(usdc.address);
+          await subject();
+          const finalDefaultPositionUnit = await setToken.getDefaultPositionRealUnit(usdc.address);;
+
+          expect(finalDefaultPositionUnit).to.eq(initialDefaultPositionUnit);
+        });
+
+        it("should NOT update the virtual quote token position unit", async () => {
+          const totalSupply = await setToken.totalSupply();
+          const initialBaseBalance = (await perpLeverageModule.getPositionNotionalInfo(subjectSetToken))[0].baseBalance;
+          const initialBasePositionUnit = preciseDiv(initialBaseBalance, totalSupply);
+
+          await subject();
+
+          const newTotalSupply = await setToken.totalSupply();
+          const finalBaseBalance = (await perpLeverageModule.getPositionNotionalInfo(subjectSetToken))[0].baseBalance;
+          const finalBasePositionUnit = preciseDiv(finalBaseBalance, newTotalSupply);
+
+          expect(initialBasePositionUnit).to.eq(finalBasePositionUnit);
         });
 
         it("should have set the expected USDC externalPositionUnit", async () => {
@@ -828,12 +864,26 @@ describe("PerpV2LeverageSlippageIssuance", () => {
         );
       });
 
-      it("should not update the USDC defaultPositionUnit", async () => {
+      it("should NOT update the USDC defaultPositionUnit", async () => {
         const initialDefaultPositionUnit = await setToken.getDefaultPositionRealUnit(usdc.address);
         await subject();
         const finalDefaultPositionUnit = await setToken.getDefaultPositionRealUnit(usdc.address);
 
         expect(initialDefaultPositionUnit).eq(finalDefaultPositionUnit);
+      });
+
+      it("should NOT update the virtual quote token position unit", async () => {
+        const totalSupply = await setToken.totalSupply();
+        const initialBaseBalance = (await perpLeverageModule.getPositionNotionalInfo(subjectSetToken))[0].baseBalance;
+        const initialBasePositionUnit = preciseDiv(initialBaseBalance, totalSupply);
+
+        await subject();
+
+        const newTotalSupply = await setToken.totalSupply();
+        const finalBaseBalance = (await perpLeverageModule.getPositionNotionalInfo(subjectSetToken))[0].baseBalance;
+        const finalBasePositionUnit = preciseDiv(finalBaseBalance, newTotalSupply);
+
+        expect(initialBasePositionUnit).to.eq(finalBasePositionUnit);
       });
 
       it("should have updated the USDC externalPositionUnit", async () => {
@@ -963,12 +1013,26 @@ describe("PerpV2LeverageSlippageIssuance", () => {
         );
       });
 
-      it("should not update the USDC defaultPositionUnit", async () => {
+      it("should NOT update the USDC defaultPositionUnit", async () => {
         const initialDefaultPositionUnit = await setToken.getDefaultPositionRealUnit(usdc.address);
         await subject();
         const finalDefaultPositionUnit = await setToken.getDefaultPositionRealUnit(usdc.address);
 
         expect(initialDefaultPositionUnit).eq(finalDefaultPositionUnit);
+      });
+
+      it("should NOT update the virtual quote token position unit", async () => {
+        const totalSupply = await setToken.totalSupply();
+        const initialBaseBalance = (await perpLeverageModule.getPositionNotionalInfo(subjectSetToken))[0].baseBalance;
+        const initialBasePositionUnit = preciseDiv(initialBaseBalance, totalSupply);
+
+        await subject();
+
+        const newTotalSupply = await setToken.totalSupply();
+        const finalBaseBalance = (await perpLeverageModule.getPositionNotionalInfo(subjectSetToken))[0].baseBalance;
+        const finalBasePositionUnit = preciseDiv(finalBaseBalance, newTotalSupply);
+
+        expect(initialBasePositionUnit).to.eq(finalBasePositionUnit);
       });
 
       it("should update the USDC externalPositionUnit", async () => {

--- a/test/integration/perpV2LeverageV2SlippageIssuance.spec.ts
+++ b/test/integration/perpV2LeverageV2SlippageIssuance.spec.ts
@@ -34,7 +34,7 @@ import {
 } from "@utils/test/index";
 import { PerpV2Fixture, SystemFixture } from "@utils/fixtures";
 import { BigNumber } from "ethers";
-import { ADDRESS_ZERO, ZERO, MAX_UINT_256, ZERO_BYTES } from "@utils/constants";
+import { ADDRESS_ZERO, ZERO, MAX_UINT_256, ZERO_BYTES, PRECISE_UNIT } from "@utils/constants";
 
 const expect = getWaffleExpect();
 
@@ -183,25 +183,20 @@ describe("PerpV2LeverageSlippageIssuance", () => {
 
   async function calculateRedemptionData(
     setToken: Address,
-    redeemQuantity: BigNumber,
+    redeemQuantityNetFees: BigNumber,
     usdcTransferOutQuantity: BigNumber
   ) {
     // Calculate fee adjusted usdcTransferOut
-    const redeemQuantityWithFees = (await slippageIssuanceModule.calculateTotalFees(
-      setToken,
-      redeemQuantity,
-      false
-    ))[0];
-
-    const feeAdjustedTransferOutUSDC = preciseMul(redeemQuantityWithFees, usdcTransferOutQuantity);
+    const externalPositionUnit = preciseDiv(usdcTransferOutQuantity, redeemQuantityNetFees);
+    const feeAdjustedTransferOutUSDC = preciseMul(redeemQuantityNetFees, externalPositionUnit);
 
     // Calculate realizedPnl. The amount is debited from collateral returned to redeemer *and*
     // debited from the Perp account collateral balance because withdraw performs a settlement.
     let realizedPnlUSDC = BigNumber.from(0);
-    const positionUnitInfo = await await perpLeverageModule.getPositionUnitInfo(setToken);
+    const positionUnitInfo = await perpLeverageModule.getPositionUnitInfo(setToken);
 
     for (const info of positionUnitInfo) {
-      const baseTradeQuantityNotional = preciseMul(info.baseUnit, redeemQuantity);
+      const baseTradeQuantityNotional = preciseMul(info.baseUnit, redeemQuantityNetFees);
 
       const { deltaQuote } = await perpSetup.getSwapQuote(
         info.baseToken,
@@ -222,14 +217,27 @@ describe("PerpV2LeverageSlippageIssuance", () => {
 
     return {
       feeAdjustedTransferOutUSDC,
-      realizedPnlUSDC,
-      redeemQuantityWithFees
+      realizedPnlUSDC
     };
+  }
+
+  function calculateQuantityNetFees(
+    setQuantity: BigNumber,
+    issueFee: BigNumber,
+    redeemFee: BigNumber,
+    isIssue: boolean,
+  ): BigNumber {
+    if (isIssue) {
+      return preciseMul(setQuantity, PRECISE_UNIT.add(issueFee));
+    } else {
+      return preciseMul(setQuantity, PRECISE_UNIT.sub(redeemFee));
+    }
   }
 
   describe("#issuance", async () => {
     let setToken: SetToken;
     let issueFee: BigNumber;
+    let redeemFee: BigNumber;
     let usdcDefaultPositionUnit: BigNumber;
 
     let subjectSetToken: Address;
@@ -248,6 +256,7 @@ describe("PerpV2LeverageSlippageIssuance", () => {
         [perpLeverageModule.address, slippageIssuanceModule.address]
       );
       issueFee = ether(0.005);
+      redeemFee = ether(0.005);
       await slippageIssuanceModule.initialize(
         setToken.address,
         ether(0.02),
@@ -333,6 +342,7 @@ describe("PerpV2LeverageSlippageIssuance", () => {
       let baseToken: Address;
       let depositQuantityUnit: BigNumber;
       let usdcTransferInQuantity: BigNumber;
+      let quantityNetFees: BigNumber;
 
       cacheBeforeEach(initializeContracts);
 
@@ -381,9 +391,10 @@ describe("PerpV2LeverageSlippageIssuance", () => {
         beforeEach(async () => {
           subjectQuantity = ether(1);
 
+          quantityNetFees = calculateQuantityNetFees(subjectQuantity, issueFee, redeemFee, true);
           usdcTransferInQuantity = await calculateUSDCTransferIn(
             setToken,
-            subjectQuantity,
+            quantityNetFees,
             perpLeverageModule,
             perpSetup
           );
@@ -398,7 +409,7 @@ describe("PerpV2LeverageSlippageIssuance", () => {
         });
 
         it("should have set the expected USDC externalPositionUnit", async () => {
-          const expectedExternalPositionUnit = preciseDiv(usdcTransferInQuantity, subjectQuantity);
+          const expectedExternalPositionUnit = preciseDiv(usdcTransferInQuantity, quantityNetFees);
 
           await subject();
 
@@ -419,7 +430,7 @@ describe("PerpV2LeverageSlippageIssuance", () => {
           const finalBaseBalance = (await perpLeverageModule.getPositionNotionalInfo(subjectSetToken))[0].baseBalance;
 
           const basePositionUnit = preciseDiv(initialBaseBalance, totalSupply);
-          const baseTokenBoughtNotional = preciseMul(basePositionUnit, subjectQuantity);
+          const baseTokenBoughtNotional = preciseMul(basePositionUnit, quantityNetFees);
           const expectedBaseBalance = initialBaseBalance.add(baseTokenBoughtNotional);
 
           expect(finalBaseBalance).eq(expectedBaseBalance);
@@ -429,30 +440,13 @@ describe("PerpV2LeverageSlippageIssuance", () => {
           const initialCollateralBalance = (await perpLeverageModule.getAccountInfo(subjectSetToken)).collateralBalance;
           await subject();
           const finalCollateralBalance = (await perpLeverageModule.getAccountInfo(subjectSetToken)).collateralBalance;
-
-          const issueQuantityWithFees = (await slippageIssuanceModule.calculateTotalFees(
-            subjectSetToken,
-            subjectQuantity,
-            true
-          ))[0];
-
-          const feeAdjustedTransferIn = preciseMul(issueQuantityWithFees, usdcTransferInQuantity);
-
-          // usdcTransferIn        = 10_008_105
-          // feeAdjustedTransferIn = 10_058_145
-          const expectedCollateralBalance = toUSDCDecimals(initialCollateralBalance).add(feeAdjustedTransferIn);
+          const expectedCollateralBalance = toUSDCDecimals(initialCollateralBalance).add(usdcTransferInQuantity);
           expect(toUSDCDecimals(finalCollateralBalance)).to.be.closeTo(expectedCollateralBalance, 2);
         });
 
         it("should get required component issuance units correctly", async () => {
-          const issueQuantityWithFees = (await slippageIssuanceModule.calculateTotalFees(
-            subjectSetToken,
-            subjectQuantity,
-            true
-          ))[0];
-
-          const externalPositionUnit = preciseDiv(usdcTransferInQuantity, subjectQuantity);
-          const feeAdjustedTransferIn = preciseMul(issueQuantityWithFees, externalPositionUnit);
+          const externalPositionUnit = preciseDiv(usdcTransferInQuantity, quantityNetFees);
+          const feeAdjustedTransferIn = preciseMul(quantityNetFees, externalPositionUnit);
 
           const [components, equityFlows, debtFlows] = await slippageIssuanceModule.callStatic.getRequiredComponentIssuanceUnitsOffChain(
             subjectSetToken,
@@ -473,16 +467,17 @@ describe("PerpV2LeverageSlippageIssuance", () => {
         beforeEach(async () => {
           subjectQuantity = ether(2);
 
+          quantityNetFees = calculateQuantityNetFees(subjectQuantity, issueFee, redeemFee, true);
           usdcTransferInQuantity = await calculateUSDCTransferIn(
             setToken,
-            subjectQuantity,
+            quantityNetFees,
             perpLeverageModule,
             perpSetup
           );
         });
 
         it("should have set the expected USDC externalPositionUnit", async () => {
-          const expectedExternalPositionUnit = preciseDiv(usdcTransferInQuantity, subjectQuantity);
+          const expectedExternalPositionUnit = preciseDiv(usdcTransferInQuantity, quantityNetFees);
 
           await subject();
 
@@ -503,7 +498,7 @@ describe("PerpV2LeverageSlippageIssuance", () => {
           const finalBaseBalance = (await perpLeverageModule.getPositionNotionalInfo(subjectSetToken))[0].baseBalance;
 
           const basePositionUnit = preciseDiv(initialBaseBalance, totalSupply);
-          const baseTokenBoughtNotional = preciseMul(basePositionUnit, subjectQuantity);
+          const baseTokenBoughtNotional = preciseMul(basePositionUnit, quantityNetFees);
           const expectedBaseBalance = initialBaseBalance.add(baseTokenBoughtNotional);
 
           expect(finalBaseBalance).eq(expectedBaseBalance);
@@ -514,14 +509,8 @@ describe("PerpV2LeverageSlippageIssuance", () => {
           await subject();
           const finalCollateralBalance = (await perpLeverageModule.getAccountInfo(subjectSetToken)).collateralBalance;
 
-          const issueQuantityWithFees = (await slippageIssuanceModule.calculateTotalFees(
-            subjectSetToken,
-            subjectQuantity,
-            true
-          ))[0];
-
-          const externalPositionUnit = preciseDiv(usdcTransferInQuantity, subjectQuantity);
-          const feeAdjustedTransferIn = preciseMul(issueQuantityWithFees, externalPositionUnit);
+          const externalPositionUnit = preciseDiv(usdcTransferInQuantity, quantityNetFees);
+          const feeAdjustedTransferIn = preciseMul(quantityNetFees, externalPositionUnit);
 
           // usdcTransferIn        = 20_024_302
           // feeAdjustedTransferIn = 20_124_423
@@ -530,14 +519,8 @@ describe("PerpV2LeverageSlippageIssuance", () => {
         });
 
         it("should deposit the expected amount into the Perp vault", async () => {
-          const issueQuantityWithFees = (await slippageIssuanceModule.calculateTotalFees(
-            subjectSetToken,
-            subjectQuantity,
-            true
-          ))[0];
-
-          const externalPositionUnit = preciseDiv(usdcTransferInQuantity, subjectQuantity);
-          const feeAdjustedTransferIn = preciseMul(issueQuantityWithFees, externalPositionUnit);
+          const externalPositionUnit = preciseDiv(usdcTransferInQuantity, quantityNetFees);
+          const feeAdjustedTransferIn = preciseMul(quantityNetFees, externalPositionUnit);
 
           const initialCollateralBalance = (await perpLeverageModule.getAccountInfo(subjectSetToken)).collateralBalance;
           await subject();
@@ -755,10 +738,12 @@ describe("PerpV2LeverageSlippageIssuance", () => {
   describe("#redemption", async () => {
     let setToken: SetToken;
     let baseToken: Address;
+    let issueFee: BigNumber;
     let redeemFee: BigNumber;
     let depositQuantityUnit: BigNumber;
     let usdcDefaultPositionUnit: BigNumber;
     let usdcTransferOutQuantity: BigNumber;
+    let quantityNetFees: BigNumber;
 
     let subjectSetToken: Address;
     let subjectQuantity: BigNumber;
@@ -775,6 +760,7 @@ describe("PerpV2LeverageSlippageIssuance", () => {
         [usdcDefaultPositionUnit],
         [perpLeverageModule.address, slippageIssuanceModule.address]
       );
+      issueFee = ether(0.005);
       redeemFee = ether(0.005);
       await slippageIssuanceModule.initialize(
         setToken.address,
@@ -833,9 +819,10 @@ describe("PerpV2LeverageSlippageIssuance", () => {
         subjectTo = owner.address;
         subjectCaller = owner;
 
+        quantityNetFees = calculateQuantityNetFees(subjectQuantity, issueFee, redeemFee, false);
         usdcTransferOutQuantity = await calculateUSDCTransferOut(
           setToken,
-          subjectQuantity,
+          quantityNetFees,
           perpLeverageModule,
           perpSetup
         );
@@ -854,10 +841,10 @@ describe("PerpV2LeverageSlippageIssuance", () => {
         await subject();
         const finalExternalPositionUnit = await setToken.getExternalPositionRealUnit(usdc.address, perpLeverageModule.address);
 
-        const expectedExternalPositionUnit = usdcTransferOutQuantity;
+        const expectedExternalPositionUnit = preciseDiv(usdcTransferOutQuantity, quantityNetFees);
 
         expect(initialExternalPositionUnit).not.eq(finalExternalPositionUnit);
-        expect(finalExternalPositionUnit).eq(expectedExternalPositionUnit);
+        expect(finalExternalPositionUnit).closeTo(expectedExternalPositionUnit, 1);
       });
 
       it("should have the expected virtual token balance", async () => {
@@ -868,7 +855,7 @@ describe("PerpV2LeverageSlippageIssuance", () => {
         const finalBaseBalance = (await perpLeverageModule.getPositionNotionalInfo(subjectSetToken))[0].baseBalance;
 
         const basePositionUnit = preciseDiv(initialBaseBalance, totalSupply);
-        const baseTokenBoughtNotional = preciseMul(basePositionUnit, subjectQuantity);
+        const baseTokenBoughtNotional = preciseMul(basePositionUnit, quantityNetFees);
         const expectedBaseBalance = initialBaseBalance.sub(baseTokenBoughtNotional);
 
         expect(finalBaseBalance).eq(expectedBaseBalance);
@@ -892,7 +879,7 @@ describe("PerpV2LeverageSlippageIssuance", () => {
             realizedPnlUSDC
           } = await calculateRedemptionData(
             subjectSetToken,
-            subjectQuantity,
+            quantityNetFees,
             usdcTransferOutQuantity
           ));
         });
@@ -927,7 +914,7 @@ describe("PerpV2LeverageSlippageIssuance", () => {
           const finalOwnerUSDCBalance = await usdc.balanceOf(subjectCaller.address);
 
           const expectedUSDCBalance = initialOwnerUSDCBalance.add(feeAdjustedTransferOutUSDC);
-          expect(finalOwnerUSDCBalance).eq(expectedUSDCBalance);
+          expect(finalOwnerUSDCBalance).closeTo(expectedUSDCBalance, 1);
         });
       });
     });
@@ -967,9 +954,10 @@ describe("PerpV2LeverageSlippageIssuance", () => {
         subjectTo = owner.address;
         subjectCaller = owner;
 
+        quantityNetFees = calculateQuantityNetFees(subjectQuantity, issueFee, redeemFee, false);
         usdcTransferOutQuantity = await calculateUSDCTransferOut(
           setToken,
-          subjectQuantity,
+          quantityNetFees,
           perpLeverageModule,
           perpSetup
         );
@@ -991,7 +979,7 @@ describe("PerpV2LeverageSlippageIssuance", () => {
         // initialExternalPositionUnit = 10_000_000
         // finalExternalPositionUnit   =  9_597_857
 
-        const expectedExternalPositionUnit = preciseDiv(usdcTransferOutQuantity, subjectQuantity);;
+        const expectedExternalPositionUnit = preciseDiv(usdcTransferOutQuantity, quantityNetFees);;
         expect(initialExternalPositionUnit).eq(usdcDefaultPositionUnit);
         expect(finalExternalPositionUnit).to.be.closeTo(expectedExternalPositionUnit, 1);
       });
@@ -1004,21 +992,15 @@ describe("PerpV2LeverageSlippageIssuance", () => {
         const finalBaseBalance = (await perpLeverageModule.getPositionNotionalInfo(subjectSetToken))[0].baseBalance;
 
         const basePositionUnit = preciseDiv(initialBaseBalance, totalSupply);
-        const baseTokenSoldNotional = preciseMul(basePositionUnit, subjectQuantity);
+        const baseTokenSoldNotional = preciseMul(basePositionUnit, quantityNetFees);
         const expectedBaseBalance = initialBaseBalance.sub(baseTokenSoldNotional);
 
         expect(finalBaseBalance).eq(expectedBaseBalance);
       });
 
       it("should get required component redemption units correctly", async () => {
-        const issueQuantityWithFees = (await slippageIssuanceModule.calculateTotalFees(
-          subjectSetToken,
-          subjectQuantity,
-          false
-        ))[0];
-
-        const externalPositionUnit = preciseDiv(usdcTransferOutQuantity, subjectQuantity);
-        const feeAdjustedTransferOut = preciseMul(issueQuantityWithFees, externalPositionUnit);
+        const externalPositionUnit = preciseDiv(usdcTransferOutQuantity, quantityNetFees);
+        const feeAdjustedTransferOut = preciseMul(quantityNetFees, externalPositionUnit);
 
         const [components, equityFlows, debtFlows] = await slippageIssuanceModule
           .callStatic
@@ -1089,7 +1071,7 @@ describe("PerpV2LeverageSlippageIssuance", () => {
             realizedPnlUSDC
           } = await calculateRedemptionData(
             subjectSetToken,
-            subjectQuantity,
+            quantityNetFees,
             usdcTransferOutQuantity)
           );
         });
@@ -1185,6 +1167,7 @@ describe("PerpV2LeverageSlippageIssuance", () => {
       describe("when redeeming after a liquidation", async () => {
         beforeEach(async () => {
           subjectQuantity = ether(1);
+          quantityNetFees = calculateQuantityNetFees(subjectQuantity, issueFee, redeemFee, false);
 
           // Calculated leverage = ~8.5X = 8_654_438_822_995_683_587
           await leverUp(
@@ -1222,21 +1205,20 @@ describe("PerpV2LeverageSlippageIssuance", () => {
 
           const usdcTransferOutQuantity = await calculateUSDCTransferOut(
             setToken,
-            subjectQuantity,
+            quantityNetFees,
             perpLeverageModule,
             perpSetup
           );
 
           const {
             feeAdjustedTransferOutUSDC,
-            redeemQuantityWithFees
           } = await calculateRedemptionData(
             subjectSetToken,
-            subjectQuantity,
+            quantityNetFees,
             usdcTransferOutQuantity
           );
 
-          const expectedTotalSupply = initialTotalSupply.sub(redeemQuantityWithFees);
+          const expectedTotalSupply = initialTotalSupply.sub(quantityNetFees);
           const expectedCollateralBalance = toUSDCDecimals(initialCollateralBalance)
             .sub(feeAdjustedTransferOutUSDC)
             .add(owedRealizedPnlUSDC);
@@ -1287,12 +1269,6 @@ describe("PerpV2LeverageSlippageIssuance", () => {
         // collateralBalance =  10050000000000000000
         // owedRealizedPnl =   -31795534271984084912
         it("should redeem without transferring any usdc (because account worth 0)", async () => {
-          const redeemQuantityWithFees = (await slippageIssuanceModule.calculateTotalFees(
-            subjectSetToken,
-            subjectQuantity,
-            false
-          ))[0];
-
           const initialRedeemerUSDCBalance = await usdc.balanceOf(subjectCaller.address);
           const initialTotalSupply = await setToken.totalSupply();
 
@@ -1301,7 +1277,7 @@ describe("PerpV2LeverageSlippageIssuance", () => {
           const finalRedeemerUSDCBalance = await usdc.balanceOf(subjectCaller.address);
           const finalTotalSupply = await setToken.totalSupply();
 
-          const expectedTotalSupply = initialTotalSupply.sub(redeemQuantityWithFees);
+          const expectedTotalSupply = initialTotalSupply.sub(quantityNetFees);
 
           expect(finalTotalSupply).eq(expectedTotalSupply);
           expect(finalRedeemerUSDCBalance).eq(initialRedeemerUSDCBalance);

--- a/test/integration/perpV2LeverageV2SlippageIssuance.spec.ts
+++ b/test/integration/perpV2LeverageV2SlippageIssuance.spec.ts
@@ -349,7 +349,7 @@ describe("PerpV2LeverageSlippageIssuance", () => {
       beforeEach(async () => {
         // Issue 1 SetToken
         issueQuantity = ether(1);
-        await slippageIssuanceModule.issue(setToken.address, issueQuantity, owner.address);
+        await slippageIssuanceModule.issueWithSlippage(setToken.address, issueQuantity, [], [], owner.address);
 
         depositQuantityUnit = usdcDefaultPositionUnit;
         await perpLeverageModule.deposit(setToken.address, depositQuantityUnit);
@@ -830,7 +830,7 @@ describe("PerpV2LeverageSlippageIssuance", () => {
       beforeEach(async () => {
         // Issue 1 SetToken
         issueQuantity = ether(1);
-        await slippageIssuanceModule.issue(setToken.address, issueQuantity, owner.address);
+        await slippageIssuanceModule.issueWithSlippage(setToken.address, issueQuantity, [], [], owner.address);
 
         depositQuantityUnit = usdcUnits(10);
         await perpLeverageModule.deposit(setToken.address, depositQuantityUnit);
@@ -978,7 +978,7 @@ describe("PerpV2LeverageSlippageIssuance", () => {
       beforeEach(async () => {
         // Issue 2 SetTokens
         issueQuantity = ether(2);
-        await slippageIssuanceModule.issue(setToken.address, issueQuantity, owner.address);
+        await slippageIssuanceModule.issueWithSlippage(setToken.address, issueQuantity, [], [], owner.address);
 
         // Deposit entire default position
         depositQuantityUnit = usdcDefaultPositionUnit;

--- a/test/protocol/modules/v1/slippageIssuanceModule.spec.ts
+++ b/test/protocol/modules/v1/slippageIssuanceModule.spec.ts
@@ -826,7 +826,7 @@ describe("SlippageIssuanceModule", () => {
 
         await setup.weth.approve(slippageIssuance.address, equityFlows[0].mul(ether(1.005)));
 
-        await slippageIssuance.issue(setToken.address, ether(1), owner.address);
+        await slippageIssuance.issueWithSlippage(setToken.address, ether(1), [], [], owner.address);
 
         await setup.dai.approve(slippageIssuance.address, ether(100.5));
 
@@ -1146,7 +1146,7 @@ describe("SlippageIssuanceModule", () => {
       });
     });
 
-    describe.only("#issue", async () => {
+    describe("#issue", async () => {
       let subjectSetToken: Address;
       let subjectQuantity: BigNumber;
       let subjectTo: Address;
@@ -1166,7 +1166,7 @@ describe("SlippageIssuanceModule", () => {
       });
     });
 
-    describe.only("#redeem", async () => {
+    describe("#redeem", async () => {
       let subjectSetToken: Address;
       let subjectQuantity: BigNumber;
       let subjectTo: Address;

--- a/test/protocol/modules/v1/slippageIssuanceModule.spec.ts
+++ b/test/protocol/modules/v1/slippageIssuanceModule.spec.ts
@@ -22,6 +22,7 @@ import {
 } from "@utils/test/index";
 import { SystemFixture } from "@utils/fixtures";
 import { ContractTransaction } from "ethers";
+import { getRandomAddress } from "@utils/common";
 
 const expect = getWaffleExpect();
 
@@ -1142,6 +1143,46 @@ describe("SlippageIssuanceModule", () => {
         it("should revert", async () => {
           await expect(subject()).to.be.revertedWith("Must be a valid and initialized SetToken");
         });
+      });
+    });
+
+    describe.only("#issue", async () => {
+      let subjectSetToken: Address;
+      let subjectQuantity: BigNumber;
+      let subjectTo: Address;
+
+      beforeEach(async () => {
+        subjectSetToken = await getRandomAddress();
+        subjectQuantity = ether(1);
+        subjectTo = await getRandomAddress();
+      });
+
+      async function subject(): Promise<any> {
+        return await slippageIssuance.issue(subjectSetToken, subjectQuantity, subjectTo);
+      }
+
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith("Call issueWithSlippage instead");
+      });
+    });
+
+    describe.only("#redeem", async () => {
+      let subjectSetToken: Address;
+      let subjectQuantity: BigNumber;
+      let subjectTo: Address;
+
+      beforeEach(async () => {
+        subjectSetToken = await getRandomAddress();
+        subjectQuantity = ether(1);
+        subjectTo = await getRandomAddress();
+      });
+
+      async function subject(): Promise<any> {
+        return await slippageIssuance.redeem(subjectSetToken, subjectQuantity, subjectTo);
+      }
+
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith("Call redeemWithSlippage instead");
       });
     });
   });


### PR DESCRIPTION
### Bug Analysis
[Triage Basis Trading: Delta Neutrality Deviation Spike](https://docs.google.com/document/d/1_P38X6SvRq4WZ9Ys3npRLnhrxY5pM1s9ne9KWj4sq90/edit)

Virtual position units update during issuance and redemption.

### Requirement
Update calculations to
1. Ensure position units don't change due to issuance and redemption.
2. Ensure we aren't double charging fees in the new flow.

### Solution
[Sheet explaining new calculations which fulfill the requirements](https://docs.google.com/spreadsheets/d/1cTMW1PacANYzf-oLkc_OFmSBDk9mZNLdA1GVQp0VEcQ/edit#gid=0)

### Tasks
- [x] Implement Fix
- [x] Fix existing tests
- [x] Add new test cases to ensure position units don't update