### PR TITLE
Rename WrappedfCashFactory to WrappedfCashFactoryExperimental

### DIFF
--- a/contracts/protocol/integration/wrap/notional/WrappedfCashFactory.sol
+++ b/contracts/protocol/integration/wrap/notional/WrappedfCashFactory.sol
@@ -1,8 +1,0 @@
-// SPDX-License-Identifier: MIT
-pragma solidity 0.8.11;
-import { WrappedfCashFactory as WrappedfCashFactoryBase } from "wrapped-fcash/contracts/proxy/WrappedfCashFactory.sol";
-
-contract WrappedfCashFactory is WrappedfCashFactoryBase {
-    constructor(address _beacon) WrappedfCashFactoryBase(_beacon){
-    }
-}

--- a/contracts/protocol/integration/wrap/notional/WrappedfCashFactoryExperimental.sol
+++ b/contracts/protocol/integration/wrap/notional/WrappedfCashFactoryExperimental.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.11;
+import { WrappedfCashFactory } from "wrapped-fcash/contracts/proxy/WrappedfCashFactory.sol";
+
+contract WrappedfCashFactoryExperimental is WrappedfCashFactory {
+    constructor(address _beacon) WrappedfCashFactory(_beacon){
+    }
+}

--- a/test/integration/notionalTradeModule/notionalTradeModule.spec.ts
+++ b/test/integration/notionalTradeModule/notionalTradeModule.spec.ts
@@ -22,7 +22,7 @@ import {
   ManagerIssuanceHookMock,
   NotionalTradeModule,
   WrappedfCash,
-  WrappedfCashFactory,
+  WrappedfCashFactoryExperimental,
 } from "@utils/contracts";
 
 import { IERC20 } from "@typechain/IERC20";
@@ -96,7 +96,7 @@ describe("Notional trade module integration [ @forked-mainnet ]", () => {
           let underlyingTokenAmount: BigNumber;
           let fCashAmount: BigNumber;
           let snapshotId: string;
-          let wrappedFCashFactory: WrappedfCashFactory;
+          let wrappedFCashFactory: WrappedfCashFactoryExperimental;
 
           before(async () => {
             wrappedFCashFactory = await deployWrappedfCashFactory(

--- a/test/integration/notionalTradeModule/utils.ts
+++ b/test/integration/notionalTradeModule/utils.ts
@@ -1,6 +1,6 @@
 import { ethers, network } from "hardhat";
 import { BigNumber, Signer } from "ethers";
-import { INotionalProxy, WrappedfCash, WrappedfCashFactory } from "@utils/contracts";
+import { INotionalProxy, WrappedfCash, WrappedfCashFactoryExperimental } from "@utils/contracts";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
 import { IERC20 } from "@typechain/IERC20";
 import { ICErc20 } from "@typechain/ICErc20";
@@ -95,7 +95,7 @@ export async function getCurrencyIdAndMaturity(underlyingAddress: string, maturi
 }
 
 export async function deployWrappedfCashInstance(
-  wrappedfCashFactory: WrappedfCashFactory,
+  wrappedfCashFactory: WrappedfCashFactoryExperimental,
   currencyId: number,
   maturity: BigNumber,
 ) {

--- a/utils/contracts/index.ts
+++ b/utils/contracts/index.ts
@@ -127,7 +127,7 @@ export { WrapV2AdapterMock } from "../../typechain/WrapV2AdapterMock";
 export { WrapModule } from "../../typechain/WrapModule";
 export { WrapModuleV2 } from "../../typechain/WrapModuleV2";
 export { WrappedfCash } from "../../typechain/WrappedfCash";
-export { WrappedfCashFactory } from "../../typechain/WrappedfCashFactory";
+export { WrappedfCashFactoryExperimental } from "../../typechain/WrappedfCashFactoryExperimental";
 export { WrappedfCashMock } from "../../typechain/WrappedfCashMock";
 export { WrappedfCashFactoryMock } from "../../typechain/WrappedfCashFactoryMock";
 export { YearnWrapV2Adapter } from "../../typechain/YearnWrapV2Adapter";

--- a/utils/contracts/notional.ts
+++ b/utils/contracts/notional.ts
@@ -1,3 +1,3 @@
 // External Uniswap Contracts
 export { WrappedfCash } from "../../typechain/WrappedfCash";
-export { WrappedfCashFactory } from "../../typechain/WrappedfCashFactory";
+export { WrappedfCashFactoryExperimental } from "../../typechain/WrappedfCashFactoryExperimental";

--- a/utils/deploys/deployExternal.ts
+++ b/utils/deploys/deployExternal.ts
@@ -37,7 +37,7 @@ import { Unitroller__factory } from "../../typechain/factories/Unitroller__facto
 import { WETH9__factory } from "../../typechain/factories/WETH9__factory";
 import { WhitePaperInterestRateModel__factory } from "../../typechain/factories/WhitePaperInterestRateModel__factory";
 import { WrappedfCash__factory } from "../../typechain/factories/WrappedfCash__factory";
-import { WrappedfCashFactory__factory } from "../../typechain/factories/WrappedfCashFactory__factory";
+import { WrappedfCashFactoryExperimental__factory } from "../../typechain/factories/WrappedfCashFactoryExperimental__factory";
 
 import {
   CurveDeposit,
@@ -73,7 +73,7 @@ import {
 
 import {
   WrappedfCash,
-  WrappedfCashFactory
+  WrappedfCashFactoryExperimental
 } from "../contracts/notional";
 
 import { StakingRewards__factory } from "../../typechain/factories/StakingRewards__factory";
@@ -732,8 +732,8 @@ export default class DeployExternalContracts {
     return await new WrappedfCash__factory(this._deployerSigner).deploy(notionalProxy, weth);
   }
 
-  public async deployWrappedfCashFactory(beacon: Address): Promise<WrappedfCashFactory> {
-    return await new WrappedfCashFactory__factory(this._deployerSigner).deploy(beacon);
+  public async deployWrappedfCashFactory(beacon: Address): Promise<WrappedfCashFactoryExperimental> {
+    return await new WrappedfCashFactoryExperimental__factory(this._deployerSigner).deploy(beacon);
   }
 
 


### PR DESCRIPTION
As part of #251, several contracts that will be published/deployed by Notional in future have been temporarily brought into the repo to enable NotionalTradeModule development and staging_mainnet testing

[WrappedfCashFactory][1] is one of these. Unfortunately the way it's imported results in duplicate hardhat artifacts being generated and two problems in the downstream deployments repo:
+ hardhat-etherscan errors with a complaint that it cannot disambiguate between the contract bytecodes for verification
+ hardhat-deploy errors with a complaint that it cannot locate the contract for deployment 

This PR renames the root-level contract and makes its bytecode slightly different (in an irrelevant way) to get around these.

[1]: https://github.com/SetProtocol/set-protocol-v2/blob/master/contracts/protocol/integration/wrap/notional/WrappedfCashFactory.sol