### PR TITLE
perf(BytesArrayUtils): reduce gas of function toBool

### DIFF
--- a/contracts/lib/BytesArrayUtils.sol
+++ b/contracts/lib/BytesArrayUtils.sol
@@ -34,16 +34,16 @@ library BytesArrayUtils {
      * @return bool        Boolean value
      */
     function toBool(bytes memory _bytes, uint256 _start) internal pure returns (bool) {
-        require(_start + 1 >= _start, "toBool_overflow");
-        require(_bytes.length >= _start + 1, "toBool_outOfBounds");
+        require(_start != type(uint256).max, "toBool_overflow");
+        require(_bytes.length > _start, "toBool_outOfBounds");
         uint8 tempUint;
 
         assembly {
             tempUint := mload(add(add(_bytes, 0x1), _start))
         }
 
-        require(tempUint <= 1, "Invalid bool data");     // Should be either 0 or 1
+        require(tempUint < 2, "Invalid bool data");     // Should be either 0 or 1
 
-        return (tempUint == 0) ? false : true;
+        return tempUint != 0;
     }
 }


### PR DESCRIPTION
In Solidity, there is no single op-code for ≤ or ≥ expressions. Solidity compiler executes the LT/GT (less than/greater than) op-code and afterwards it executes an ISZERO op-code to check if the result of the previous comparison (LT/ GT) is zero and validate it or not. So the use of < and > are cheaper than ≤ and ≥.