### PR TITLE
feat(integrations): add ETH compatibility to AaveV2WrapV2Adapter

### DIFF
--- a/contracts/interfaces/external/aave-v2/IWETHGateway.sol
+++ b/contracts/interfaces/external/aave-v2/IWETHGateway.sol
@@ -1,0 +1,46 @@
+/*
+  Copyright 2021 Set Labs Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  SPDX-License-Identifier: Apache License, Version 2.0
+*/
+pragma solidity 0.6.10;
+
+interface IWETHGateway {
+  function depositETH(
+    address lendingPool,
+    address onBehalfOf,
+    uint16 referralCode
+  ) external payable;
+
+  function withdrawETH(
+    address lendingPool,
+    uint256 amount,
+    address onBehalfOf
+  ) external;
+
+  function repayETH(
+    address lendingPool,
+    uint256 amount,
+    uint256 rateMode,
+    address onBehalfOf
+  ) external payable;
+
+  function borrowETH(
+    address lendingPool,
+    uint256 amount,
+    uint256 interesRateMode,
+    uint16 referralCode
+  ) external;
+}


### PR DESCRIPTION
Adds the WETHGateway to the AaveV2WrapV2Adapter so that it behaves the same way as the CompoundWrapV2Adapter. 

I thought ensuring behavior across integrations reduces some complexity 


Rebasing could be a problem, that has to be researched further. I asked on the discord because there is some conflicting information: 
- In the [FAQ](https://docs.tokensets.com/resources/faq#what-restrictions-apply-for-erc-20-or-erc-721-tokens-interest-bearing-tokens-like-adai) it says that Set tokens do not support rebasing tokens
- In the [docs](https://docs.tokensets.com/managers/set-trading#token-eligibility) it says 
> Another caveat to be aware of in the current interaction of Set is that any asset that you want to include must not be a Rebasing token or one with a Transfer Fee associated with it. The issue here is that these token properties are not compatible with the contract assumptions of a Set being 100% collateralised at present. 
- On Set protocol discord it was mentioned that
[the leverage module syncs on issuance](https://discord.com/channels/668970715759771652/668972832780451870/974650844005949510)

[the wrap module would add support for tokens that don't fulfill the liquidity requirement](https://discord.com/channels/668970715759771652/668972832780451870/984887134550917120)

I tried to ask for more details on [discord](https://discord.com/channels/668970715759771652/668992788615921666/1021786370861191179)